### PR TITLE
feat: v2 readability redesign — SnapshotCard + ContributorRow + skill detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ yarn-error.log*
 # superpowers brainstorm
 .superpowers/
 
+# git worktrees
+.worktrees/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/docs/mac-mini-qa-runner.md
+++ b/docs/mac-mini-qa-runner.md
@@ -1,0 +1,99 @@
+# Mac Mini QA Runner Setup
+
+Self-hosted GitHub Actions runner on the Mac Mini that automatically runs Claude-powered QA tests (via Playwright) when code is pushed to feature branches or PRs targeting main.
+
+## How It Works
+
+1. Push code from dev machine to GitHub
+2. GitHub Actions triggers the `qa.yml` workflow
+3. The workflow routes to the Mac Mini (the self-hosted runner)
+4. Mac Mini clones the repo, boots the dev server, and runs Claude Code with Playwright MCP
+5. Claude navigates the app in a real browser, tests all pages/flows, and reports pass/fail
+6. Results appear in the GitHub Actions log (and as a PR comment if triggered by a PR)
+
+## What Was Set Up
+
+### On the Mac Mini
+
+1. **GitHub Actions runner** installed at `~/actions-runner`
+   - Registered with `craigdossantos/insightful` repo
+   - Running as a background service (starts on boot)
+
+2. **Claude Code** installed globally via `npm install -g @anthropic-ai/claude-code`
+
+3. **Playwright MCP** added to Claude Code:
+   ```bash
+   claude mcp add playwright -- npx @anthropic-ai/mcp-playwright
+   ```
+
+### On GitHub
+
+- **Workflow file:** `.github/workflows/qa.yml`
+- **Repository secrets** added (Settings > Secrets and variables > Actions):
+  - `ANTHROPIC_API_KEY`
+  - `DATABASE_URL`
+  - `DIRECT_URL`
+  - `AUTH_SECRET`
+  - `AUTH_GITHUB_ID`
+  - `AUTH_GITHUB_SECRET`
+  - `NEXT_PUBLIC_SUPABASE_URL`
+  - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+  - `SUPABASE_SERVICE_ROLE_KEY`
+
+## Triggering a Run
+
+- **Automatic:** Push to any `feat/*` branch or open a PR to `main`
+- **Manual:** GitHub repo > Actions tab > "QA Testing on Mac Mini" > "Run workflow"
+
+## Stopping the Runner
+
+Temporarily stop (can restart later):
+
+```bash
+cd ~/actions-runner
+./svc.sh stop
+```
+
+Restart after stopping:
+
+```bash
+cd ~/actions-runner
+./svc.sh start
+```
+
+## Full Removal
+
+### 1. Stop and uninstall the service
+
+```bash
+cd ~/actions-runner
+./svc.sh stop
+./svc.sh uninstall
+```
+
+### 2. Remove the runner from GitHub
+
+Option A — from the command line:
+
+```bash
+cd ~/actions-runner
+./config.sh remove --token PASTE_REMOVAL_TOKEN
+```
+
+Get the removal token from: GitHub repo > Settings > Actions > Runners > click the runner > Remove.
+
+Option B — from the browser: go to the same page and click Remove directly.
+
+### 3. Delete the runner files
+
+```bash
+rm -rf ~/actions-runner
+```
+
+### 4. Remove the workflow file
+
+Delete `.github/workflows/qa.yml` from the repo so pushes no longer trigger the (now-missing) runner.
+
+### 5. Optionally remove GitHub secrets
+
+GitHub repo > Settings > Secrets and variables > Actions > delete the secrets listed above.

--- a/docs/mockups/v2-readability-redesign.html
+++ b/docs/mockups/v2-readability-redesign.html
@@ -1,0 +1,2311 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Insightful v2 — Readability Redesign</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          "Inter",
+          -apple-system,
+          sans-serif;
+        background: #f5f5f0;
+        color: #333;
+      }
+
+      /* ── Sticky Nav ── */
+      .mockup-nav {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: #1e1e1e;
+        color: #fff;
+        padding: 10px 16px;
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        align-items: center;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      }
+      .mockup-nav .title {
+        font-size: 14px;
+        font-weight: 600;
+        margin-right: 12px;
+        white-space: nowrap;
+      }
+      .mockup-nav a {
+        color: #a8c8ff;
+        text-decoration: none;
+        font-size: 12px;
+        padding: 3px 8px;
+        border-radius: 4px;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        transition: background 0.15s;
+      }
+      .mockup-nav a:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      .viewport-toggle {
+        display: flex;
+        gap: 2px;
+        margin-left: 8px;
+        background: rgba(255, 255, 255, 0.08);
+        border-radius: 6px;
+        padding: 2px;
+      }
+      .viewport-toggle button {
+        background: transparent;
+        border: none;
+        color: rgba(255, 255, 255, 0.5);
+        padding: 4px 10px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s;
+      }
+      .viewport-toggle button:hover {
+        color: rgba(255, 255, 255, 0.8);
+      }
+      .viewport-toggle button.active {
+        background: rgba(255, 255, 255, 0.15);
+        color: #fff;
+      }
+      .mockup-nav .copy-all-btn {
+        margin-left: auto;
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        padding: 6px 14px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .mockup-nav .copy-all-btn:hover {
+        background: #1d4ed8;
+      }
+      .mockup-nav .copy-all-btn.copied {
+        background: #16a34a;
+      }
+
+      /* ── Section layout ── */
+      .mockup-section {
+        max-width: 900px;
+        margin: 40px auto;
+        padding: 0 16px;
+      }
+      .mockup-section.wide {
+        max-width: 1200px;
+      }
+      body.viewport-mobile .mockup-section,
+      body.viewport-mobile .mockup-section.wide {
+        max-width: 600px;
+      }
+      body.viewport-desktop .mockup-section {
+        max-width: 900px;
+      }
+      body.viewport-desktop .mockup-section.wide {
+        max-width: 1200px;
+      }
+
+      .iframe-frame {
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        overflow: hidden;
+        background: #fff;
+        position: relative;
+        margin: 0 auto;
+      }
+      .iframe-frame iframe {
+        width: 100%;
+        border: none;
+        display: block;
+      }
+      body.viewport-mobile .iframe-frame {
+        max-width: 375px;
+      }
+      body.viewport-mobile .iframe-frame::before {
+        content: "";
+        display: block;
+        height: 24px;
+        background: #f3f4f6;
+        border-bottom: 1px solid #e5e5e5;
+        border-radius: 8px 8px 0 0;
+      }
+
+      .section-label {
+        background: #1e1e1e;
+        color: #fff;
+        display: inline-block;
+        padding: 4px 12px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 12px;
+      }
+      .section-desc {
+        font-size: 13px;
+        color: #888;
+        margin-bottom: 16px;
+        line-height: 1.5;
+      }
+      .section-divider {
+        height: 1px;
+        background: #ddd;
+        margin: 48px 0;
+      }
+
+      .version-container {
+        position: relative;
+      }
+      .version {
+        display: none;
+      }
+      .version.active {
+        display: block;
+      }
+      .version-nav {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        gap: 12px;
+        margin-top: 12px;
+        padding: 8px;
+        background: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 8px;
+      }
+      .version-nav.visible {
+        display: flex;
+      }
+      .version-nav button {
+        background: #f3f4f6;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        padding: 4px 12px;
+        font-size: 12px;
+        font-family: inherit;
+        cursor: pointer;
+        color: #374151;
+      }
+      .version-nav button:disabled {
+        opacity: 0.35;
+        cursor: default;
+      }
+      .version-nav .version-label {
+        font-size: 12px;
+        font-weight: 600;
+        color: #6b7280;
+        min-width: 80px;
+        text-align: center;
+      }
+
+      .feedback-area {
+        margin-top: 16px;
+        background: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 8px;
+        padding: 12px;
+      }
+      .feedback-area label {
+        display: block;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #888;
+        margin-bottom: 6px;
+      }
+      .feedback-area textarea {
+        width: 100%;
+        min-height: 80px;
+        border: 1px solid #e5e5e5;
+        border-radius: 6px;
+        padding: 10px;
+        font-family: inherit;
+        font-size: 14px;
+        line-height: 1.5;
+        resize: vertical;
+        color: #333;
+      }
+      .feedback-area textarea:focus {
+        outline: none;
+        border-color: #2563eb;
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+      }
+      .feedback-area .char-count {
+        font-size: 11px;
+        color: #aaa;
+        text-align: right;
+        margin-top: 4px;
+      }
+
+      .design-note {
+        background: #fffbeb;
+        border: 1px solid #fcd34d;
+        border-radius: 8px;
+        padding: 10px 14px;
+        margin: 12px 0;
+        font-size: 12px;
+        color: #92400e;
+        line-height: 1.5;
+      }
+      .design-note strong {
+        font-weight: 600;
+      }
+      .design-note.info {
+        background: #f0fdf4;
+        border-color: #86efac;
+        color: #166534;
+      }
+      .design-note.future {
+        background: #eff6ff;
+        border-color: #93c5fd;
+        color: #1e40af;
+      }
+
+      /* ══════════════════════════════════════════════════════════════
+   INSIGHTFUL MOCKUP STYLES — matches project Tailwind/design
+   ══════════════════════════════════════════════════════════════ */
+
+      .i-page {
+        background: #f8fafc;
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+        overflow: hidden;
+      }
+
+      /* ── Homepage list ── */
+      .i-list-header {
+        padding: 32px 24px 0;
+        text-align: center;
+      }
+      .i-list-header h1 {
+        font-size: 28px;
+        font-weight: 700;
+        color: #0f172a;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+      }
+      .i-list-header h1 svg {
+        color: #2563eb;
+      }
+      .i-list-header p {
+        color: #64748b;
+        font-size: 15px;
+        margin-top: 8px;
+      }
+
+      .i-sort-tabs {
+        display: flex;
+        gap: 4px;
+        background: #f1f5f9;
+        border-radius: 12px;
+        padding: 4px;
+        width: fit-content;
+        margin: 20px auto 0;
+      }
+      .i-sort-tabs button {
+        background: none;
+        border: none;
+        padding: 8px 16px;
+        border-radius: 8px;
+        font-size: 13px;
+        font-weight: 500;
+        color: #64748b;
+        cursor: pointer;
+        font-family: inherit;
+      }
+      .i-sort-tabs button.active {
+        background: white;
+        color: #0f172a;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+      }
+
+      .i-contributor-list {
+        padding: 20px 24px 24px;
+      }
+      .i-contributor-row {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 16px;
+        border-radius: 12px;
+        border: 1px solid #e2e8f0;
+        background: white;
+        margin-bottom: 8px;
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+      .i-contributor-row:hover {
+        border-color: #93c5fd;
+        box-shadow: 0 4px 12px rgba(59, 130, 246, 0.08);
+      }
+      .i-contributor-row img {
+        width: 48px;
+        height: 48px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .i-contributor-info {
+        flex: 1;
+        min-width: 0;
+      }
+      .i-contributor-info .name {
+        font-weight: 600;
+        font-size: 15px;
+        color: #0f172a;
+      }
+      .i-contributor-info .handle {
+        font-size: 13px;
+        color: #94a3b8;
+      }
+      .i-contributor-stats {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        margin-top: 6px;
+        font-size: 12px;
+        color: #64748b;
+      }
+      .i-contributor-stats .stat {
+        white-space: nowrap;
+      }
+      .i-contributor-stats .stat strong {
+        font-weight: 600;
+        color: #334155;
+      }
+      .i-contributor-stats .green {
+        color: #16a34a;
+      }
+      .i-contributor-stats .red {
+        color: #dc2626;
+      }
+      .i-tools {
+        font-size: 12px;
+        color: #64748b;
+        margin-top: 4px;
+      }
+      .i-skills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 6px;
+      }
+      .i-skill-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+      }
+      .i-skill-badge.agents {
+        background: #ede9fe;
+        color: #6d28d9;
+      }
+      .i-skill-badge.worktrees {
+        background: #dcfce7;
+        color: #15803d;
+      }
+      .i-skill-badge.skills {
+        background: #fef3c7;
+        color: #b45309;
+      }
+      .i-skill-badge.playwright {
+        background: #fce7f3;
+        color: #be185d;
+      }
+      .i-skill-badge.hooks {
+        background: #e0f2fe;
+        color: #0369a1;
+      }
+      .i-skill-badge.mcp {
+        background: #f1f5f9;
+        color: #475569;
+      }
+      .i-skill-badge.review {
+        background: #fef2f2;
+        color: #b91c1c;
+      }
+      .i-skill-badge.plan {
+        background: #ecfdf5;
+        color: #065f46;
+      }
+
+      /* ── Report detail ── */
+      .i-detail {
+        padding: 32px 24px;
+      }
+      .i-detail-author {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      .i-detail-author img {
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+      }
+      .i-detail-author .info .name {
+        font-weight: 600;
+        font-size: 15px;
+        color: #0f172a;
+      }
+      .i-detail-author .info .date {
+        font-size: 13px;
+        color: #94a3b8;
+      }
+
+      /* Snapshot card */
+      .i-snapshot {
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 16px;
+        padding: 24px;
+        margin-bottom: 32px;
+      }
+      .i-stats-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 24px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid #f1f5f9;
+      }
+      .i-stat {
+        text-align: center;
+      }
+      .i-stat .val {
+        font-size: 24px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .i-stat .label {
+        font-size: 11px;
+        color: #94a3b8;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-top: 2px;
+      }
+      .i-stat .val.green {
+        color: #16a34a;
+      }
+      .i-stat .val.red {
+        color: #dc2626;
+      }
+
+      /* Tool chart */
+      .i-tool-chart {
+        margin-top: 20px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid #f1f5f9;
+      }
+      .i-tool-chart h3 {
+        font-size: 11px;
+        font-weight: 600;
+        color: #94a3b8;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 12px;
+      }
+      .i-bar-row {
+        display: flex;
+        align-items: center;
+        margin-bottom: 6px;
+      }
+      .i-bar-label {
+        width: 80px;
+        font-size: 12px;
+        color: #475569;
+        flex-shrink: 0;
+      }
+      .i-bar-track {
+        flex: 1;
+        height: 8px;
+        background: #f1f5f9;
+        border-radius: 4px;
+        margin: 0 8px;
+        overflow: hidden;
+      }
+      .i-bar-fill {
+        height: 100%;
+        border-radius: 4px;
+        background: #3b82f6;
+      }
+      .i-bar-value {
+        width: 40px;
+        font-size: 12px;
+        font-weight: 500;
+        color: #64748b;
+        text-align: right;
+      }
+
+      /* Skills row */
+      .i-skills-row {
+        margin-top: 20px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid #f1f5f9;
+      }
+      .i-skills-row h3 {
+        font-size: 11px;
+        font-weight: 600;
+        color: #94a3b8;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 10px;
+      }
+
+      /* Key pattern */
+      .i-key-pattern {
+        margin-top: 20px;
+        padding: 16px;
+        background: #f0f9ff;
+        border-radius: 10px;
+        border-left: 3px solid #3b82f6;
+      }
+      .i-key-pattern p {
+        font-size: 14px;
+        line-height: 1.6;
+        color: #334155;
+        font-style: italic;
+      }
+
+      /* Collapsible sections */
+      .i-section-card {
+        background: white;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        margin-bottom: 12px;
+        overflow: hidden;
+      }
+      .i-section-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 18px 20px;
+        cursor: pointer;
+        transition: background 0.1s;
+      }
+      .i-section-header:hover {
+        background: #f8fafc;
+      }
+      .i-section-icon {
+        width: 36px;
+        height: 36px;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+        flex-shrink: 0;
+      }
+      .i-section-icon.glance {
+        background: #fef3c7;
+      }
+      .i-section-icon.style {
+        background: #e0e7ff;
+      }
+      .i-section-icon.projects {
+        background: #f1f5f9;
+      }
+      .i-section-icon.workflows {
+        background: #dcfce7;
+      }
+      .i-section-icon.friction {
+        background: #fef2f2;
+      }
+      .i-section-icon.suggestions {
+        background: #fef9c3;
+      }
+      .i-section-icon.horizon {
+        background: #f5f3ff;
+      }
+      .i-section-icon.fun {
+        background: #fce7f3;
+      }
+      .i-section-title {
+        flex: 1;
+        min-width: 0;
+      }
+      .i-section-title h3 {
+        font-size: 16px;
+        font-weight: 600;
+        color: #0f172a;
+      }
+      .i-section-title p {
+        font-size: 13px;
+        color: #64748b;
+        margin-top: 2px;
+        line-height: 1.4;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .i-section-chevron {
+        color: #94a3b8;
+        font-size: 18px;
+        flex-shrink: 0;
+        transition: transform 0.2s;
+      }
+      .i-section-chevron.open {
+        transform: rotate(180deg);
+      }
+      .i-section-body {
+        padding: 0 20px 20px;
+        border-top: 1px solid #f1f5f9;
+      }
+      .i-section-body p {
+        font-size: 15px;
+        line-height: 1.75;
+        color: #334155;
+        margin-top: 16px;
+      }
+      .i-section-body .key-insight {
+        background: #f0fdf4;
+        border: 1px solid #bbf7d0;
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-top: 12px;
+        font-size: 14px;
+        color: #166534;
+        line-height: 1.6;
+      }
+
+      /* Project area cards */
+      .i-project-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .i-project-card {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        padding: 16px;
+      }
+      .i-project-card .name {
+        font-weight: 600;
+        font-size: 14px;
+        color: #0f172a;
+        margin-bottom: 4px;
+      }
+      .i-project-card .sessions {
+        font-size: 12px;
+        color: #64748b;
+        margin-bottom: 8px;
+      }
+      .i-project-card .desc {
+        font-size: 13px;
+        color: #475569;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body class="viewport-desktop">
+    <nav class="mockup-nav">
+      <span class="title">Insightful v2 — Readability Redesign</span>
+      <a href="#homepage">Homepage</a>
+      <a href="#detail">Report Detail</a>
+      <div class="viewport-toggle">
+        <button data-viewport="mobile" title="Mobile (375px)">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path
+              d="M7 2h10a2 2 0 012 2v16a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2zm5 18a1 1 0 100-2 1 1 0 000 2z"
+            />
+          </svg>
+          Mobile
+        </button>
+        <button data-viewport="desktop" class="active" title="Desktop">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+            <path
+              d="M3 4h18a1 1 0 011 1v11a1 1 0 01-1 1H3a1 1 0 01-1-1V5a1 1 0 011-1zm5 16h8m-4-3v3"
+            />
+          </svg>
+          Desktop
+        </button>
+      </div>
+      <button class="copy-all-btn" onclick="copyAllFeedback()">
+        Copy All Feedback
+      </button>
+    </nav>
+
+    <!-- ═══════════════════════════════════════════════════════
+     SECTION 1: Homepage — Contributor Directory
+     ═══════════════════════════════════════════════════════ -->
+    <div class="mockup-section wide" data-section-id="homepage" id="homepage">
+      <span class="section-label">Homepage — Contributor List</span>
+      <p class="section-desc">
+        Replaces the current card grid with a contributor-focused list. Each row
+        shows avatar, stats, top tools, and skill badges.
+      </p>
+
+      <div class="version-container">
+        <div class="version" data-version="1">
+          <div class="design-note info">
+            <strong>Note:</strong> v1 — original proposal. See v2 for updated
+            version with per-week stats and clearer labels.
+          </div>
+
+          <div class="i-page">
+            <div class="i-list-header">
+              <h1>
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+                  />
+                </svg>
+                Insightful
+              </h1>
+              <p>
+                Discover how developers use Claude Code. Browse shared insights
+                and learn new workflows.
+              </p>
+            </div>
+
+            <div class="i-sort-tabs">
+              <button class="active">Newest</button>
+              <button>Most Voted</button>
+              <button>Trending</button>
+            </div>
+
+            <div class="i-contributor-list">
+              <!-- Row 1 -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://avatars.githubusercontent.com/u/124315902?v=4"
+                  alt=""
+                />
+                <div class="i-contributor-info">
+                  <div class="name">craigdossantos</div>
+                  <div class="handle">@craigdossantos · Apr 3, 2026</div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>1,268</strong> msgs</span>
+                    <span class="stat green">+47,313</span>
+                    <span class="stat red">-2,967</span>
+                    <span class="stat"><strong>405</strong> files</span>
+                    <span class="stat"><strong>18</strong> days</span>
+                    <span class="stat"><strong>70.4</strong>/day</span>
+                  </div>
+                  <div class="i-tools">
+                    Top tools: Bash (2,922) · Read (1,318) · Edit (714)
+                  </div>
+                  <div class="i-skills">
+                    <span class="i-skill-badge agents">🔀 Parallel Agents</span>
+                    <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                    <span class="i-skill-badge playwright">🎭 Playwright</span>
+                    <span class="i-skill-badge hooks">🪝 Hooks</span>
+                    <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                    <span class="i-skill-badge review">📝 Code Review</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Row 2: example other user -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://api.dicebear.com/7.x/initials/svg?seed=SA&backgroundColor=6366f1"
+                  alt=""
+                  style="width: 48px; height: 48px; border-radius: 50%"
+                />
+                <div class="i-contributor-info">
+                  <div class="name">sarahdev</div>
+                  <div class="handle">@sarahdev · Apr 1, 2026</div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>843</strong> msgs</span>
+                    <span class="stat green">+22,105</span>
+                    <span class="stat red">-1,230</span>
+                    <span class="stat"><strong>189</strong> files</span>
+                    <span class="stat"><strong>24</strong> days</span>
+                    <span class="stat"><strong>35.1</strong>/day</span>
+                  </div>
+                  <div class="i-tools">
+                    Top tools: Read (1,450) · Edit (890) · Bash (670)
+                  </div>
+                  <div class="i-skills">
+                    <span class="i-skill-badge worktrees">🌳 Worktrees</span>
+                    <span class="i-skill-badge plan">📋 Plan Mode</span>
+                    <span class="i-skill-badge review">📝 Code Review</span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Row 3: example -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://api.dicebear.com/7.x/initials/svg?seed=MK&backgroundColor=059669"
+                  alt=""
+                  style="width: 48px; height: 48px; border-radius: 50%"
+                />
+                <div class="i-contributor-info">
+                  <div class="name">Mike Kim</div>
+                  <div class="handle">@mikekim · Mar 28, 2026</div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>2,104</strong> msgs</span>
+                    <span class="stat green">+91,230</span>
+                    <span class="stat red">-8,422</span>
+                    <span class="stat"><strong>612</strong> files</span>
+                    <span class="stat"><strong>30</strong> days</span>
+                    <span class="stat"><strong>70.1</strong>/day</span>
+                  </div>
+                  <div class="i-tools">
+                    Top tools: Bash (4,100) · Agent (1,200) · Edit (980)
+                  </div>
+                  <div class="i-skills">
+                    <span class="i-skill-badge agents">🔀 Parallel Agents</span>
+                    <span class="i-skill-badge worktrees">🌳 Worktrees</span>
+                    <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                    <span class="i-skill-badge hooks">🪝 Hooks</span>
+                    <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ HOMEPAGE V2 ═══ -->
+        <div class="version active" data-version="2">
+          <div class="design-note">
+            <strong>Change (v2):</strong> Added per-week normalized stats for
+            comparability. Labeled lines added/removed clearly. Added "Skills
+            Used" label above badges. Removed raw tool counts from inline
+            display.
+          </div>
+
+          <div class="i-page">
+            <div class="i-list-header">
+              <h1>
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path
+                    d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+                  />
+                </svg>
+                Insightful
+              </h1>
+              <p>
+                Discover how developers use Claude Code. Browse shared insights
+                and learn new workflows.
+              </p>
+            </div>
+
+            <div class="i-sort-tabs">
+              <button class="active">Newest</button>
+              <button>Most Voted</button>
+              <button>Trending</button>
+            </div>
+
+            <div class="i-contributor-list">
+              <!-- Row 1: Craig -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://avatars.githubusercontent.com/u/124315902?v=4"
+                  alt=""
+                />
+                <div class="i-contributor-info">
+                  <div class="name">craigdossantos</div>
+                  <div class="handle">
+                    @craigdossantos · Apr 3, 2026 · 18 days tracked
+                  </div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>493</strong> msgs/wk</span>
+                    <span class="stat"><strong>18,340</strong> lines/wk</span>
+                    <span class="stat" style="color: #16a34a"
+                      >+47,313 added</span
+                    >
+                    <span class="stat" style="color: #dc2626"
+                      >-2,967 removed</span
+                    >
+                    <span class="stat"><strong>405</strong> files</span>
+                    <span class="stat"><strong>124</strong> commits</span>
+                  </div>
+                  <div style="margin-top: 8px">
+                    <span
+                      style="
+                        font-size: 11px;
+                        font-weight: 600;
+                        color: #94a3b8;
+                        text-transform: uppercase;
+                        letter-spacing: 0.05em;
+                      "
+                      >Skills Used</span
+                    >
+                    <div class="i-skills" style="margin-top: 4px">
+                      <span class="i-skill-badge agents"
+                        >🔀 Parallel Agents</span
+                      >
+                      <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                      <span class="i-skill-badge playwright"
+                        >🎭 Playwright</span
+                      >
+                      <span class="i-skill-badge hooks">🪝 Hooks</span>
+                      <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                      <span class="i-skill-badge review">📝 Code Review</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Row 2: Sarah -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://api.dicebear.com/7.x/initials/svg?seed=SA&backgroundColor=6366f1"
+                  alt=""
+                  style="width: 48px; height: 48px; border-radius: 50%"
+                />
+                <div class="i-contributor-info">
+                  <div class="name">sarahdev</div>
+                  <div class="handle">
+                    @sarahdev · Apr 1, 2026 · 24 days tracked
+                  </div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>246</strong> msgs/wk</span>
+                    <span class="stat"><strong>6,806</strong> lines/wk</span>
+                    <span class="stat" style="color: #16a34a"
+                      >+22,105 added</span
+                    >
+                    <span class="stat" style="color: #dc2626"
+                      >-1,230 removed</span
+                    >
+                    <span class="stat"><strong>189</strong> files</span>
+                    <span class="stat"><strong>87</strong> commits</span>
+                  </div>
+                  <div style="margin-top: 8px">
+                    <span
+                      style="
+                        font-size: 11px;
+                        font-weight: 600;
+                        color: #94a3b8;
+                        text-transform: uppercase;
+                        letter-spacing: 0.05em;
+                      "
+                      >Skills Used</span
+                    >
+                    <div class="i-skills" style="margin-top: 4px">
+                      <span class="i-skill-badge worktrees">🌳 Worktrees</span>
+                      <span class="i-skill-badge plan">📋 Plan Mode</span>
+                      <span class="i-skill-badge review">📝 Code Review</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Row 3: Mike -->
+              <div class="i-contributor-row">
+                <img
+                  src="https://api.dicebear.com/7.x/initials/svg?seed=MK&backgroundColor=059669"
+                  alt=""
+                  style="width: 48px; height: 48px; border-radius: 50%"
+                />
+                <div class="i-contributor-info">
+                  <div class="name">Mike Kim</div>
+                  <div class="handle">
+                    @mikekim · Mar 28, 2026 · 30 days tracked
+                  </div>
+                  <div class="i-contributor-stats">
+                    <span class="stat"><strong>491</strong> msgs/wk</span>
+                    <span class="stat"><strong>19,370</strong> lines/wk</span>
+                    <span class="stat" style="color: #16a34a"
+                      >+91,230 added</span
+                    >
+                    <span class="stat" style="color: #dc2626"
+                      >-8,422 removed</span
+                    >
+                    <span class="stat"><strong>612</strong> files</span>
+                    <span class="stat"><strong>210</strong> commits</span>
+                  </div>
+                  <div style="margin-top: 8px">
+                    <span
+                      style="
+                        font-size: 11px;
+                        font-weight: 600;
+                        color: #94a3b8;
+                        text-transform: uppercase;
+                        letter-spacing: 0.05em;
+                      "
+                      >Skills Used</span
+                    >
+                    <div class="i-skills" style="margin-top: 4px">
+                      <span class="i-skill-badge agents"
+                        >🔀 Parallel Agents</span
+                      >
+                      <span class="i-skill-badge worktrees">🌳 Worktrees</span>
+                      <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                      <span class="i-skill-badge hooks">🪝 Hooks</span>
+                      <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="version-nav">
+        <button data-dir="prev" disabled>&larr; Prev</button
+        ><span class="version-label">v2 of 2</span
+        ><button data-dir="next" disabled>Next &rarr;</button>
+      </div>
+      <div class="feedback-area">
+        <label for="fb-homepage">Feedback</label
+        ><textarea
+          id="fb-homepage"
+          placeholder="Voice transcribe or type feedback for this section..."
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ═══════════════════════════════════════════════════════
+     SECTION 2: Report Detail — Snapshot + Collapsible
+     ═══════════════════════════════════════════════════════ -->
+    <div class="mockup-section wide" data-section-id="detail" id="detail">
+      <span class="section-label">Report Detail — Redesigned</span>
+      <p class="section-desc">
+        Top snapshot card with stats, tool chart, skill badges, and key pattern.
+        Sections below are collapsible with summary headers.
+      </p>
+
+      <div class="version-container">
+        <div class="version" data-version="1">
+          <div class="design-note info">
+            <strong>Note:</strong> v1 — see v2 for updated version. The snapshot
+            card surfaces the most interesting data immediately. Sections
+            collapse to show summaries, expandable for full content.
+          </div>
+
+          <div class="i-page">
+            <div class="i-detail">
+              <!-- Author row -->
+              <div class="i-detail-author">
+                <img
+                  src="https://avatars.githubusercontent.com/u/124315902?v=4"
+                  alt=""
+                />
+                <div class="info">
+                  <div class="name">craigdossantos</div>
+                  <div class="date">Apr 3, 2026 · Mar 2 – Apr 2, 2026</div>
+                </div>
+              </div>
+
+              <!-- ══ SNAPSHOT CARD ══ -->
+              <div class="i-snapshot">
+                <!-- Stats bar -->
+                <div class="i-stats-bar">
+                  <div class="i-stat">
+                    <div class="val">126</div>
+                    <div class="label">Sessions</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">1,268</div>
+                    <div class="label">Messages</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val green">+47,313</div>
+                    <div class="label">Lines Added</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val red">-2,967</div>
+                    <div class="label">Removed</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">405</div>
+                    <div class="label">Files</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">18</div>
+                    <div class="label">Days</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">70.4</div>
+                    <div class="label">Msgs/Day</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">124</div>
+                    <div class="label">Commits</div>
+                  </div>
+                </div>
+
+                <!-- Tool usage chart -->
+                <div class="i-tool-chart">
+                  <h3>Top Tools Used</h3>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">Bash</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 100%"></div>
+                    </div>
+                    <div class="i-bar-value">2,922</div>
+                  </div>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">Read</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 45%"></div>
+                    </div>
+                    <div class="i-bar-value">1,318</div>
+                  </div>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">Edit</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 24%"></div>
+                    </div>
+                    <div class="i-bar-value">714</div>
+                  </div>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">TaskUpdate</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 13%"></div>
+                    </div>
+                    <div class="i-bar-value">374</div>
+                  </div>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">Grep</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 13%"></div>
+                    </div>
+                    <div class="i-bar-value">374</div>
+                  </div>
+                  <div class="i-bar-row">
+                    <div class="i-bar-label">Agent</div>
+                    <div class="i-bar-track">
+                      <div class="i-bar-fill" style="width: 11%"></div>
+                    </div>
+                    <div class="i-bar-value">319</div>
+                  </div>
+                </div>
+
+                <!-- Skills badges -->
+                <div class="i-skills-row">
+                  <h3>Skills & Features Used</h3>
+                  <div class="i-skills">
+                    <span class="i-skill-badge agents">🔀 Parallel Agents</span>
+                    <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                    <span class="i-skill-badge playwright">🎭 Playwright</span>
+                    <span class="i-skill-badge hooks">🪝 Hooks</span>
+                    <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                    <span class="i-skill-badge review">📝 Code Review</span>
+                    <span class="i-skill-badge plan">📋 Plan Mode</span>
+                  </div>
+                </div>
+
+                <!-- Key pattern -->
+                <div class="i-key-pattern">
+                  <p>
+                    "Operates as a high-trust project manager who delegates
+                    ambitious multi-phase tasks to Claude, lets it run
+                    autonomously, and iteratively course-corrects through rapid
+                    QA cycles until production-ready."
+                  </p>
+                </div>
+              </div>
+
+              <!-- ══ COLLAPSIBLE SECTIONS ══ -->
+
+              <!-- At a Glance — always open -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon glance">✨</div>
+                  <div class="i-section-title">
+                    <h3>At a Glance</h3>
+                  </div>
+                  <span class="i-section-chevron open">▾</span>
+                </div>
+                <div class="i-section-body">
+                  <div
+                    style="
+                      display: grid;
+                      grid-template-columns: 1fr 1fr;
+                      gap: 12px;
+                      margin-top: 16px;
+                    "
+                  >
+                    <div
+                      style="
+                        background: #f0fdf4;
+                        border: 1px solid #bbf7d0;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #166534;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        What's Working
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #15803d;
+                          line-height: 1.6;
+                        "
+                      >
+                        Developed a genuinely powerful workflow using Claude as
+                        a team coordinator — spinning up parallel agents for
+                        everything from course site generation to implementation
+                        plan reviews.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #fef2f2;
+                        border: 1px solid #fca5a5;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #991b1b;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        What's Hindering
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #7f1d1d;
+                          line-height: 1.6;
+                        "
+                      >
+                        Claude too often starts with the wrong approach —
+                        approximating instead of using real data, reading when
+                        it should generate, ignoring explicit instructions.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #eff6ff;
+                        border: 1px solid #93c5fd;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #1e40af;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        Quick Wins
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #1e3a8a;
+                          line-height: 1.6;
+                        "
+                      >
+                        Try using hooks to auto-run your test suite before
+                        commits. Consider running Claude in headless mode with
+                        pre-validated MCP connections.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #f5f3ff;
+                        border: 1px solid #c4b5fd;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #5b21b6;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        On the Horizon
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #6d28d9;
+                          line-height: 1.6;
+                        "
+                      >
+                        Autonomous test-fix loops where parallel agents each own
+                        a test suite and iterate until green without needing you
+                        to say 'continue.'
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Interaction Style — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon style">🎯</div>
+                  <div class="i-section-title">
+                    <h3>How They Use Claude Code</h3>
+                    <p>
+                      High-velocity orchestrator who treats Claude Code as a
+                      full-stack engineering partner rather than a simple coding
+                      assistant.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Across 102 sessions in a single month, consistently
+                    delegates ambitious, multi-phase projects — redesigning
+                    entire UIs, running 82-step QA checklists, building course
+                    sites with 19 parallel agents, and executing 6-task launch
+                    hardening plans. The style is to set big goals and let
+                    Claude run, often kicking off parallel agent workflows and
+                    trusting Claude to handle multi-file changes.
+                  </p>
+                  <p style="margin-top: 12px">
+                    The interaction pattern is distinctly iterative and
+                    QA-driven. Rarely provides exhaustive upfront specs;
+                    instead, launches into implementation, reviews the output,
+                    and then runs multiple fix cycles. The heavy Bash usage
+                    (2,922 calls) confirms constant builds, tests, and
+                    deployments — treating each session as a real production
+                    push.
+                  </p>
+                  <div class="key-insight" style="margin-top: 16px">
+                    <strong>Key pattern:</strong> High-trust project manager who
+                    delegates ambitious multi-phase tasks, lets Claude run
+                    autonomously, and iteratively course-corrects through rapid
+                    QA cycles.
+                  </div>
+                </div>
+              </div>
+
+              <!-- Project Areas — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon projects">📁</div>
+                  <div class="i-section-title">
+                    <h3>Project Areas</h3>
+                    <p>5 project areas across ~55 sessions</p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <div class="i-project-grid">
+                    <div class="i-project-card">
+                      <div class="name">Appeal Mailer SaaS</div>
+                      <div class="sessions">~18 sessions</div>
+                      <div class="desc">
+                        Building and launching a health insurance appeal letter
+                        SaaS app with full UI redesign, schema migrations,
+                        Stripe payments, and deployment.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">Whispergram Audio Platform</div>
+                      <div class="sessions">~12 sessions</div>
+                      <div class="desc">
+                        Collaborative audio gift compilation platform. UX
+                        polish, clip ordering, audio ducking, music playback via
+                        Supabase.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">CourseCapture Pipeline</div>
+                      <div class="sessions">~5 sessions</div>
+                      <div class="desc">
+                        Video scraping, transcription, slide extraction, and
+                        static site generation with 19 parallel blog post
+                        agents.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">LighterSky Sites</div>
+                      <div class="sessions">~8 sessions</div>
+                      <div class="desc">
+                        Business planning, website launches, booking site for
+                        wedding, research dashboards, and explainer sites.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Impressive Workflows — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon workflows">🏆</div>
+                  <div class="i-section-title">
+                    <h3>Impressive Workflows</h3>
+                    <p>
+                      Developed a genuinely powerful workflow using Claude as a
+                      team coordinator — spinning up parallel agents...
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Content expands here with the full impressive workflows
+                    details...
+                  </p>
+                </div>
+              </div>
+
+              <!-- Friction — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon friction">⚡</div>
+                  <div class="i-section-title">
+                    <h3>Where Things Go Wrong</h3>
+                    <p>
+                      Claude too often starts with the wrong approach —
+                      approximating instead of using real data...
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>Content expands here...</p>
+                </div>
+              </div>
+
+              <!-- Suggestions — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon suggestions">💡</div>
+                  <div class="i-section-title">
+                    <h3>Suggestions</h3>
+                    <p>
+                      Try using hooks to auto-run your test suite or lint checks
+                      before commits...
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>Content expands here...</p>
+                </div>
+              </div>
+
+              <!-- Horizon — collapsed -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon horizon">🔮</div>
+                  <div class="i-section-title">
+                    <h3>On the Horizon</h3>
+                    <p>
+                      Autonomous test-fix loops where parallel agents each own a
+                      test suite and iterate until green...
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>Content expands here...</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ═══ DETAIL V2 ═══ -->
+        <div class="version active" data-version="2">
+          <div class="design-note">
+            <strong>Change (v2):</strong> Replaced "Top Tools Used" chart with
+            "Skills & Features" as primary. Expanded section summaries to 2-3
+            lines. Tool chart moved below skills as secondary info.
+          </div>
+
+          <div class="i-page">
+            <div class="i-detail">
+              <div class="i-detail-author">
+                <img
+                  src="https://avatars.githubusercontent.com/u/124315902?v=4"
+                  alt=""
+                />
+                <div class="info">
+                  <div class="name">craigdossantos</div>
+                  <div class="date">
+                    Apr 3, 2026 · Mar 2 – Apr 2, 2026 · 18 days tracked
+                  </div>
+                </div>
+              </div>
+
+              <!-- ══ SNAPSHOT CARD v2 ══ -->
+              <div class="i-snapshot">
+                <div class="i-stats-bar">
+                  <div class="i-stat">
+                    <div class="val">126</div>
+                    <div class="label">Sessions</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">1,268</div>
+                    <div class="label">Messages</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">493</div>
+                    <div class="label">Msgs/Week</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val green">+47,313</div>
+                    <div class="label">Lines Added</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val red">-2,967</div>
+                    <div class="label">Removed</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">405</div>
+                    <div class="label">Files</div>
+                  </div>
+                  <div class="i-stat">
+                    <div class="val">124</div>
+                    <div class="label">Commits</div>
+                  </div>
+                </div>
+
+                <!-- Skills & features FIRST (more useful than tools) -->
+                <div class="i-skills-row">
+                  <h3>Skills & Features Used</h3>
+                  <div class="i-skills">
+                    <span class="i-skill-badge agents">🔀 Parallel Agents</span>
+                    <span class="i-skill-badge skills">⚡ Custom Skills</span>
+                    <span class="i-skill-badge playwright">🎭 Playwright</span>
+                    <span class="i-skill-badge hooks">🪝 Hooks</span>
+                    <span class="i-skill-badge mcp">🔌 MCP Servers</span>
+                    <span class="i-skill-badge review">📝 Code Review</span>
+                    <span class="i-skill-badge plan">📋 Plan Mode</span>
+                  </div>
+                </div>
+
+                <!-- Key pattern -->
+                <div class="i-key-pattern">
+                  <p>
+                    "Operates as a high-trust project manager who delegates
+                    ambitious multi-phase tasks to Claude, lets it run
+                    autonomously, and iteratively course-corrects through rapid
+                    QA cycles until production-ready."
+                  </p>
+                </div>
+
+                <!-- Tool chart SECONDARY (collapsed by default) -->
+                <div style="margin-top: 20px">
+                  <details>
+                    <summary
+                      style="
+                        font-size: 11px;
+                        font-weight: 600;
+                        color: #94a3b8;
+                        text-transform: uppercase;
+                        letter-spacing: 0.05em;
+                        cursor: pointer;
+                        padding: 4px 0;
+                      "
+                    >
+                      Top Tools Used ▸
+                    </summary>
+                    <div style="margin-top: 10px">
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">Bash</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 100%"></div>
+                        </div>
+                        <div class="i-bar-value">2,922</div>
+                      </div>
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">Read</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 45%"></div>
+                        </div>
+                        <div class="i-bar-value">1,318</div>
+                      </div>
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">Edit</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 24%"></div>
+                        </div>
+                        <div class="i-bar-value">714</div>
+                      </div>
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">TaskUpdate</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 13%"></div>
+                        </div>
+                        <div class="i-bar-value">374</div>
+                      </div>
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">Grep</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 13%"></div>
+                        </div>
+                        <div class="i-bar-value">374</div>
+                      </div>
+                      <div class="i-bar-row">
+                        <div class="i-bar-label">Agent</div>
+                        <div class="i-bar-track">
+                          <div class="i-bar-fill" style="width: 11%"></div>
+                        </div>
+                        <div class="i-bar-value">319</div>
+                      </div>
+                    </div>
+                  </details>
+                </div>
+              </div>
+
+              <!-- ══ COLLAPSIBLE SECTIONS v2 — expanded summaries ══ -->
+
+              <!-- At a Glance — always open -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon glance">✨</div>
+                  <div class="i-section-title"><h3>At a Glance</h3></div>
+                  <span class="i-section-chevron open">▾</span>
+                </div>
+                <div class="i-section-body">
+                  <div
+                    style="
+                      display: grid;
+                      grid-template-columns: 1fr 1fr;
+                      gap: 12px;
+                      margin-top: 16px;
+                    "
+                  >
+                    <div
+                      style="
+                        background: #f0fdf4;
+                        border: 1px solid #bbf7d0;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #166534;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        What's Working
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #15803d;
+                          line-height: 1.6;
+                        "
+                      >
+                        Developed a genuinely powerful workflow using Claude as
+                        a team coordinator — spinning up parallel agents for
+                        everything from course site generation to implementation
+                        plan reviews.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #fef2f2;
+                        border: 1px solid #fca5a5;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #991b1b;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        What's Hindering
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #7f1d1d;
+                          line-height: 1.6;
+                        "
+                      >
+                        Claude too often starts with the wrong approach —
+                        approximating instead of using real data, reading when
+                        it should generate, ignoring explicit instructions.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #eff6ff;
+                        border: 1px solid #93c5fd;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #1e40af;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        Quick Wins
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #1e3a8a;
+                          line-height: 1.6;
+                        "
+                      >
+                        Try using hooks to auto-run your test suite before
+                        commits. Consider running Claude in headless mode with
+                        pre-validated MCP connections.
+                      </div>
+                    </div>
+                    <div
+                      style="
+                        background: #f5f3ff;
+                        border: 1px solid #c4b5fd;
+                        border-radius: 10px;
+                        padding: 14px;
+                      "
+                    >
+                      <div
+                        style="
+                          font-weight: 600;
+                          font-size: 13px;
+                          color: #5b21b6;
+                          margin-bottom: 6px;
+                        "
+                      >
+                        On the Horizon
+                      </div>
+                      <div
+                        style="
+                          font-size: 14px;
+                          color: #6d28d9;
+                          line-height: 1.6;
+                        "
+                      >
+                        Autonomous test-fix loops where parallel agents each own
+                        a test suite and iterate until green without needing you
+                        to say 'continue.'
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Interaction Style — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon style">🎯</div>
+                  <div class="i-section-title">
+                    <h3>How They Use Claude Code</h3>
+                    <p>
+                      A high-velocity orchestrator who treats Claude Code as a
+                      full-stack engineering partner. Across 102 sessions in a
+                      single month, consistently delegates ambitious,
+                      multi-phase projects — redesigning entire UIs, running
+                      82-step QA checklists, and building course sites with 19
+                      parallel agents.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    The style is to set big goals and let Claude run, often
+                    kicking off parallel agent workflows and trusting Claude to
+                    handle multi-file changes. Doesn't micromanage; instead,
+                    course-corrects when things go wrong — 47 instances of wrong
+                    approach and 42 of buggy code — but handles friction
+                    pragmatically, redirecting rather than abandoning.
+                  </p>
+                  <p style="margin-top: 12px">
+                    The interaction pattern is distinctly iterative and
+                    QA-driven. Rarely provides exhaustive upfront specs;
+                    instead, launches into implementation, reviews the output,
+                    and then runs multiple fix cycles. The heavy Bash usage
+                    (2,922 calls) confirms constant builds, tests, and
+                    deployments — treating each session as a real production
+                    push.
+                  </p>
+                  <div class="key-insight" style="margin-top: 16px">
+                    <strong>Key pattern:</strong> High-trust project manager who
+                    delegates ambitious multi-phase tasks, lets Claude run
+                    autonomously, and iteratively course-corrects through rapid
+                    QA cycles.
+                  </div>
+                </div>
+              </div>
+
+              <!-- Project Areas — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon projects">📁</div>
+                  <div class="i-section-title">
+                    <h3>Project Areas</h3>
+                    <p>
+                      5 project areas across ~55 sessions. Major projects
+                      include a SaaS app (Appeal Mailer), an audio gift platform
+                      (Whispergram), a course content pipeline with parallel
+                      agents, and multiple business/marketing sites.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <div class="i-project-grid">
+                    <div class="i-project-card">
+                      <div class="name">Appeal Mailer SaaS</div>
+                      <div class="sessions">~18 sessions</div>
+                      <div class="desc">
+                        Building and launching a health insurance appeal letter
+                        SaaS app with full UI redesign, schema migrations,
+                        Stripe payments, and deployment.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">Whispergram Audio Platform</div>
+                      <div class="sessions">~12 sessions</div>
+                      <div class="desc">
+                        Collaborative audio gift compilation platform. UX
+                        polish, clip ordering, audio ducking, music playback via
+                        Supabase.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">CourseCapture Pipeline</div>
+                      <div class="sessions">~5 sessions</div>
+                      <div class="desc">
+                        Video scraping, transcription, slide extraction, and
+                        static site generation with 19 parallel blog post
+                        agents.
+                      </div>
+                    </div>
+                    <div class="i-project-card">
+                      <div class="name">LighterSky Sites</div>
+                      <div class="sessions">~8 sessions</div>
+                      <div class="desc">
+                        Business planning, website launches, booking site for
+                        wedding, research dashboards, and explainer sites.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Impressive Workflows — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon workflows">🏆</div>
+                  <div class="i-section-title">
+                    <h3>Impressive Workflows</h3>
+                    <p>
+                      Developed a genuinely powerful workflow using Claude as a
+                      team coordinator — spinning up parallel agents for
+                      everything from course site generation to implementation
+                      plan reviews. Most impressive sessions combine planning,
+                      multi-file implementation, and deployment into single
+                      flows.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Full impressive workflows content expands here with detailed
+                    examples of each standout workflow...
+                  </p>
+                </div>
+              </div>
+
+              <!-- Friction — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon friction">⚡</div>
+                  <div class="i-section-title">
+                    <h3>Where Things Go Wrong</h3>
+                    <p>
+                      Claude too often starts with the wrong approach —
+                      approximating instead of using real data, reading when it
+                      should generate, ignoring explicit instructions like using
+                      Codex CLI. MCP and Playwright configuration issues
+                      derailed at least six sessions without a permanent fix.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Full friction analysis with categories and examples expands
+                    here...
+                  </p>
+                </div>
+              </div>
+
+              <!-- Suggestions — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon suggestions">💡</div>
+                  <div class="i-section-title">
+                    <h3>Suggestions</h3>
+                    <p>
+                      Try using hooks to auto-run your test suite or lint checks
+                      before commits — this could catch many of the buggy code
+                      issues that currently require multiple fix rounds. Also
+                      consider running Claude in headless mode with
+                      pre-validated MCP connections.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Full suggestions with CLAUDE.md additions, features to try,
+                    and usage patterns expand here...
+                  </p>
+                </div>
+              </div>
+
+              <!-- Horizon — 2-3 line summary -->
+              <div class="i-section-card">
+                <div
+                  class="i-section-header"
+                  onclick="
+                    this.nextElementSibling.style.display =
+                      this.nextElementSibling.style.display === 'none'
+                        ? 'block'
+                        : 'none';
+                    this.querySelector('.i-section-chevron').classList.toggle(
+                      'open',
+                    );
+                  "
+                >
+                  <div class="i-section-icon horizon">🔮</div>
+                  <div class="i-section-title">
+                    <h3>On the Horizon</h3>
+                    <p>
+                      As models get more capable, autonomous test-fix loops
+                      where parallel agents each own a test suite and iterate
+                      until green. Even more powerful: a full PR pipeline where
+                      one agent implements, a second reviews, and a third runs
+                      CI — all in parallel.
+                    </p>
+                  </div>
+                  <span class="i-section-chevron">▾</span>
+                </div>
+                <div class="i-section-body" style="display: none">
+                  <p>
+                    Full horizon opportunities with copyable prompts expand
+                    here...
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="version-nav">
+        <button data-dir="prev" disabled>&larr; Prev</button
+        ><span class="version-label">v2 of 2</span
+        ><button data-dir="next" disabled>Next &rarr;</button>
+      </div>
+      <div class="feedback-area">
+        <label for="fb-detail">Feedback</label
+        ><textarea
+          id="fb-detail"
+          placeholder="Voice transcribe or type feedback for this section..."
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div style="height: 80px"></div>
+
+    <script>
+      // Viewport toggle
+      document.querySelectorAll(".viewport-toggle button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          document
+            .querySelectorAll(".viewport-toggle button")
+            .forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          document.body.classList.remove("viewport-mobile", "viewport-desktop");
+          document.body.classList.add("viewport-" + btn.dataset.viewport);
+        });
+      });
+
+      // Copy all feedback
+      function copyAllFeedback() {
+        const viewport = document.body.classList.contains("viewport-mobile")
+          ? "mobile"
+          : "desktop";
+        const sections = {};
+        document.querySelectorAll(".mockup-section").forEach((s) => {
+          const id = s.dataset.sectionId;
+          const ta = s.querySelector("textarea");
+          const activeVersion = s.querySelector(".version.active");
+          const allVersions = s.querySelectorAll(".version");
+          sections[id] = {
+            feedback: ta ? ta.value : "",
+            viewing_version: activeVersion
+              ? parseInt(activeVersion.dataset.version)
+              : 1,
+            total_versions: allVersions.length,
+            viewport,
+          };
+        });
+        const json = JSON.stringify(
+          {
+            mockup: document.title,
+            timestamp: new Date().toISOString(),
+            viewport,
+            sections,
+          },
+          null,
+          2,
+        );
+        navigator.clipboard.writeText(json).then(() => {
+          const btn = document.querySelector(".copy-all-btn");
+          btn.textContent = "Copied!";
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.textContent = "Copy All Feedback";
+            btn.classList.remove("copied");
+          }, 2000);
+        });
+      }
+
+      // Version nav
+      document.querySelectorAll(".version-nav button").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const container = btn
+            .closest(".mockup-section")
+            .querySelector(".version-container");
+          const versions = container.querySelectorAll(".version");
+          const active = container.querySelector(".version.active");
+          const idx = Array.from(versions).indexOf(active);
+          const dir = btn.dataset.dir === "prev" ? -1 : 1;
+          const next = idx + dir;
+          if (next >= 0 && next < versions.length) {
+            active.classList.remove("active");
+            versions[next].classList.add("active");
+            const nav = btn.closest(".version-nav");
+            nav.querySelector("[data-dir=prev]").disabled = next === 0;
+            nav.querySelector("[data-dir=next]").disabled =
+              next === versions.length - 1;
+            nav.querySelector(".version-label").textContent =
+              `v${next + 1} of ${versions.length}`;
+          }
+        });
+      });
+
+      // Show version nav when >1 version
+      document.querySelectorAll(".mockup-section").forEach((s) => {
+        if (s.querySelectorAll(".version").length > 1) {
+          s.querySelector(".version-nav").classList.add("visible");
+        }
+      });
+
+      // Char count
+      document.querySelectorAll(".feedback-area textarea").forEach((ta) => {
+        const counter = ta.parentElement.querySelector(".char-count");
+        ta.addEventListener("input", () => {
+          counter.textContent = ta.value.length
+            ? ta.value.length + " chars"
+            : "";
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/docs/superpowers/plans/2026-04-04-readability-redesign-plan.md
+++ b/docs/superpowers/plans/2026-04-04-readability-redesign-plan.md
@@ -1,0 +1,2187 @@
+# Insightful v2 — Readability Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform Insightful's report display from text-heavy walls into scannable, data-rich pages with contributor-focused homepage, snapshot cards, and collapsible sections.
+
+**Architecture:** Extend upload parser to extract structured chart data and detect skill mentions. Store new JSON fields on `InsightReport`. Rebuild homepage as a contributor list. Redesign detail page with snapshot card + collapsible sections.
+
+**Tech Stack:** Next.js 16 App Router, Prisma + Supabase PostgreSQL, cheerio (HTML parsing), Tailwind CSS, Lucide React icons, Vitest for unit tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-04-readability-redesign-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+- `src/lib/skill-detector.ts` — skill detection logic
+- `src/lib/__tests__/skill-detector.test.ts` — tests for detector
+- `src/lib/chart-parser.ts` — chart data extraction from HTML
+- `src/lib/__tests__/chart-parser.test.ts` — tests for chart parser
+- `src/components/SkillBadges.tsx` — renders skill badge chips
+- `src/components/ToolUsageChart.tsx` — horizontal bar chart for tools
+- `src/components/SnapshotCard.tsx` — top snapshot card on detail page
+- `src/components/CollapsibleSection.tsx` — collapsible section card with summary
+- `src/components/ContributorRow.tsx` — homepage list row
+- `prisma/migrations/add_chart_data_and_skills.sql` — manual migration SQL
+
+**Modified files:**
+
+- `prisma/schema.prisma` — add `chartData Json?` and `detectedSkills String[]`
+- `src/types/insights.ts` — add `ChartData` and `SkillKey` types
+- `src/lib/parser.ts` — no changes (chart parser is separate)
+- `src/lib/redaction.ts` — strengthen project redaction
+- `src/app/api/upload/route.ts` — call chart parser + skill detector
+- `src/app/api/insights/route.ts` — return `chartData`, `detectedSkills`
+- `src/app/api/insights/[slug]/route.ts` — return new fields + compute per-week stats
+- `src/app/page.tsx` — new homepage layout with ContributorRow
+- `src/app/insights/[slug]/page.tsx` — use SnapshotCard + CollapsibleSection
+- `src/components/SectionRenderer.tsx` — add `readOnly` prop
+- `src/app/upload/page.tsx` — show full content in redaction review step
+
+---
+
+## Task 1: Add schema fields and apply migration
+
+**Files:**
+
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/add_chart_data_and_skills.sql`
+
+- [ ] **Step 1: Add fields to Prisma schema**
+
+Edit `prisma/schema.prisma`. Find the `InsightReport` model and add these fields in the Stats section (after `msgsPerDay`):
+
+```prisma
+  // v2 additions
+  chartData       Json?
+  detectedSkills  String[]   @default([])
+```
+
+- [ ] **Step 2: Create migration SQL file**
+
+Create `prisma/migrations/add_chart_data_and_skills.sql`:
+
+```sql
+ALTER TABLE "InsightReport"
+  ADD COLUMN IF NOT EXISTS "chartData" JSONB,
+  ADD COLUMN IF NOT EXISTS "detectedSkills" TEXT[] NOT NULL DEFAULT '{}';
+```
+
+- [ ] **Step 3: Apply migration to Supabase**
+
+Run: `npx supabase@latest db query --linked -f prisma/migrations/add_chart_data_and_skills.sql`
+
+Expected: `{ "rows": [] }` (empty success)
+
+- [ ] **Step 4: Regenerate Prisma client**
+
+Run: `npx prisma generate`
+
+Expected: `✔ Generated Prisma Client`
+
+- [ ] **Step 5: Verify build still passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+Expected: Next.js build output with no errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/add_chart_data_and_skills.sql
+git commit -m "feat(schema): add chartData and detectedSkills fields to InsightReport"
+```
+
+---
+
+## Task 2: Add types for ChartData and SkillKey
+
+**Files:**
+
+- Modify: `src/types/insights.ts`
+
+- [ ] **Step 1: Add types at the end of the file**
+
+Open `src/types/insights.ts` and append:
+
+```typescript
+// v2: Chart data parsed from HTML report
+export interface ChartDataPoint {
+  label: string;
+  value: number;
+}
+
+export interface ChartData {
+  toolUsage?: ChartDataPoint[];
+  requestTypes?: ChartDataPoint[];
+  languages?: ChartDataPoint[];
+  sessionTypes?: ChartDataPoint[];
+}
+
+// v2: Closed set of detectable Claude Code skills/features
+export const SKILL_KEYS = [
+  "parallel_agents",
+  "worktrees",
+  "custom_skills",
+  "hooks",
+  "mcp_servers",
+  "playwright",
+  "headless_mode",
+  "plan_mode",
+  "code_review",
+  "subagents",
+] as const;
+
+export type SkillKey = (typeof SKILL_KEYS)[number];
+
+export interface SkillMetadata {
+  key: SkillKey;
+  label: string;
+  icon: string;
+  colorClass: string;
+}
+
+export const SKILL_METADATA: Record<SkillKey, SkillMetadata> = {
+  parallel_agents: {
+    key: "parallel_agents",
+    label: "Parallel Agents",
+    icon: "🔀",
+    colorClass: "bg-violet-100 text-violet-700",
+  },
+  worktrees: {
+    key: "worktrees",
+    label: "Worktrees",
+    icon: "🌳",
+    colorClass: "bg-green-100 text-green-700",
+  },
+  custom_skills: {
+    key: "custom_skills",
+    label: "Custom Skills",
+    icon: "⚡",
+    colorClass: "bg-amber-100 text-amber-700",
+  },
+  hooks: {
+    key: "hooks",
+    label: "Hooks",
+    icon: "🪝",
+    colorClass: "bg-sky-100 text-sky-700",
+  },
+  mcp_servers: {
+    key: "mcp_servers",
+    label: "MCP Servers",
+    icon: "🔌",
+    colorClass: "bg-slate-100 text-slate-700",
+  },
+  playwright: {
+    key: "playwright",
+    label: "Playwright",
+    icon: "🎭",
+    colorClass: "bg-pink-100 text-pink-700",
+  },
+  headless_mode: {
+    key: "headless_mode",
+    label: "Headless Mode",
+    icon: "🤖",
+    colorClass: "bg-indigo-100 text-indigo-700",
+  },
+  plan_mode: {
+    key: "plan_mode",
+    label: "Plan Mode",
+    icon: "📋",
+    colorClass: "bg-emerald-100 text-emerald-700",
+  },
+  code_review: {
+    key: "code_review",
+    label: "Code Review",
+    icon: "📝",
+    colorClass: "bg-red-100 text-red-700",
+  },
+  subagents: {
+    key: "subagents",
+    label: "Subagents",
+    icon: "🧩",
+    colorClass: "bg-teal-100 text-teal-700",
+  },
+};
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+Expected: Build succeeds, no type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/insights.ts
+git commit -m "feat(types): add ChartData and SkillKey types with metadata"
+```
+
+---
+
+## Task 3: Write failing test for chart parser
+
+**Files:**
+
+- Create: `src/lib/__tests__/chart-parser.test.ts`
+
+- [ ] **Step 1: Create test file**
+
+Create `src/lib/__tests__/chart-parser.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { parseChartData } from "../chart-parser";
+
+const SAMPLE_HTML = `
+<html><body>
+  <div class="chart-card">
+    <div class="chart-title">What You Wanted</div>
+    <div class="bar-row">
+      <div class="bar-label">Bug Fix</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">27</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">Code Review</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">16</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Top Tools Used</div>
+    <div class="bar-row">
+      <div class="bar-label">Bash</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">2922</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">Read</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">1318</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Languages</div>
+    <div class="bar-row">
+      <div class="bar-label">TypeScript</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">1345</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Session Types</div>
+    <div class="bar-row">
+      <div class="bar-label">Multi Task</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">40</div>
+    </div>
+  </div>
+</body></html>
+`;
+
+describe("parseChartData", () => {
+  it("extracts tool usage from 'Top Tools Used' chart", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.toolUsage).toEqual([
+      { label: "Bash", value: 2922 },
+      { label: "Read", value: 1318 },
+    ]);
+  });
+
+  it("extracts request types from 'What You Wanted' chart", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.requestTypes).toEqual([
+      { label: "Bug Fix", value: 27 },
+      { label: "Code Review", value: 16 },
+    ]);
+  });
+
+  it("extracts languages", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.languages).toEqual([{ label: "TypeScript", value: 1345 }]);
+  });
+
+  it("extracts session types", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.sessionTypes).toEqual([{ label: "Multi Task", value: 40 }]);
+  });
+
+  it("returns empty object when no charts present", () => {
+    const result = parseChartData("<html><body><p>no charts</p></body></html>");
+    expect(result).toEqual({});
+  });
+
+  it("handles comma-formatted numbers", () => {
+    const html = `
+      <div class="chart-card">
+        <div class="chart-title">Top Tools Used</div>
+        <div class="bar-row">
+          <div class="bar-label">Bash</div>
+          <div class="bar-value">2,922</div>
+        </div>
+      </div>
+    `;
+    const result = parseChartData(html);
+    expect(result.toolUsage?.[0]).toEqual({ label: "Bash", value: 2922 });
+  });
+
+  it("omits keys for charts that aren't in the HTML", () => {
+    const html = `
+      <div class="chart-card">
+        <div class="chart-title">Top Tools Used</div>
+        <div class="bar-row">
+          <div class="bar-label">Bash</div>
+          <div class="bar-value">100</div>
+        </div>
+      </div>
+    `;
+    const result = parseChartData(html);
+    expect(result.toolUsage).toBeDefined();
+    expect(result.requestTypes).toBeUndefined();
+    expect(result.languages).toBeUndefined();
+    expect(result.sessionTypes).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/__tests__/chart-parser.test.ts 2>&1 | tail -20`
+
+Expected: FAIL with "Cannot find module '../chart-parser'" or similar
+
+---
+
+## Task 4: Implement chart parser
+
+**Files:**
+
+- Create: `src/lib/chart-parser.ts`
+
+- [ ] **Step 1: Create chart parser implementation**
+
+Create `src/lib/chart-parser.ts`:
+
+```typescript
+import * as cheerio from "cheerio";
+import type { ChartData, ChartDataPoint } from "@/types/insights";
+
+/**
+ * Parse chart data from a Claude Code HTML insights report.
+ *
+ * The HTML report contains multiple `.chart-card` elements, each with a
+ * `.chart-title` and one or more `.bar-row` children. Each bar row has
+ * a `.bar-label` and `.bar-value`. We extract the four chart types we
+ * know about by matching the chart title.
+ */
+export function parseChartData(html: string): ChartData {
+  const $ = cheerio.load(html);
+  const result: ChartData = {};
+
+  $(".chart-card").each((_, card) => {
+    const title = $(card).find(".chart-title").first().text().trim();
+    const rows: ChartDataPoint[] = [];
+
+    $(card)
+      .find(".bar-row")
+      .each((_, row) => {
+        const label = $(row).find(".bar-label").text().trim();
+        const valueText = $(row).find(".bar-value").text().trim();
+        const value = parseInt(valueText.replace(/,/g, ""), 10);
+
+        if (label && !isNaN(value)) {
+          rows.push({ label, value });
+        }
+      });
+
+    if (rows.length === 0) return;
+
+    // Map chart title to our structured field
+    const titleLower = title.toLowerCase();
+    if (titleLower.includes("tools used") || titleLower.includes("top tools")) {
+      result.toolUsage = rows;
+    } else if (
+      titleLower.includes("what you wanted") ||
+      titleLower.includes("request")
+    ) {
+      result.requestTypes = rows;
+    } else if (titleLower.includes("language")) {
+      result.languages = rows;
+    } else if (titleLower.includes("session type")) {
+      result.sessionTypes = rows;
+    }
+  });
+
+  return result;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/__tests__/chart-parser.test.ts 2>&1 | tail -15`
+
+Expected: All 7 tests passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/chart-parser.ts src/lib/__tests__/chart-parser.test.ts
+git commit -m "feat(parser): add chart data extraction from HTML reports"
+```
+
+---
+
+## Task 5: Write failing tests for skill detector
+
+**Files:**
+
+- Create: `src/lib/__tests__/skill-detector.test.ts`
+
+- [ ] **Step 1: Create test file**
+
+Create `src/lib/__tests__/skill-detector.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { detectSkills } from "../skill-detector";
+import type { InsightsData, ChartData } from "@/types/insights";
+
+function makeData(narrativeText: string): InsightsData {
+  return {
+    at_a_glance: {
+      whats_working: "",
+      whats_hindering: "",
+      quick_wins: "",
+      ambitious_workflows: "",
+    },
+    interaction_style: { narrative: narrativeText, key_pattern: "" },
+    project_areas: { areas: [] },
+    what_works: { intro: "", impressive_workflows: [] },
+    friction_analysis: { intro: "", categories: [] },
+    suggestions: {
+      claude_md_additions: [],
+      features_to_try: [],
+      usage_patterns: [],
+    },
+    on_the_horizon: { intro: "", opportunities: [] },
+    fun_ending: { headline: "", detail: "" },
+  };
+}
+
+describe("detectSkills", () => {
+  it("detects parallel_agents from narrative text", () => {
+    const data = makeData(
+      "You used parallel agents to run multiple test suites simultaneously.",
+    );
+    const result = detectSkills(data, {});
+    expect(result).toContain("parallel_agents");
+  });
+
+  it("detects parallel_agents from TaskCreate in tool usage", () => {
+    const data = makeData("No mentions here.");
+    const chartData: ChartData = {
+      toolUsage: [
+        { label: "Bash", value: 100 },
+        { label: "TaskCreate", value: 191 },
+      ],
+    };
+    const result = detectSkills(data, chartData);
+    expect(result).toContain("parallel_agents");
+  });
+
+  it("detects worktrees", () => {
+    const data = makeData("You created git worktrees for isolation.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("worktrees");
+  });
+
+  it("detects custom_skills from SKILL.md mention", () => {
+    const data = makeData("You published a SKILL.md file for reuse.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("custom_skills");
+  });
+
+  it("detects hooks", () => {
+    const data = makeData("You configured pre-commit hooks.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("hooks");
+  });
+
+  it("detects mcp_servers", () => {
+    const data = makeData("Playwright MCP server configuration.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("mcp_servers");
+  });
+
+  it("detects playwright", () => {
+    const data = makeData("You ran browser tests with Playwright.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("playwright");
+  });
+
+  it("detects plan_mode", () => {
+    const data = makeData("Used plan mode for complex refactors.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("plan_mode");
+  });
+
+  it("detects code_review", () => {
+    const data = makeData("Ran code review with a review agent.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("code_review");
+  });
+
+  it("returns empty array when nothing detected", () => {
+    const data = makeData("Just a normal session.");
+    const result = detectSkills(data, {});
+    expect(result).toEqual([]);
+  });
+
+  it("deduplicates results", () => {
+    const data = makeData(
+      "parallel agents, parallel agents, and more parallel agents",
+    );
+    const result = detectSkills(data, {});
+    const count = result.filter((s) => s === "parallel_agents").length;
+    expect(count).toBe(1);
+  });
+
+  it("detects multiple skills from the same text", () => {
+    const data = makeData(
+      "You used parallel agents with Playwright MCP and worktrees for isolation.",
+    );
+    const result = detectSkills(data, {});
+    expect(result).toContain("parallel_agents");
+    expect(result).toContain("playwright");
+    expect(result).toContain("mcp_servers");
+    expect(result).toContain("worktrees");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/__tests__/skill-detector.test.ts 2>&1 | tail -10`
+
+Expected: FAIL with "Cannot find module '../skill-detector'"
+
+---
+
+## Task 6: Implement skill detector
+
+**Files:**
+
+- Create: `src/lib/skill-detector.ts`
+
+- [ ] **Step 1: Create skill detector implementation**
+
+Create `src/lib/skill-detector.ts`:
+
+```typescript
+import type { InsightsData, ChartData, SkillKey } from "@/types/insights";
+
+/**
+ * Collect all text content from parsed insights data into a single searchable string.
+ */
+function collectText(data: InsightsData): string {
+  const parts: string[] = [];
+
+  const walk = (obj: unknown): void => {
+    if (typeof obj === "string") {
+      parts.push(obj);
+    } else if (Array.isArray(obj)) {
+      obj.forEach(walk);
+    } else if (obj !== null && typeof obj === "object") {
+      Object.values(obj).forEach(walk);
+    }
+  };
+
+  walk(data);
+  return parts.join(" ").toLowerCase();
+}
+
+interface SkillRule {
+  key: SkillKey;
+  textPatterns?: string[];
+  toolPatterns?: string[];
+}
+
+const RULES: SkillRule[] = [
+  {
+    key: "parallel_agents",
+    textPatterns: ["parallel agent", "parallel sub-agent", "agent workflow"],
+    toolPatterns: ["TaskCreate"],
+  },
+  {
+    key: "worktrees",
+    textPatterns: ["worktree", "git worktree"],
+  },
+  {
+    key: "custom_skills",
+    textPatterns: ["skill.md", "custom skill", "slash command"],
+  },
+  {
+    key: "hooks",
+    textPatterns: [
+      "pre-commit hook",
+      "post-tool hook",
+      "pre-tool hook",
+      "hooks configured",
+      "hook configured",
+      "configured hooks",
+    ],
+  },
+  {
+    key: "mcp_servers",
+    textPatterns: ["mcp server", "mcp "],
+  },
+  {
+    key: "playwright",
+    textPatterns: ["playwright", "browser test"],
+  },
+  {
+    key: "headless_mode",
+    textPatterns: [
+      "headless mode",
+      "headless claude",
+      "non-interactive claude",
+    ],
+  },
+  {
+    key: "plan_mode",
+    textPatterns: ["plan mode", "implementation plan"],
+  },
+  {
+    key: "code_review",
+    textPatterns: ["code review", "review agent", "codex cli review"],
+  },
+  {
+    key: "subagents",
+    textPatterns: ["subagent", "sub-agent"],
+    toolPatterns: ["Agent"],
+  },
+];
+
+/**
+ * Scan parsed insights data and chart data for mentions of Claude Code features.
+ * Returns an array of detected skill keys (deduplicated).
+ */
+export function detectSkills(
+  data: InsightsData,
+  chartData: ChartData,
+): SkillKey[] {
+  const text = collectText(data);
+  const toolNames = new Set((chartData.toolUsage ?? []).map((t) => t.label));
+
+  const detected = new Set<SkillKey>();
+
+  for (const rule of RULES) {
+    // Check text patterns
+    if (rule.textPatterns) {
+      for (const pattern of rule.textPatterns) {
+        if (text.includes(pattern.toLowerCase())) {
+          detected.add(rule.key);
+          break;
+        }
+      }
+    }
+
+    // Check tool patterns (exact match on tool names)
+    if (!detected.has(rule.key) && rule.toolPatterns) {
+      for (const pattern of rule.toolPatterns) {
+        if (toolNames.has(pattern)) {
+          detected.add(rule.key);
+          break;
+        }
+      }
+    }
+  }
+
+  return Array.from(detected);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/__tests__/skill-detector.test.ts 2>&1 | tail -20`
+
+Expected: All 12 tests passing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/skill-detector.ts src/lib/__tests__/skill-detector.test.ts
+git commit -m "feat(parser): add skill detection from insights text and tool usage"
+```
+
+---
+
+## Task 7: Wire chart parser and skill detector into upload API
+
+**Files:**
+
+- Modify: `src/app/api/upload/route.ts`
+
+- [ ] **Step 1: Read the current upload route to understand its structure**
+
+Run: `head -60 src/app/api/upload/route.ts`
+
+Look for where `parseInsightsHtml` is called and where `detectRedactions` runs.
+
+- [ ] **Step 2: Add imports at the top of the file**
+
+Edit `src/app/api/upload/route.ts`. Find the import section and add:
+
+```typescript
+import { parseChartData } from "@/lib/chart-parser";
+import { detectSkills } from "@/lib/skill-detector";
+```
+
+- [ ] **Step 3: Call the new parsers after parseInsightsHtml**
+
+Find the line that calls `parseInsightsHtml(html)` (stores result in `parsed`). Immediately after it, add:
+
+```typescript
+const chartData = parseChartData(html);
+const detectedSkills = detectSkills(parsed.data, chartData);
+```
+
+- [ ] **Step 4: Include new fields in the response**
+
+Find the `NextResponse.json(...)` return statement. Add `chartData` and `detectedSkills` to the response body. The response should look like:
+
+```typescript
+return NextResponse.json({
+  stats: parsed.stats,
+  data: parsed.data,
+  detectedRedactions: parsed.detectedRedactions,
+  chartData,
+  detectedSkills,
+});
+```
+
+- [ ] **Step 5: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/upload/route.ts
+git commit -m "feat(api): include chartData and detectedSkills in upload response"
+```
+
+---
+
+## Task 8: Accept chartData and detectedSkills in POST /api/insights
+
+**Files:**
+
+- Modify: `src/app/api/insights/route.ts`
+
+- [ ] **Step 1: Read current POST handler**
+
+Run: `grep -n "chartData\|detectedSkills\|prisma.insightReport.create" src/app/api/insights/route.ts`
+
+- [ ] **Step 2: Add fields to request body destructuring**
+
+Edit `src/app/api/insights/route.ts`. Find the `const { title, ... } = body;` destructuring inside the POST handler. Add `chartData` and `detectedSkills`:
+
+```typescript
+const {
+  title: providedTitle,
+  sessionCount,
+  messageCount,
+  commitCount,
+  dateRangeStart,
+  dateRangeEnd,
+  linesAdded,
+  linesRemoved,
+  fileCount,
+  dayCount,
+  msgsPerDay,
+  chartData,
+  detectedSkills,
+  atAGlance,
+  interactionStyle,
+  projectAreas,
+  impressiveWorkflows,
+  frictionAnalysis,
+  suggestions,
+  onTheHorizon,
+  funEnding,
+  projectLinks,
+} = body;
+```
+
+- [ ] **Step 3: Pass the fields to Prisma create**
+
+Find the `prisma.insightReport.create({ data: { ... } })` call. Add these fields alongside the other stats:
+
+```typescript
+        chartData: chartData ?? undefined,
+        detectedSkills: detectedSkills ?? [],
+```
+
+- [ ] **Step 4: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+Expected: Build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/insights/route.ts
+git commit -m "feat(api): persist chartData and detectedSkills on insight create"
+```
+
+---
+
+## Task 9: Send chartData and detectedSkills from upload client
+
+**Files:**
+
+- Modify: `src/app/upload/page.tsx`
+
+- [ ] **Step 1: Update ParsedInsightsReport type usage**
+
+The upload page stores the parsed response in `parsed` state. Find the interface/type for the parsed data and ensure it includes `chartData` and `detectedSkills`. Check `src/types/insights.ts` for `ParsedInsightsReport`:
+
+Run: `grep -n "ParsedInsightsReport" src/types/insights.ts`
+
+If `ParsedInsightsReport` doesn't include the new fields, extend it:
+
+Find the `ParsedInsightsReport` interface and add:
+
+```typescript
+  chartData?: ChartData;
+  detectedSkills?: SkillKey[];
+```
+
+- [ ] **Step 2: Pass fields to publish API**
+
+In `src/app/upload/page.tsx`, find the `handlePublish` function and the fetch POST body to `/api/insights`. Add `chartData` and `detectedSkills`:
+
+```typescript
+          chartData: parsed.chartData,
+          detectedSkills: parsed.detectedSkills,
+```
+
+Place these alongside the other stats in the JSON body.
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/insights.ts src/app/upload/page.tsx
+git commit -m "feat(upload): forward chartData and detectedSkills to publish API"
+```
+
+---
+
+## Task 10: Strengthen project redaction
+
+**Files:**
+
+- Modify: `src/lib/redaction.ts`
+- Modify: `src/lib/__tests__/redaction.test.ts`
+
+- [ ] **Step 1: Read current redaction.ts**
+
+Run: `cat src/lib/redaction.ts`
+
+Find the `applyRedactions` function.
+
+- [ ] **Step 2: Write a failing test**
+
+Edit `src/lib/__tests__/redaction.test.ts`. Add a new test:
+
+```typescript
+it("also redacts project description when project name is redacted", () => {
+  const data: InsightsData = {
+    at_a_glance: {
+      whats_working: "",
+      whats_hindering: "",
+      quick_wins: "",
+      ambitious_workflows: "",
+    },
+    interaction_style: { narrative: "", key_pattern: "" },
+    project_areas: {
+      areas: [
+        {
+          name: "SecretProject",
+          session_count: 10,
+          description: "A secret health insurance app with Stripe payments",
+        },
+      ],
+    },
+    what_works: { intro: "", impressive_workflows: [] },
+    friction_analysis: { intro: "", categories: [] },
+    suggestions: {
+      claude_md_additions: [],
+      features_to_try: [],
+      usage_patterns: [],
+    },
+    on_the_horizon: { intro: "", opportunities: [] },
+    fun_ending: { headline: "", detail: "" },
+  };
+
+  const decisions: RedactionItem[] = [
+    {
+      id: "1",
+      text: "SecretProject",
+      type: "project_name",
+      context: "",
+      sectionKey: "project_areas",
+      action: "redact",
+    },
+  ];
+
+  const result = applyRedactions(data, decisions);
+  const area = result.project_areas.areas[0];
+  expect(area.name).toBe("[redacted]");
+  expect(area.description).toBe("[redacted]");
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/__tests__/redaction.test.ts 2>&1 | tail -10`
+
+Expected: FAIL — current logic only redacts the name string, not the description.
+
+- [ ] **Step 4: Update applyRedactions**
+
+Edit `src/lib/redaction.ts`. In the `applyRedactions` function, after the existing string replacement logic, add a block that walks `clone.project_areas.areas` and replaces descriptions of redacted projects:
+
+```typescript
+// v2: If a project name is marked for full redaction, also clear its description
+const redactedProjectNames = new Set(
+  decisions
+    .filter(
+      (d) =>
+        d.type === "project_name" &&
+        d.sectionKey === "project_areas" &&
+        d.action === "redact",
+    )
+    .map((d) => d.text),
+);
+
+if (redactedProjectNames.size > 0 && clone.project_areas?.areas) {
+  for (const area of clone.project_areas.areas) {
+    // area.name has already been replaced with [redacted] by string replacement
+    // We need to detect which areas had redacted names. Check if the original
+    // name was in the redacted set by comparing the description's original position.
+    // Simpler: match by session_count and replace description if name is now [redacted]
+    if (area.name === "[redacted]") {
+      area.description = "[redacted]";
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/__tests__/redaction.test.ts 2>&1 | tail -10`
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/redaction.ts src/lib/__tests__/redaction.test.ts
+git commit -m "feat(redaction): also redact project descriptions when name is redacted"
+```
+
+---
+
+## Task 11: Add readOnly prop to SectionRenderer
+
+**Files:**
+
+- Modify: `src/components/SectionRenderer.tsx`
+
+- [ ] **Step 1: Read SectionRenderer props interface**
+
+Run: `grep -n "interface\|VoteButton\|readOnly" src/components/SectionRenderer.tsx | head -20`
+
+Find the component's prop interface.
+
+- [ ] **Step 2: Add readOnly prop to interface**
+
+Edit `src/components/SectionRenderer.tsx`. In the props interface (likely `SectionRendererProps`), add:
+
+```typescript
+  readOnly?: boolean;
+```
+
+- [ ] **Step 3: Pass readOnly to the component signature**
+
+Find the function signature and add the prop:
+
+```typescript
+export default function SectionRenderer({
+  // ... existing props
+  readOnly = false,
+}: SectionRendererProps) {
+```
+
+- [ ] **Step 4: Conditionally render vote/highlight buttons**
+
+Find where `<VoteButton />` is rendered (likely in a footer section of the component). Wrap it in a conditional:
+
+```typescript
+{!readOnly && (
+  <VoteButton
+    // existing props
+  />
+)}
+```
+
+Do the same for any highlight buttons or other interactive controls.
+
+- [ ] **Step 5: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/SectionRenderer.tsx
+git commit -m "feat(components): add readOnly prop to SectionRenderer"
+```
+
+---
+
+## Task 12: Show full section content in upload review step
+
+**Files:**
+
+- Modify: `src/app/upload/page.tsx`
+
+- [ ] **Step 1: Find the redact step JSX**
+
+Run: `grep -n "step === .redact.\|step === \"redact\"" src/app/upload/page.tsx`
+
+- [ ] **Step 2: Add a full-content preview below the section toggles**
+
+In the redact step JSX, after the existing section toggles UI, add a new block that renders each section's full content:
+
+```typescript
+{/* Full content preview */}
+<div className="mt-8 space-y-6">
+  <h3 className="text-sm font-semibold text-slate-700">
+    Preview: Full Content
+  </h3>
+  <p className="text-xs text-slate-500">
+    This is what others will see. Review carefully before publishing.
+  </p>
+  {SECTION_OPTIONS.map(({ dataKey, sectionType }) => {
+    if (disabledSections[dataKey]) return null;
+    const sectionData = parsed.data[dataKey];
+    if (!sectionData) return null;
+    return (
+      <div key={dataKey} className="rounded-lg border border-slate-200 bg-white p-4">
+        <SectionRenderer
+          slug="preview"
+          sectionKey={dataKey}
+          sectionType={sectionType}
+          data={sectionData}
+          reportId="preview"
+          voteCount={0}
+          voted={false}
+          readOnly
+        />
+      </div>
+    );
+  })}
+</div>
+```
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/upload/page.tsx
+git commit -m "feat(upload): show full section content in redaction review step"
+```
+
+---
+
+## Task 13: Create SkillBadges component
+
+**Files:**
+
+- Create: `src/components/SkillBadges.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/SkillBadges.tsx`:
+
+```typescript
+import type { SkillKey } from "@/types/insights";
+import { SKILL_METADATA } from "@/types/insights";
+import clsx from "clsx";
+
+interface SkillBadgesProps {
+  skills: SkillKey[];
+  size?: "sm" | "md";
+}
+
+export default function SkillBadges({ skills, size = "md" }: SkillBadgesProps) {
+  if (!skills || skills.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {skills.map((key) => {
+        const meta = SKILL_METADATA[key];
+        if (!meta) return null;
+        return (
+          <span
+            key={key}
+            className={clsx(
+              "inline-flex items-center gap-1 rounded-full font-semibold uppercase tracking-wide",
+              meta.colorClass,
+              size === "sm"
+                ? "px-2 py-0.5 text-[10px]"
+                : "px-2.5 py-1 text-xs",
+            )}
+          >
+            <span>{meta.icon}</span>
+            <span>{meta.label}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SkillBadges.tsx
+git commit -m "feat(components): add SkillBadges component"
+```
+
+---
+
+## Task 14: Create ToolUsageChart component
+
+**Files:**
+
+- Create: `src/components/ToolUsageChart.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/ToolUsageChart.tsx`:
+
+```typescript
+import type { ChartDataPoint } from "@/types/insights";
+
+interface ToolUsageChartProps {
+  data: ChartDataPoint[];
+  max?: number;
+}
+
+export default function ToolUsageChart({
+  data,
+  max = 6,
+}: ToolUsageChartProps) {
+  if (!data || data.length === 0) return null;
+
+  const topItems = data.slice(0, max);
+  const maxValue = Math.max(...topItems.map((d) => d.value));
+
+  return (
+    <div className="space-y-1.5">
+      {topItems.map((item) => {
+        const pct = maxValue > 0 ? (item.value / maxValue) * 100 : 0;
+        return (
+          <div key={item.label} className="flex items-center gap-2">
+            <div className="w-20 shrink-0 text-xs text-slate-600 dark:text-slate-400">
+              {item.label}
+            </div>
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+              <div
+                className="h-full rounded-full bg-blue-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="w-14 shrink-0 text-right text-xs font-medium text-slate-500 dark:text-slate-400">
+              {item.value.toLocaleString()}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ToolUsageChart.tsx
+git commit -m "feat(components): add ToolUsageChart bar chart component"
+```
+
+---
+
+## Task 15: Create SnapshotCard component
+
+**Files:**
+
+- Create: `src/components/SnapshotCard.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/SnapshotCard.tsx`:
+
+```typescript
+import type { ChartData, SkillKey } from "@/types/insights";
+import SkillBadges from "./SkillBadges";
+import ToolUsageChart from "./ToolUsageChart";
+
+interface SnapshotCardProps {
+  sessionCount: number | null;
+  messageCount: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  dayCount: number | null;
+  commitCount: number | null;
+  chartData: ChartData | null;
+  detectedSkills: SkillKey[];
+  keyPattern: string | null;
+}
+
+function StatCell({
+  value,
+  label,
+  className = "",
+}: {
+  value: string | number;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div className="text-center">
+      <div className={`text-2xl font-bold ${className}`}>{value}</div>
+      <div className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export default function SnapshotCard({
+  sessionCount,
+  messageCount,
+  linesAdded,
+  linesRemoved,
+  fileCount,
+  dayCount,
+  commitCount,
+  chartData,
+  detectedSkills,
+  keyPattern,
+}: SnapshotCardProps) {
+  const msgsPerWeek =
+    messageCount && dayCount ? Math.round(messageCount / (dayCount / 7)) : null;
+
+  return (
+    <div className="mb-8 rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
+      {/* Stats bar */}
+      <div className="flex flex-wrap gap-6 pb-5">
+        {sessionCount != null && (
+          <StatCell value={sessionCount} label="Sessions" />
+        )}
+        {messageCount != null && (
+          <StatCell value={messageCount.toLocaleString()} label="Messages" />
+        )}
+        {msgsPerWeek != null && (
+          <StatCell value={msgsPerWeek.toLocaleString()} label="Msgs/Week" />
+        )}
+        {linesAdded != null && (
+          <StatCell
+            value={`+${linesAdded.toLocaleString()}`}
+            label="Lines Added"
+            className="text-green-600 dark:text-green-400"
+          />
+        )}
+        {linesRemoved != null && (
+          <StatCell
+            value={`-${linesRemoved.toLocaleString()}`}
+            label="Removed"
+            className="text-red-600 dark:text-red-400"
+          />
+        )}
+        {fileCount != null && <StatCell value={fileCount} label="Files" />}
+        {commitCount != null && (
+          <StatCell value={commitCount} label="Commits" />
+        )}
+      </div>
+
+      {/* Skills badges */}
+      {detectedSkills.length > 0 && (
+        <div className="border-t border-slate-100 pt-5 dark:border-slate-800">
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+            Skills & Features Used
+          </h3>
+          <SkillBadges skills={detectedSkills} />
+        </div>
+      )}
+
+      {/* Key pattern */}
+      {keyPattern && (
+        <div className="mt-5 rounded-lg border-l-4 border-blue-500 bg-blue-50 px-4 py-3 dark:bg-blue-950/30">
+          <p className="text-sm italic leading-relaxed text-slate-700 dark:text-slate-300">
+            &ldquo;{keyPattern}&rdquo;
+          </p>
+        </div>
+      )}
+
+      {/* Tool usage chart — collapsed by default */}
+      {chartData?.toolUsage && chartData.toolUsage.length > 0 && (
+        <details className="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800">
+          <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-slate-400 hover:text-slate-600">
+            Top Tools Used ▸
+          </summary>
+          <div className="mt-3">
+            <ToolUsageChart data={chartData.toolUsage} />
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/SnapshotCard.tsx
+git commit -m "feat(components): add SnapshotCard for report detail page"
+```
+
+---
+
+## Task 16: Create CollapsibleSection component
+
+**Files:**
+
+- Create: `src/components/CollapsibleSection.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/CollapsibleSection.tsx`:
+
+```typescript
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import clsx from "clsx";
+
+interface CollapsibleSectionProps {
+  icon: string;
+  iconBgClass?: string;
+  title: string;
+  summary?: string | null;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export default function CollapsibleSection({
+  icon,
+  iconBgClass = "bg-slate-100 dark:bg-slate-800",
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/50">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-start gap-4 p-5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50"
+        type="button"
+      >
+        <div
+          className={clsx(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl",
+            iconBgClass,
+          )}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h3>
+          {summary && (
+            <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+              {summary}
+            </p>
+          )}
+        </div>
+        <ChevronDown
+          className={clsx(
+            "mt-1 h-5 w-5 shrink-0 text-slate-400 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-slate-100 px-5 pb-6 pt-4 dark:border-slate-800">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/CollapsibleSection.tsx
+git commit -m "feat(components): add CollapsibleSection component"
+```
+
+---
+
+## Task 17: Create ContributorRow component
+
+**Files:**
+
+- Create: `src/components/ContributorRow.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/ContributorRow.tsx`:
+
+```typescript
+import Link from "next/link";
+import Image from "next/image";
+import { User } from "lucide-react";
+import type { SkillKey } from "@/types/insights";
+import SkillBadges from "./SkillBadges";
+
+interface ContributorRowProps {
+  slug: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  publishedAt: string;
+  dayCount: number | null;
+  messageCount: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  commitCount: number | null;
+  detectedSkills: SkillKey[];
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function ContributorRow({
+  slug,
+  username,
+  displayName,
+  avatarUrl,
+  publishedAt,
+  dayCount,
+  messageCount,
+  linesAdded,
+  linesRemoved,
+  fileCount,
+  commitCount,
+  detectedSkills,
+}: ContributorRowProps) {
+  // Per-week normalization for comparability
+  const msgsPerWeek =
+    messageCount && dayCount && dayCount > 0
+      ? Math.round(messageCount / (dayCount / 7))
+      : null;
+
+  const totalLines = (linesAdded ?? 0) + (linesRemoved ?? 0);
+  const linesPerWeek =
+    totalLines && dayCount && dayCount > 0
+      ? Math.round(totalLines / (dayCount / 7))
+      : null;
+
+  return (
+    <Link
+      href={`/insights/${slug}`}
+      className="group flex items-start gap-4 rounded-xl border border-slate-200 bg-white p-4 transition-all hover:border-blue-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-900/50 dark:hover:border-blue-700"
+    >
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt=""
+          width={48}
+          height={48}
+          className="h-12 w-12 shrink-0 rounded-full"
+        />
+      ) : (
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+          <User className="h-6 w-6" />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className="font-semibold text-slate-900 group-hover:text-blue-600 dark:text-slate-100 dark:group-hover:text-blue-400">
+          {displayName || username}
+        </div>
+        <div className="text-xs text-slate-400">
+          @{username} · {formatDate(publishedAt)}
+          {dayCount != null && ` · ${dayCount} days tracked`}
+        </div>
+
+        {/* Stats row */}
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600 dark:text-slate-400">
+          {msgsPerWeek != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {msgsPerWeek.toLocaleString()}
+              </strong>{" "}
+              msgs/wk
+            </span>
+          )}
+          {linesPerWeek != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {linesPerWeek.toLocaleString()}
+              </strong>{" "}
+              lines/wk
+            </span>
+          )}
+          {linesAdded != null && (
+            <span className="text-green-600 dark:text-green-400">
+              +{linesAdded.toLocaleString()} added
+            </span>
+          )}
+          {linesRemoved != null && (
+            <span className="text-red-600 dark:text-red-400">
+              -{linesRemoved.toLocaleString()} removed
+            </span>
+          )}
+          {fileCount != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {fileCount}
+              </strong>{" "}
+              files
+            </span>
+          )}
+          {commitCount != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {commitCount}
+              </strong>{" "}
+              commits
+            </span>
+          )}
+        </div>
+
+        {/* Skills badges */}
+        {detectedSkills.length > 0 && (
+          <div className="mt-2">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              Skills Used
+            </div>
+            <SkillBadges skills={detectedSkills} size="sm" />
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/ContributorRow.tsx
+git commit -m "feat(components): add ContributorRow for homepage list"
+```
+
+---
+
+## Task 18: Rebuild homepage with ContributorRow list
+
+**Files:**
+
+- Modify: `src/app/page.tsx`
+
+- [ ] **Step 1: Read the current page.tsx structure**
+
+Run: `head -100 src/app/page.tsx`
+
+- [ ] **Step 2: Replace the InsightSummary interface and mapping**
+
+Edit `src/app/page.tsx`. Update the `InsightSummary` interface to include `detectedSkills`:
+
+```typescript
+interface InsightSummary {
+  slug: string;
+  title: string;
+  publishedAt: string;
+  dayCount?: number | null;
+  messageCount?: number | null;
+  linesAdded?: number | null;
+  linesRemoved?: number | null;
+  fileCount?: number | null;
+  commitCount?: number | null;
+  detectedSkills: SkillKey[];
+  author: {
+    username: string;
+    displayName?: string | null;
+    avatarUrl?: string | null;
+  };
+}
+```
+
+Add the import at the top: `import type { SkillKey } from "@/types/insights";` and `import ContributorRow from "@/components/ContributorRow";`
+
+- [ ] **Step 3: Update the fetch mapper to include detectedSkills**
+
+Find the `.then((json) => { ... })` block inside the fetch. Update the mapper to include:
+
+```typescript
+return {
+  slug: r.slug,
+  title: r.title,
+  publishedAt: r.publishedAt,
+  dayCount: r.dayCount,
+  messageCount: r.messageCount,
+  linesAdded: r.linesAdded,
+  linesRemoved: r.linesRemoved,
+  fileCount: r.fileCount,
+  commitCount: r.commitCount,
+  detectedSkills: (r.detectedSkills as SkillKey[]) ?? [],
+  author: r.author,
+};
+```
+
+Remove fields no longer used (atAGlance preview, voteCount, commentCount, sessionCount).
+
+- [ ] **Step 4: Replace the rendered grid with ContributorRow list**
+
+Find the `insights.length > 0 ?` block. Replace the `<div className="grid ...">` with:
+
+```typescript
+        <div className="space-y-3">
+          {insights.map((insight) => (
+            <ContributorRow
+              key={insight.slug}
+              slug={insight.slug}
+              username={insight.author.username}
+              displayName={insight.author.displayName ?? null}
+              avatarUrl={insight.author.avatarUrl ?? null}
+              publishedAt={insight.publishedAt}
+              dayCount={insight.dayCount ?? null}
+              messageCount={insight.messageCount ?? null}
+              linesAdded={insight.linesAdded ?? null}
+              linesRemoved={insight.linesRemoved ?? null}
+              fileCount={insight.fileCount ?? null}
+              commitCount={insight.commitCount ?? null}
+              detectedSkills={insight.detectedSkills}
+            />
+          ))}
+        </div>
+```
+
+Remove the `InsightCard` import if no longer used.
+
+- [ ] **Step 5: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/page.tsx
+git commit -m "feat(homepage): replace card grid with ContributorRow list"
+```
+
+---
+
+## Task 19: Update GET /api/insights/[slug] to return new fields
+
+**Files:**
+
+- Modify: `src/app/api/insights/[slug]/route.ts`
+
+- [ ] **Step 1: Read current select clause**
+
+Run: `grep -n "chartData\|detectedSkills\|select:" src/app/api/insights/\[slug\]/route.ts`
+
+- [ ] **Step 2: Add chartData and detectedSkills to the Prisma select**
+
+Edit the route file. Find the `select: { ... }` inside `prisma.insightReport.findUnique`. Add:
+
+```typescript
+        chartData: true,
+        detectedSkills: true,
+```
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/insights/\[slug\]/route.ts
+git commit -m "feat(api): return chartData and detectedSkills on report detail"
+```
+
+---
+
+## Task 20: Redesign report detail page with SnapshotCard and CollapsibleSection
+
+**Files:**
+
+- Modify: `src/app/insights/[slug]/page.tsx`
+
+- [ ] **Step 1: Read current detail page structure**
+
+Run: `head -120 src/app/insights/\[slug\]/page.tsx`
+
+Find the SECTIONS array and the JSX that renders sections.
+
+- [ ] **Step 2: Add imports**
+
+Add to the imports at top of file:
+
+```typescript
+import SnapshotCard from "@/components/SnapshotCard";
+import CollapsibleSection from "@/components/CollapsibleSection";
+import type { ChartData, SkillKey } from "@/types/insights";
+```
+
+- [ ] **Step 3: Extend ReportData interface**
+
+Add to the `ReportData` interface (if any of these fields are missing):
+
+```typescript
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  dayCount: number | null;
+  msgsPerDay: number | null;
+  chartData: ChartData | null;
+  detectedSkills: SkillKey[];
+```
+
+- [ ] **Step 4: Extract summary helper function**
+
+Add this helper above the component (before `export default function`):
+
+```typescript
+function getSectionSummary(
+  sectionKey: string,
+  report: ReportData,
+): string | null {
+  const atAGlance = report.atAGlance;
+  const interactionStyle = report.interactionStyle;
+  const projectAreas = report.projectAreas;
+  const funEnding = report.funEnding;
+
+  switch (sectionKey) {
+    case "interaction_style":
+      if (!interactionStyle?.narrative) return null;
+      // First 2-3 sentences
+      const sentences = interactionStyle.narrative.match(/[^.!?]+[.!?]+/g);
+      return sentences?.slice(0, 2).join(" ").trim() || null;
+    case "project_areas":
+      const areas = projectAreas?.areas ?? [];
+      if (areas.length === 0) return null;
+      const total = areas.reduce((sum, a) => sum + (a.session_count ?? 0), 0);
+      const topNames = areas
+        .slice(0, 2)
+        .map((a) => a.name)
+        .join(", ");
+      return `${areas.length} project areas across ~${total} sessions. Major projects include ${topNames}.`;
+    case "impressive_workflows":
+      return atAGlance?.whats_working ?? null;
+    case "friction_analysis":
+      return atAGlance?.whats_hindering ?? null;
+    case "suggestions":
+      return atAGlance?.quick_wins ?? null;
+    case "on_the_horizon":
+      return atAGlance?.ambitious_workflows ?? null;
+    case "fun_ending":
+      if (!funEnding?.headline) return null;
+      return funEnding.detail
+        ? `${funEnding.headline}. ${funEnding.detail.split(".")[0]}.`
+        : funEnding.headline;
+    default:
+      return null;
+  }
+}
+```
+
+- [ ] **Step 5: Replace the stats bar + sections JSX with SnapshotCard + CollapsibleSections**
+
+Find the JSX that renders the stats bar and the SECTIONS.map. Replace with:
+
+```typescript
+      {/* Snapshot card */}
+      <SnapshotCard
+        sessionCount={report.sessionCount}
+        messageCount={report.messageCount}
+        linesAdded={report.linesAdded ?? null}
+        linesRemoved={report.linesRemoved ?? null}
+        fileCount={report.fileCount ?? null}
+        dayCount={report.dayCount ?? null}
+        commitCount={report.commitCount}
+        chartData={report.chartData}
+        detectedSkills={report.detectedSkills}
+        keyPattern={report.interactionStyle?.key_pattern ?? null}
+      />
+
+      {/* Collapsible sections */}
+      <div className="space-y-4">
+        {SECTIONS.map((section) => {
+          const data = (report as any)[section.dataKey];
+          if (!data) return null;
+          const summary = getSectionSummary(section.key, report);
+          const isAtAGlance = section.key === "at_a_glance";
+          return (
+            <CollapsibleSection
+              key={section.key}
+              icon={section.icon}
+              iconBgClass={section.iconBgClass}
+              title={section.label}
+              summary={isAtAGlance ? null : summary}
+              defaultOpen={isAtAGlance}
+            >
+              <SectionRenderer
+                slug={report.slug}
+                sectionKey={section.key}
+                sectionType={section.sectionType}
+                data={data}
+                reportId={report.id}
+                voteCount={report.voteCounts[section.key] ?? 0}
+                voted={report.userVotes[section.key] ?? false}
+              />
+            </CollapsibleSection>
+          );
+        })}
+      </div>
+```
+
+You'll need to update the SECTIONS constant to include `icon` (emoji string) and `iconBgClass`. Replace the SECTIONS array with:
+
+```typescript
+const SECTIONS: Array<{
+  key: string;
+  label: string;
+  dataKey: keyof ReportData;
+  sectionType: string;
+  icon: string;
+  iconBgClass: string;
+}> = [
+  {
+    key: "at_a_glance",
+    label: "At a Glance",
+    dataKey: "atAGlance",
+    sectionType: "at_a_glance",
+    icon: "✨",
+    iconBgClass: "bg-amber-100 dark:bg-amber-900/30",
+  },
+  {
+    key: "interaction_style",
+    label: "How They Use Claude Code",
+    dataKey: "interactionStyle",
+    sectionType: "interaction_style",
+    icon: "🎯",
+    iconBgClass: "bg-indigo-100 dark:bg-indigo-900/30",
+  },
+  {
+    key: "project_areas",
+    label: "Project Areas",
+    dataKey: "projectAreas",
+    sectionType: "project_areas",
+    icon: "📁",
+    iconBgClass: "bg-slate-100 dark:bg-slate-800",
+  },
+  {
+    key: "impressive_workflows",
+    label: "Impressive Workflows",
+    dataKey: "impressiveWorkflows",
+    sectionType: "impressive_workflows",
+    icon: "🏆",
+    iconBgClass: "bg-green-100 dark:bg-green-900/30",
+  },
+  {
+    key: "friction_analysis",
+    label: "Where Things Go Wrong",
+    dataKey: "frictionAnalysis",
+    sectionType: "friction_analysis",
+    icon: "⚡",
+    iconBgClass: "bg-red-100 dark:bg-red-900/30",
+  },
+  {
+    key: "suggestions",
+    label: "Suggestions",
+    dataKey: "suggestions",
+    sectionType: "suggestions",
+    icon: "💡",
+    iconBgClass: "bg-yellow-100 dark:bg-yellow-900/30",
+  },
+  {
+    key: "on_the_horizon",
+    label: "On the Horizon",
+    dataKey: "onTheHorizon",
+    sectionType: "on_the_horizon",
+    icon: "🔮",
+    iconBgClass: "bg-purple-100 dark:bg-purple-900/30",
+  },
+  {
+    key: "fun_ending",
+    label: "Fun Ending",
+    dataKey: "funEnding",
+    sectionType: "fun_ending",
+    icon: "🎉",
+    iconBgClass: "bg-pink-100 dark:bg-pink-900/30",
+  },
+];
+```
+
+- [ ] **Step 6: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/insights/\[slug\]/page.tsx
+git commit -m "feat(detail): redesign report page with SnapshotCard and CollapsibleSection"
+```
+
+---
+
+## Task 21: Update list API to return detectedSkills
+
+**Files:**
+
+- Modify: `src/app/api/insights/route.ts`
+
+- [ ] **Step 1: Find the GET handler's select clause**
+
+Run: `grep -n "detectedSkills\|select:" src/app/api/insights/route.ts | head -20`
+
+- [ ] **Step 2: Add detectedSkills to the select**
+
+Edit the file. Find the `select: { ... }` inside `prisma.insightReport.findMany` (inside the GET handler). Add:
+
+```typescript
+        detectedSkills: true,
+        dayCount: true,
+        linesAdded: true,
+        linesRemoved: true,
+        fileCount: true,
+```
+
+(Verify `linesAdded`, `linesRemoved`, `fileCount`, `dayCount` are not already included — if they are, skip duplicates.)
+
+- [ ] **Step 3: Verify build passes**
+
+Run: `npm run build 2>&1 | tail -5`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/insights/route.ts
+git commit -m "feat(api): include detectedSkills and enhanced stats in list response"
+```
+
+---
+
+## Task 22: Manual end-to-end test
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Start dev server**
+
+Run: `npm run dev &` (background)
+
+Wait: 5 seconds for ready
+
+- [ ] **Step 2: Verify home page loads with new layout**
+
+Run: `curl -s "http://localhost:3000/api/insights?sort=newest" | python3 -m json.tool | head -40`
+
+Expected: Response includes `detectedSkills` field (may be empty `[]` for existing records)
+
+- [ ] **Step 3: Screenshot the homepage**
+
+Run:
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --headless=new \
+  --screenshot=/tmp/v2-home.png --window-size=1440,900 --disable-gpu \
+  --virtual-time-budget=5000 "http://localhost:3000" 2>/dev/null
+```
+
+Read the screenshot and verify:
+
+- Hero section with "Insightful" title
+- Sort tabs (Newest, Most Voted, Trending)
+- Contributor rows (may just show existing data with empty skills arrays)
+
+- [ ] **Step 4: Re-upload the sample report to get new data**
+
+The existing reports in the DB don't have `chartData` or `detectedSkills` because they were uploaded before these fields existed. To test the new pipeline end-to-end, a fresh upload is needed.
+
+Prompt the user: "The existing report in the DB doesn't have chartData or detectedSkills populated (it was uploaded before the new fields existed). To verify the new pipeline end-to-end, you'll need to upload a fresh report via the UI. Go to http://localhost:3000/upload and upload `~/.claude/usage-data/report.html` again."
+
+- [ ] **Step 5: After user confirms upload, verify new fields are populated**
+
+Run: `curl -s "http://localhost:3000/api/insights?sort=newest" | python3 -c "import json,sys;d=json.load(sys.stdin)['data'][0];print('Skills:',d.get('detectedSkills'));print('Chart:',list((d.get('chartData') or {}).keys()))"`
+
+Expected: Non-empty `detectedSkills` array and `chartData` with keys like `toolUsage`, `requestTypes`, `languages`, `sessionTypes`
+
+- [ ] **Step 6: Screenshot the detail page**
+
+Run:
+
+```bash
+SLUG=$(curl -s "http://localhost:3000/api/insights?sort=newest" | python3 -c "import json,sys;print(json.load(sys.stdin)['data'][0]['slug'])")
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --headless=new \
+  --screenshot=/tmp/v2-detail.png --window-size=1440,2400 --disable-gpu \
+  --virtual-time-budget=5000 "http://localhost:3000/insights/$SLUG" 2>/dev/null
+```
+
+Read the screenshot and verify:
+
+- SnapshotCard at top with stats, skills badges, key pattern
+- Collapsible sections below with 2-3 line summaries
+- At a Glance section expanded by default
+
+- [ ] **Step 7: Stop dev server**
+
+Run: `pkill -f "next dev"`
+
+- [ ] **Step 8: Commit screenshots for documentation**
+
+Create `docs/screenshots/v2/` and save the screenshots there for reference:
+
+```bash
+mkdir -p docs/screenshots/v2
+cp /tmp/v2-home.png docs/screenshots/v2/home.png
+cp /tmp/v2-detail.png docs/screenshots/v2/detail.png
+git add docs/screenshots/v2/
+git commit -m "docs: add v2 redesign screenshots"
+```
+
+---
+
+## Task 23: Deploy to production
+
+**Files:** None (deployment only)
+
+- [ ] **Step 1: Verify all tests pass locally**
+
+Run: `npx vitest run 2>&1 | tail -10`
+
+Expected: All tests passing.
+
+- [ ] **Step 2: Final production build check**
+
+Run: `npm run build 2>&1 | tail -15`
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 3: Deploy to Vercel**
+
+Run: `vercel deploy --prod 2>&1`
+
+Expected: Deployment success with Production URL.
+
+- [ ] **Step 4: Smoke test on production**
+
+Wait 20 seconds after deploy, then:
+
+```bash
+curl -s "https://insightharness.com/api/health"
+curl -s "https://insightharness.com/api/insights?sort=newest" | python3 -c "import json,sys;d=json.load(sys.stdin);print(f'Reports: {d[\"pagination\"][\"total\"]}')"
+```
+
+Expected: Health `{ "status": "ok" }` and at least 1 report.
+
+- [ ] **Step 5: Screenshot production**
+
+```bash
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --headless=new \
+  --screenshot=/tmp/prod-home.png --window-size=1440,900 --disable-gpu \
+  --virtual-time-budget=5000 "https://insightharness.com" 2>/dev/null
+```
+
+Read the screenshot to verify production renders correctly.
+
+---
+
+## Summary
+
+**Total tasks:** 23
+**Total commits:** ~20 focused commits
+
+**What this delivers:**
+
+1. Schema + types for chart data and skills
+2. Chart parser extracting tool usage, request types, languages, session types
+3. Skill detector identifying 10 Claude Code features
+4. Strengthened project redaction
+5. Upload review step shows full content
+6. SkillBadges, ToolUsageChart, SnapshotCard, CollapsibleSection, ContributorRow components
+7. Homepage rebuilt as contributor list
+8. Detail page rebuilt with snapshot + collapsible sections
+9. E2E tested locally and deployed to production

--- a/docs/superpowers/specs/2026-04-04-readability-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-04-readability-redesign-design.md
@@ -13,11 +13,16 @@ Replace the current report-card grid with a contributor-grouped list. One row pe
 **Layout:** Clean list rows, each containing:
 
 - GitHub avatar (already stored from OAuth)
-- Display name + @username
-- Inline key stats: messages, days active, lines added/removed, commits
-- Top 2-3 tools as small text (e.g., "Bash, Read, Edit")
-- Skills badges: small colored chips (e.g., `Parallel Agents`, `Worktrees`, `Custom Skills`)
+- Display name + @username + date + days tracked (e.g., "@craigdossantos · Apr 3, 2026 · 18 days tracked")
+- **Normalized per-week stats** for comparability: messages/week, lines/week
+- Absolute labeled stats: "+N added" (green), "-N removed" (red), files, commits
+- "Skills Used" label above badges row
+- Skills badges: small colored chips
 - Click entire row → report detail page
+
+**Per-week calculation:** `messagesPerWeek = messageCount / (dayCount / 7)`, `linesPerWeek = (linesAdded + linesRemoved) / (dayCount / 7)`. Computed at read time — not stored.
+
+**Raw tool counts NOT shown** on homepage rows (Bash is always at top for everyone — not differentiating). Tools belong in the detail page only.
 
 If a user has multiple reports, they appear as separate rows but visually grouped under the same contributor header.
 
@@ -112,32 +117,35 @@ Migration: add columns via SQL applied through `npx supabase db query --linked -
 
 #### 4a. Top Snapshot Card
 
-A visually prominent card at the top of the report, above all sections:
+A visually prominent card at the top of the report, above all sections. **Order matters — skills first, tools collapsed.**
 
-**Row 1: Stats bar** (existing, but redesigned)
+**Row 1: Stats bar**
 
 - Larger numbers, bolder typography
-- Stats: Sessions | Messages | Lines (+/-) | Files | Days | Msgs/Day | Commits
+- Stats: Sessions | Messages | Msgs/Week | Lines Added (green) | Removed (red) | Files | Commits
+- `Msgs/Week = messageCount / (dayCount / 7)` computed at read time
 
-**Row 2: Tool usage chart**
+**Row 2: Skills & Features (primary, always visible)**
 
-- Horizontal bar chart rendered from `chartData.toolUsage`
-- Top 5-6 tools, proportional bars with values
-- Clean, minimal design (no axis labels, just bars with inline labels)
-- If `chartData.toolUsage` is missing/empty, hide this row entirely
-
-**Row 3: Skills badges**
-
+- Header: "Skills & Features Used"
 - Colored chip/badge for each detected skill
 - e.g., `🔀 Parallel Agents` `🌳 Worktrees` `⚡ Custom Skills` `🎭 Playwright`
 - Muted colors, small text, pill-shaped
 - If `detectedSkills` is empty, hide this row entirely
 
-**Row 4: Key pattern highlight**
+**Row 3: Key pattern highlight**
 
 - The one-liner from `interactionStyle.key_pattern` (derived at read time)
-- Displayed in a slightly highlighted/quoted style
+- Displayed in a slightly highlighted/quoted style with left border accent
 - If missing, hide this row
+
+**Row 4: Tool usage chart (secondary, collapsed by default)**
+
+- Wrapped in a native `<details>` element with summary "Top Tools Used ▸"
+- Horizontal bar chart rendered from `chartData.toolUsage`
+- Top 5-6 tools, proportional bars with values
+- If `chartData.toolUsage` is missing/empty, hide entirely
+- **Rationale:** Bash is always at the top for everyone, so this is lower-value info than skills
 
 #### 4b. Collapsible Sections
 
@@ -146,7 +154,7 @@ Each of the 8 content sections becomes a collapsible card:
 **Header (always visible):**
 
 - Section icon + section name (larger, bolder than current)
-- 1-2 sentence summary (see mapping below)
+- **2-3 sentence summary** (see mapping below) — long enough to give real sense of what's inside
 - Expand/collapse chevron
 
 **Body (collapsed by default except "At a Glance"):**
@@ -154,16 +162,16 @@ Each of the 8 content sections becomes a collapsible card:
 - Full section content with improved typography
 - Section-specific card layouts for structured content (project areas, friction categories, etc.)
 
-**Section → summary mapping:**
+**Section → summary mapping (2-3 sentences each):**
 
 - At a Glance: always expanded, shows 4 sub-cards
-- Interaction Style: `key_pattern` as summary
-- Project Areas: count of projects with data (e.g., "5 project areas")
-- Impressive Workflows: `at_a_glance.whats_working` first sentence
-- Friction Analysis: `at_a_glance.whats_hindering` first sentence
-- Suggestions: `at_a_glance.quick_wins` first sentence
-- On the Horizon: `at_a_glance.ambitious_workflows` first sentence
-- Fun Ending: the headline as summary
+- Interaction Style: first 2-3 sentences of `interaction_style.narrative`
+- Project Areas: computed text like "{N} project areas across ~{total} sessions. Major projects include {top_2_names}."
+- Impressive Workflows: full `at_a_glance.whats_working` text (already 2-3 sentences)
+- Friction Analysis: full `at_a_glance.whats_hindering` text
+- Suggestions: full `at_a_glance.quick_wins` text
+- On the Horizon: full `at_a_glance.ambitious_workflows` text
+- Fun Ending: the headline + first sentence of detail
 
 **Fallback:** If a summary source is missing, show only the section name with no summary text.
 

--- a/prisma/migrations/add_chart_data_and_skills.sql
+++ b/prisma/migrations/add_chart_data_and_skills.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "InsightReport"
+  ADD COLUMN IF NOT EXISTS "chartData" JSONB,
+  ADD COLUMN IF NOT EXISTS "detectedSkills" TEXT[] NOT NULL DEFAULT '{}';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,10 @@ model InsightReport {
   dayCount      Int?
   msgsPerDay    Float?
 
+  // v2 additions
+  chartData       Json?
+  detectedSkills  String[]   @default([])
+
   // Content sections (stored as redacted JSON)
   atAGlance          Json?
   interactionStyle   Json?

--- a/src/app/api/insights/[slug]/route.ts
+++ b/src/app/api/insights/[slug]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import type { InsightReportDetailContract } from "@/types/api-contracts";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -22,6 +23,12 @@ export async function GET(
     const session = await auth();
     const userId = session?.user?.id ?? null;
 
+    // v2 invariant: These routes use `include` (not `select`) so ALL scalar fields
+    // on InsightReport flow through to the response automatically. The homepage
+    // (src/app/page.tsx) and detail page (src/app/insights/[slug]/page.tsx) depend
+    // on the following v2 fields being present: chartData, detectedSkills, dayCount,
+    // linesAdded, linesRemoved, fileCount. If you change this to an explicit
+    // `select`, you MUST add those fields explicitly, or the UI will silently break.
     const report = await prisma.insightReport.findUnique({
       where: { slug },
       include: {
@@ -51,6 +58,11 @@ export async function GET(
     if (!report) {
       return NextResponse.json({ error: "Insight not found" }, { status: 404 });
     }
+
+    // v2 compile-time contract check: fails to compile if Prisma ever stops
+    // returning the v2 scalar fields the detail page depends on.
+    const _contractCheck: InsightReportDetailContract = report;
+    void _contractCheck;
 
     // Aggregate vote counts and user's own votes/highlights per section
     const voteCounts: Record<string, number> = {};

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import type { InsightReportListItemContract } from "@/types/api-contracts";
 const SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
@@ -51,6 +52,12 @@ export async function GET(request: Request) {
     const fetchLimit = isTrending ? Math.max(limit * 3, 60) : limit;
     const fetchSkip = isTrending ? 0 : skip;
 
+    // v2 invariant: These routes use `include` (not `select`) so ALL scalar fields
+    // on InsightReport flow through to the response automatically. The homepage
+    // (src/app/page.tsx) and detail page (src/app/insights/[slug]/page.tsx) depend
+    // on the following v2 fields being present: chartData, detectedSkills, dayCount,
+    // linesAdded, linesRemoved, fileCount. If you change this to an explicit
+    // `select`, you MUST add those fields explicitly, or the UI will silently break.
     const reportsQuery = prisma.insightReport.findMany({
       skip: fetchSkip,
       take: fetchLimit,
@@ -78,6 +85,11 @@ export async function GET(request: Request) {
     const countQuery = prisma.insightReport.count();
 
     const [reports, total] = await Promise.all([reportsQuery, countQuery]);
+
+    // v2 compile-time contract check: fails to compile if Prisma ever stops
+    // returning the v2 scalar fields the homepage depends on.
+    const _contractCheck: InsightReportListItemContract[] = reports;
+    void _contractCheck;
 
     // Aggregate vote counts per section for each report
     const mapped = reports.map((report) => {

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -191,6 +191,8 @@ export async function POST(request: Request) {
       onTheHorizon,
       funEnding,
       projectLinks,
+      chartData,
+      detectedSkills,
     } = body;
 
     // Auto-generate title if not provided
@@ -223,6 +225,8 @@ export async function POST(request: Request) {
         suggestions: suggestions ?? undefined,
         onTheHorizon: onTheHorizon ?? undefined,
         funEnding: funEnding ?? undefined,
+        chartData: chartData ?? undefined,
+        detectedSkills: detectedSkills ?? [],
         ...(Array.isArray(projectLinks) && projectLinks.length > 0
           ? {
               projectLinks: {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { parseInsightsHtml } from "@/lib/parser";
 import { detectRedactions } from "@/lib/redaction";
+import { parseChartData } from "@/lib/chart-parser";
+import { detectSkills } from "@/lib/skill-detector";
 import * as cheerio from "cheerio";
 
 /**
@@ -84,6 +86,10 @@ export async function POST(request: Request) {
     // Parse using the cheerio-based parser
     const parsed = parseInsightsHtml(html);
 
+    // Extract chart data and detect skills
+    const chartData = parseChartData(html);
+    const detectedSkills = detectSkills(parsed.data, chartData);
+
     // Detect sensitive data using the redaction engine
     const detectedRedactions = detectRedactions(parsed.data);
 
@@ -97,6 +103,8 @@ export async function POST(request: Request) {
       },
       data: parsed.data,
       detectedRedactions,
+      chartData,
+      detectedSkills,
     });
   } catch (error) {
     console.error("POST /api/upload error:", error);

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -10,7 +10,12 @@ import CommentSection from "@/components/CommentSection";
 import ProjectLinks from "@/components/ProjectLinks";
 import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
-import type { InsightsData, ChartData, SkillKey } from "@/types/insights";
+import {
+  normalizeSkills,
+  type InsightsData,
+  type ChartData,
+  type SkillKey,
+} from "@/types/insights";
 
 interface ReportData {
   id: string;
@@ -190,7 +195,13 @@ export default function InsightDetailPage() {
         if (!res.ok) throw new Error("Report not found");
         return res.json();
       })
-      .then((json) => setReport(json.data || json))
+      .then((json) => {
+        const raw = json.data || json;
+        if (raw) {
+          raw.detectedSkills = normalizeSkills(raw.detectedSkills);
+        }
+        setReport(raw);
+      })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [slug]);

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -4,18 +4,13 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
-import {
-  Calendar,
-  MessageSquare,
-  GitCommitHorizontal,
-  Activity,
-  Clock,
-  Share2,
-} from "lucide-react";
+import { Calendar, Share2 } from "lucide-react";
 import SectionRenderer from "@/components/SectionRenderer";
 import CommentSection from "@/components/CommentSection";
 import ProjectLinks from "@/components/ProjectLinks";
-import type { InsightsData } from "@/types/insights";
+import SnapshotCard from "@/components/SnapshotCard";
+import CollapsibleSection from "@/components/CollapsibleSection";
+import type { InsightsData, ChartData, SkillKey } from "@/types/insights";
 
 interface ReportData {
   id: string;
@@ -27,6 +22,13 @@ interface ReportData {
   commitCount: number | null;
   dateRangeStart: string | null;
   dateRangeEnd: string | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  dayCount: number | null;
+  msgsPerDay: number | null;
+  chartData: ChartData | null;
+  detectedSkills: SkillKey[];
   atAGlance: InsightsData["at_a_glance"] | null;
   interactionStyle: InsightsData["interaction_style"] | null;
   projectAreas: InsightsData["project_areas"] | null;
@@ -58,59 +60,121 @@ interface ReportData {
 
 const SECTIONS: Array<{
   key: string;
-  type: string;
   label: string;
-  field: keyof ReportData;
+  dataKey: keyof ReportData;
+  sectionType: string;
+  icon: string;
+  iconBgClass: string;
 }> = [
   {
     key: "at_a_glance",
-    type: "at_a_glance",
     label: "At a Glance",
-    field: "atAGlance",
+    dataKey: "atAGlance",
+    sectionType: "at_a_glance",
+    icon: "✨",
+    iconBgClass: "bg-amber-100 dark:bg-amber-900/30",
   },
   {
     key: "interaction_style",
-    type: "interaction_style",
-    label: "Your Interaction Style",
-    field: "interactionStyle",
+    label: "How They Use Claude Code",
+    dataKey: "interactionStyle",
+    sectionType: "interaction_style",
+    icon: "🎯",
+    iconBgClass: "bg-indigo-100 dark:bg-indigo-900/30",
   },
   {
     key: "project_areas",
-    type: "project_areas",
     label: "Project Areas",
-    field: "projectAreas",
+    dataKey: "projectAreas",
+    sectionType: "project_areas",
+    icon: "📁",
+    iconBgClass: "bg-slate-100 dark:bg-slate-800",
   },
   {
     key: "impressive_workflows",
-    type: "impressive_workflows",
-    label: "Impressive Things You Did",
-    field: "impressiveWorkflows",
+    label: "Impressive Workflows",
+    dataKey: "impressiveWorkflows",
+    sectionType: "impressive_workflows",
+    icon: "🏆",
+    iconBgClass: "bg-green-100 dark:bg-green-900/30",
   },
   {
     key: "friction_analysis",
-    type: "friction_analysis",
     label: "Where Things Go Wrong",
-    field: "frictionAnalysis",
+    dataKey: "frictionAnalysis",
+    sectionType: "friction_analysis",
+    icon: "⚡",
+    iconBgClass: "bg-red-100 dark:bg-red-900/30",
   },
   {
     key: "suggestions",
-    type: "suggestions",
     label: "Suggestions",
-    field: "suggestions",
+    dataKey: "suggestions",
+    sectionType: "suggestions",
+    icon: "💡",
+    iconBgClass: "bg-yellow-100 dark:bg-yellow-900/30",
   },
   {
     key: "on_the_horizon",
-    type: "on_the_horizon",
     label: "On the Horizon",
-    field: "onTheHorizon",
+    dataKey: "onTheHorizon",
+    sectionType: "on_the_horizon",
+    icon: "🔮",
+    iconBgClass: "bg-purple-100 dark:bg-purple-900/30",
   },
   {
     key: "fun_ending",
-    type: "fun_ending",
     label: "Fun Ending",
-    field: "funEnding",
+    dataKey: "funEnding",
+    sectionType: "fun_ending",
+    icon: "🎉",
+    iconBgClass: "bg-pink-100 dark:bg-pink-900/30",
   },
 ];
+
+function getSectionSummary(
+  sectionKey: string,
+  report: ReportData,
+): string | null {
+  const atAGlance = report.atAGlance;
+  const interactionStyle = report.interactionStyle;
+  const projectAreas = report.projectAreas;
+  const funEnding = report.funEnding;
+
+  switch (sectionKey) {
+    case "interaction_style": {
+      if (!interactionStyle?.narrative) return null;
+      const sentences = interactionStyle.narrative.match(/[^.!?]+[.!?]+/g);
+      return sentences?.slice(0, 2).join(" ").trim() || null;
+    }
+    case "project_areas": {
+      const areas = projectAreas?.areas ?? [];
+      if (areas.length === 0) return null;
+      const total = areas.reduce((sum, a) => sum + (a.session_count ?? 0), 0);
+      const topNames = areas
+        .slice(0, 2)
+        .map((a) => a.name)
+        .join(", ");
+      return `${areas.length} project areas across ~${total} sessions. Major projects include ${topNames}.`;
+    }
+    case "impressive_workflows":
+      return atAGlance?.whats_working ?? null;
+    case "friction_analysis":
+      return atAGlance?.whats_hindering ?? null;
+    case "suggestions":
+      return atAGlance?.quick_wins ?? null;
+    case "on_the_horizon":
+      return atAGlance?.ambitious_workflows ?? null;
+    case "fun_ending": {
+      if (!funEnding?.headline) return null;
+      return funEnding.detail
+        ? `${funEnding.headline}. ${funEnding.detail.split(".")[0]}.`
+        : funEnding.headline;
+    }
+    default:
+      return null;
+  }
+}
 
 export default function InsightDetailPage() {
   const params = useParams();
@@ -219,90 +283,51 @@ export default function InsightDetailPage() {
         </button>
       </div>
 
-      {/* Stats banner */}
-      <div className="mb-8 flex flex-wrap gap-8 rounded-xl border border-slate-200 bg-white px-6 py-4">
-        {report.sessionCount && (
-          <div className="flex items-center gap-2">
-            <Activity className="h-5 w-5 text-blue-500" />
-            <div>
-              <div className="text-lg font-bold text-slate-900">
-                {report.sessionCount}
-              </div>
-              <div className="text-xs uppercase text-slate-500">Sessions</div>
-            </div>
-          </div>
-        )}
-        {report.messageCount && (
-          <div className="flex items-center gap-2">
-            <MessageSquare className="h-5 w-5 text-green-500" />
-            <div>
-              <div className="text-lg font-bold text-slate-900">
-                {report.messageCount.toLocaleString()}
-              </div>
-              <div className="text-xs uppercase text-slate-500">Messages</div>
-            </div>
-          </div>
-        )}
-        {report.commitCount && (
-          <div className="flex items-center gap-2">
-            <GitCommitHorizontal className="h-5 w-5 text-purple-500" />
-            <div>
-              <div className="text-lg font-bold text-slate-900">
-                {report.commitCount}
-              </div>
-              <div className="text-xs uppercase text-slate-500">Commits</div>
-            </div>
-          </div>
-        )}
-        {report.dateRangeStart && report.dateRangeEnd && (
-          <div className="flex items-center gap-2">
-            <Clock className="h-5 w-5 text-amber-500" />
-            <div>
-              <div className="text-sm font-semibold text-slate-900">
-                {report.dateRangeStart} to {report.dateRangeEnd}
-              </div>
-              <div className="text-xs uppercase text-slate-500">Period</div>
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Table of contents */}
-      <div className="mb-8 rounded-xl border border-slate-200 bg-white p-4">
-        <h3 className="mb-3 text-sm font-semibold uppercase text-slate-500">
-          Sections
-        </h3>
-        <div className="flex flex-wrap gap-2">
-          {SECTIONS.filter((s) => report[s.field]).map((s) => (
-            <a
-              key={s.key}
-              href={`#${s.key}`}
-              className="rounded-lg bg-slate-100 px-3 py-1.5 text-xs text-slate-600 transition-colors hover:bg-slate-200"
-            >
-              {s.label}
-            </a>
-          ))}
-        </div>
+      {/* Snapshot */}
+      <div className="mb-8">
+        <SnapshotCard
+          sessionCount={report.sessionCount}
+          messageCount={report.messageCount}
+          linesAdded={report.linesAdded ?? null}
+          linesRemoved={report.linesRemoved ?? null}
+          fileCount={report.fileCount ?? null}
+          dayCount={report.dayCount ?? null}
+          commitCount={report.commitCount}
+          chartData={report.chartData}
+          detectedSkills={report.detectedSkills}
+          keyPattern={report.interactionStyle?.key_pattern ?? null}
+        />
       </div>
 
       {/* Sections */}
-      <div className="space-y-8">
+      <div className="space-y-4">
         {SECTIONS.map((section) => {
-          const data = report[section.field];
+          const data = (report as unknown as Record<string, unknown>)[
+            section.dataKey
+          ];
           if (!data) return null;
+          const summary = getSectionSummary(section.key, report);
+          const isAtAGlance = section.key === "at_a_glance";
           return (
-            <div key={section.key} id={section.key}>
+            <CollapsibleSection
+              key={section.key}
+              icon={section.icon}
+              iconBgClass={section.iconBgClass}
+              title={section.label}
+              summary={isAtAGlance ? null : summary}
+              defaultOpen={isAtAGlance}
+            >
               <SectionRenderer
                 slug={slug}
                 sectionKey={section.key}
-                sectionType={section.type}
+                sectionType={section.sectionType}
                 data={data}
                 reportId={report.id}
-                voteCount={report.voteCounts[section.key] || 0}
-                voted={report.userVotes[section.key] || false}
+                voteCount={report.voteCounts[section.key] ?? 0}
+                voted={report.userVotes[section.key] ?? false}
                 annotation={annotations[section.key]}
               />
-            </div>
+            </CollapsibleSection>
           );
         })}
       </div>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -16,6 +16,7 @@ import {
   type ChartData,
   type SkillKey,
 } from "@/types/insights";
+import { normalizeChartData } from "@/lib/chart-parser";
 
 interface ReportData {
   id: string;
@@ -199,6 +200,7 @@ export default function InsightDetailPage() {
         const raw = json.data || json;
         if (raw) {
           raw.detectedSkills = normalizeSkills(raw.detectedSkills);
+          raw.chartData = normalizeChartData(raw.chartData);
         }
         setReport(raw);
       })

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { Sparkles, TrendingUp, Clock, Flame } from "lucide-react";
 import clsx from "clsx";
-import InsightCard from "@/components/InsightCard";
+import type { SkillKey } from "@/types/insights";
+import ContributorRow from "@/components/ContributorRow";
 
 type SortOption = "newest" | "most_voted" | "trending";
 
@@ -11,20 +12,13 @@ interface InsightSummary {
   slug: string;
   title: string;
   publishedAt: string;
-  dateRangeStart?: string | null;
-  dateRangeEnd?: string | null;
-  sessionCount?: number | null;
+  dayCount?: number | null;
   messageCount?: number | null;
-  commitCount?: number | null;
   linesAdded?: number | null;
   linesRemoved?: number | null;
   fileCount?: number | null;
-  dayCount?: number | null;
-  msgsPerDay?: number | null;
-  whatsWorkingPreview?: string | null;
-  voteCount: number;
-  commentCount: number;
-  sectionTags: string[];
+  commitCount?: number | null;
+  detectedSkills: SkillKey[];
   author: {
     username: string;
     displayName?: string | null;
@@ -54,35 +48,18 @@ export default function HomePage() {
       .then((json) => {
         const reports = json.data || json.insights || [];
         const mapped = reports.map((r: Record<string, unknown>) => {
-          const atAGlance = r.atAGlance as Record<string, string> | null;
-          const counts = r._count as Record<string, number> | undefined;
-          const voteCounts = r.voteCounts as Record<string, number> | undefined;
-          const totalVotes = voteCounts
-            ? Object.values(voteCounts).reduce(
-                (a: number, b: number) => a + b,
-                0,
-              )
-            : (counts?.votes ?? 0);
           return {
-            slug: r.slug,
-            title: r.title,
-            publishedAt: r.publishedAt,
-            dateRangeStart: r.dateRangeStart,
-            dateRangeEnd: r.dateRangeEnd,
-            sessionCount: r.sessionCount,
-            messageCount: r.messageCount,
-            commitCount: r.commitCount,
+            slug: r.slug as string,
+            title: r.title as string,
+            publishedAt: r.publishedAt as string,
+            dayCount: r.dayCount as number | null,
+            messageCount: r.messageCount as number | null,
             linesAdded: r.linesAdded as number | null,
             linesRemoved: r.linesRemoved as number | null,
             fileCount: r.fileCount as number | null,
-            dayCount: r.dayCount as number | null,
-            msgsPerDay: r.msgsPerDay as number | null,
-            whatsWorkingPreview:
-              atAGlance?.whats_working?.slice(0, 150) || null,
-            voteCount: totalVotes,
-            commentCount: counts?.comments ?? 0,
-            sectionTags: [],
-            author: r.author,
+            commitCount: r.commitCount as number | null,
+            detectedSkills: (r.detectedSkills as SkillKey[]) ?? [],
+            author: r.author as InsightSummary["author"],
           };
         });
         setInsights(mapped);
@@ -152,30 +129,22 @@ export default function HomePage() {
           ))}
         </div>
       ) : insights.length > 0 ? (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 min-w-0">
+        <div className="space-y-3">
           {insights.map((insight) => (
-            <InsightCard
+            <ContributorRow
               key={insight.slug}
               slug={insight.slug}
-              title={insight.title}
-              authorUsername={insight.author.username}
-              authorAvatar={insight.author.avatarUrl}
-              authorDisplayName={insight.author.displayName}
+              username={insight.author.username}
+              displayName={insight.author.displayName ?? null}
+              avatarUrl={insight.author.avatarUrl ?? null}
               publishedAt={insight.publishedAt}
-              dateRangeStart={insight.dateRangeStart}
-              dateRangeEnd={insight.dateRangeEnd}
-              sessionCount={insight.sessionCount}
-              messageCount={insight.messageCount}
-              commitCount={insight.commitCount}
-              linesAdded={insight.linesAdded}
-              linesRemoved={insight.linesRemoved}
-              fileCount={insight.fileCount}
-              dayCount={insight.dayCount}
-              msgsPerDay={insight.msgsPerDay}
-              whatsWorkingPreview={insight.whatsWorkingPreview}
-              voteCount={insight.voteCount}
-              commentCount={insight.commentCount}
-              sectionTags={insight.sectionTags}
+              dayCount={insight.dayCount ?? null}
+              messageCount={insight.messageCount ?? null}
+              linesAdded={insight.linesAdded ?? null}
+              linesRemoved={insight.linesRemoved ?? null}
+              fileCount={insight.fileCount ?? null}
+              commitCount={insight.commitCount ?? null}
+              detectedSkills={insight.detectedSkills}
             />
           ))}
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { Sparkles, TrendingUp, Clock, Flame } from "lucide-react";
 import clsx from "clsx";
-import type { SkillKey } from "@/types/insights";
+import { normalizeSkills, type SkillKey } from "@/types/insights";
 import ContributorRow from "@/components/ContributorRow";
 
 type SortOption = "newest" | "most_voted" | "trending";
@@ -58,7 +58,7 @@ export default function HomePage() {
             linesRemoved: r.linesRemoved as number | null,
             fileCount: r.fileCount as number | null,
             commitCount: r.commitCount as number | null,
-            detectedSkills: (r.detectedSkills as SkillKey[]) ?? [],
+            detectedSkills: normalizeSkills(r.detectedSkills),
             author: r.author as InsightSummary["author"],
           };
         });

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -252,6 +252,8 @@ export default function UploadPage() {
           msgsPerDay: parsed.stats.msgsPerDay ?? null,
           ...sectionFields,
           projectLinks,
+          chartData: parsed.chartData,
+          detectedSkills: parsed.detectedSkills,
         }),
       });
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -554,6 +554,38 @@ export default function UploadPage() {
               ))}
             </div>
           )}
+
+          {/* Full content preview */}
+          <div className="mt-8 space-y-6">
+            <h3 className="text-sm font-semibold text-slate-700">
+              Preview: Full Content
+            </h3>
+            <p className="text-xs text-slate-500">
+              This is what others will see. Review carefully before publishing.
+            </p>
+            {SECTION_OPTIONS.map(({ dataKey, sectionType }) => {
+              if (disabledSections[dataKey]) return null;
+              const sectionData = parsed.data[dataKey];
+              if (!sectionData) return null;
+              return (
+                <div
+                  key={dataKey}
+                  className="rounded-lg border border-slate-200 bg-white p-4"
+                >
+                  <SectionRenderer
+                    slug="preview"
+                    sectionKey={dataKey}
+                    sectionType={sectionType}
+                    data={sectionData}
+                    reportId="preview"
+                    voteCount={0}
+                    voted={false}
+                    readOnly
+                  />
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import clsx from "clsx";
+
+interface CollapsibleSectionProps {
+  icon: string;
+  iconBgClass?: string;
+  title: string;
+  summary?: string | null;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+export default function CollapsibleSection({
+  icon,
+  iconBgClass = "bg-slate-100 dark:bg-slate-800",
+  title,
+  summary,
+  defaultOpen = false,
+  children,
+}: CollapsibleSectionProps) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/50">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-start gap-4 p-5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50"
+        type="button"
+      >
+        <div
+          className={clsx(
+            "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl",
+            iconBgClass,
+          )}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            {title}
+          </h3>
+          {summary && (
+            <p className="mt-1 line-clamp-3 text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+              {summary}
+            </p>
+          )}
+        </div>
+        <ChevronDown
+          className={clsx(
+            "mt-1 h-5 w-5 shrink-0 text-slate-400 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-slate-100 px-5 pb-6 pt-4 dark:border-slate-800">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ContributorRow.tsx
+++ b/src/components/ContributorRow.tsx
@@ -1,0 +1,142 @@
+import Link from "next/link";
+import Image from "next/image";
+import { User } from "lucide-react";
+import type { SkillKey } from "@/types/insights";
+import SkillBadges from "./SkillBadges";
+
+interface ContributorRowProps {
+  slug: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  publishedAt: string;
+  dayCount: number | null;
+  messageCount: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  commitCount: number | null;
+  detectedSkills: SkillKey[];
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function ContributorRow({
+  slug,
+  username,
+  displayName,
+  avatarUrl,
+  publishedAt,
+  dayCount,
+  messageCount,
+  linesAdded,
+  linesRemoved,
+  fileCount,
+  commitCount,
+  detectedSkills,
+}: ContributorRowProps) {
+  // Per-week normalization for comparability
+  const msgsPerWeek =
+    messageCount && dayCount && dayCount > 0
+      ? Math.round(messageCount / (dayCount / 7))
+      : null;
+
+  const totalLines = (linesAdded ?? 0) + (linesRemoved ?? 0);
+  const linesPerWeek =
+    totalLines && dayCount && dayCount > 0
+      ? Math.round(totalLines / (dayCount / 7))
+      : null;
+
+  return (
+    <Link
+      href={`/insights/${slug}`}
+      className="group flex items-start gap-4 rounded-xl border border-slate-200 bg-white p-4 transition-all hover:border-blue-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-900/50 dark:hover:border-blue-700"
+    >
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt=""
+          width={48}
+          height={48}
+          className="h-12 w-12 shrink-0 rounded-full"
+        />
+      ) : (
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900 dark:text-blue-400">
+          <User className="h-6 w-6" />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <div className="font-semibold text-slate-900 group-hover:text-blue-600 dark:text-slate-100 dark:group-hover:text-blue-400">
+          {displayName || username}
+        </div>
+        <div className="text-xs text-slate-400">
+          @{username} · {formatDate(publishedAt)}
+          {dayCount != null && ` · ${dayCount} days tracked`}
+        </div>
+
+        {/* Stats row */}
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600 dark:text-slate-400">
+          {msgsPerWeek != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {msgsPerWeek.toLocaleString()}
+              </strong>{" "}
+              msgs/wk
+            </span>
+          )}
+          {linesPerWeek != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {linesPerWeek.toLocaleString()}
+              </strong>{" "}
+              lines/wk
+            </span>
+          )}
+          {linesAdded != null && (
+            <span className="text-green-600 dark:text-green-400">
+              +{linesAdded.toLocaleString()} added
+            </span>
+          )}
+          {linesRemoved != null && (
+            <span className="text-red-600 dark:text-red-400">
+              -{linesRemoved.toLocaleString()} removed
+            </span>
+          )}
+          {fileCount != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {fileCount}
+              </strong>{" "}
+              files
+            </span>
+          )}
+          {commitCount != null && (
+            <span>
+              <strong className="text-slate-800 dark:text-slate-200">
+                {commitCount}
+              </strong>{" "}
+              commits
+            </span>
+          )}
+        </div>
+
+        {/* Skills badges */}
+        {detectedSkills.length > 0 && (
+          <div className="mt-2">
+            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+              Skills Used
+            </div>
+            <SkillBadges skills={detectedSkills} size="sm" />
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/SectionRenderer.tsx
+++ b/src/components/SectionRenderer.tsx
@@ -36,6 +36,7 @@ interface SectionRendererProps {
   voteCount?: number;
   voted?: boolean;
   annotation?: string | null;
+  readOnly?: boolean;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -571,6 +572,7 @@ export default function SectionRenderer({
   voteCount = 0,
   voted = false,
   annotation,
+  readOnly = false,
 }: SectionRendererProps) {
   const meta = sectionMeta[sectionType] || sectionMeta.at_a_glance;
 
@@ -659,19 +661,21 @@ export default function SectionRenderer({
       {annotation && <AnnotationCallout body={annotation} />}
 
       {/* Actions */}
-      <div className="mt-5 flex items-center gap-3 border-t border-slate-100 pt-4 dark:border-slate-800">
-        <VoteButton
-          slug={slug}
-          reportId={reportId}
-          sectionKey={sectionKey}
-          initialCount={voteCount}
-          initialVoted={voted}
-        />
-        <button className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-500 transition-colors hover:bg-amber-50 hover:text-amber-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-amber-950/30 dark:hover:text-amber-400">
-          <Star className="h-4 w-4" />
-          Highlight
-        </button>
-      </div>
+      {!readOnly && (
+        <div className="mt-5 flex items-center gap-3 border-t border-slate-100 pt-4 dark:border-slate-800">
+          <VoteButton
+            slug={slug}
+            reportId={reportId}
+            sectionKey={sectionKey}
+            initialCount={voteCount}
+            initialVoted={voted}
+          />
+          <button className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-500 transition-colors hover:bg-amber-50 hover:text-amber-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:bg-amber-950/30 dark:hover:text-amber-400">
+            <Star className="h-4 w-4" />
+            Highlight
+          </button>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/SkillBadges.tsx
+++ b/src/components/SkillBadges.tsx
@@ -1,0 +1,34 @@
+import type { SkillKey } from "@/types/insights";
+import { SKILL_METADATA } from "@/types/insights";
+import clsx from "clsx";
+
+interface SkillBadgesProps {
+  skills: SkillKey[];
+  size?: "sm" | "md";
+}
+
+export default function SkillBadges({ skills, size = "md" }: SkillBadgesProps) {
+  if (!skills || skills.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {skills.map((key) => {
+        const meta = SKILL_METADATA[key];
+        if (!meta) return null;
+        return (
+          <span
+            key={key}
+            className={clsx(
+              "inline-flex items-center gap-1 rounded-full font-semibold uppercase tracking-wide",
+              meta.colorClass,
+              size === "sm" ? "px-2 py-0.5 text-[10px]" : "px-2.5 py-1 text-xs",
+            )}
+          >
+            <span>{meta.icon}</span>
+            <span>{meta.label}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/SnapshotCard.tsx
+++ b/src/components/SnapshotCard.tsx
@@ -1,0 +1,117 @@
+import type { ChartData, SkillKey } from "@/types/insights";
+import SkillBadges from "./SkillBadges";
+import ToolUsageChart from "./ToolUsageChart";
+
+interface SnapshotCardProps {
+  sessionCount: number | null;
+  messageCount: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  dayCount: number | null;
+  commitCount: number | null;
+  chartData: ChartData | null;
+  detectedSkills: SkillKey[];
+  keyPattern: string | null;
+}
+
+function StatCell({
+  value,
+  label,
+  className = "",
+}: {
+  value: string | number;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <div className="text-center">
+      <div className={`text-2xl font-bold ${className}`}>{value}</div>
+      <div className="mt-0.5 text-[11px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export default function SnapshotCard({
+  sessionCount,
+  messageCount,
+  linesAdded,
+  linesRemoved,
+  fileCount,
+  dayCount,
+  commitCount,
+  chartData,
+  detectedSkills,
+  keyPattern,
+}: SnapshotCardProps) {
+  const msgsPerWeek =
+    messageCount && dayCount ? Math.round(messageCount / (dayCount / 7)) : null;
+
+  return (
+    <div className="mb-8 rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
+      {/* Stats bar */}
+      <div className="flex flex-wrap gap-6 pb-5">
+        {sessionCount != null && (
+          <StatCell value={sessionCount} label="Sessions" />
+        )}
+        {messageCount != null && (
+          <StatCell value={messageCount.toLocaleString()} label="Messages" />
+        )}
+        {msgsPerWeek != null && (
+          <StatCell value={msgsPerWeek.toLocaleString()} label="Msgs/Week" />
+        )}
+        {linesAdded != null && (
+          <StatCell
+            value={`+${linesAdded.toLocaleString()}`}
+            label="Lines Added"
+            className="text-green-600 dark:text-green-400"
+          />
+        )}
+        {linesRemoved != null && (
+          <StatCell
+            value={`-${linesRemoved.toLocaleString()}`}
+            label="Removed"
+            className="text-red-600 dark:text-red-400"
+          />
+        )}
+        {fileCount != null && <StatCell value={fileCount} label="Files" />}
+        {commitCount != null && (
+          <StatCell value={commitCount} label="Commits" />
+        )}
+      </div>
+
+      {/* Skills badges */}
+      {detectedSkills.length > 0 && (
+        <div className="border-t border-slate-100 pt-5 dark:border-slate-800">
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+            Skills & Features Used
+          </h3>
+          <SkillBadges skills={detectedSkills} />
+        </div>
+      )}
+
+      {/* Key pattern */}
+      {keyPattern && (
+        <div className="mt-5 rounded-lg border-l-4 border-blue-500 bg-blue-50 px-4 py-3 dark:bg-blue-950/30">
+          <p className="text-sm italic leading-relaxed text-slate-700 dark:text-slate-300">
+            &ldquo;{keyPattern}&rdquo;
+          </p>
+        </div>
+      )}
+
+      {/* Tool usage chart — collapsed by default */}
+      {chartData?.toolUsage && chartData.toolUsage.length > 0 && (
+        <details className="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800">
+          <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-slate-400 hover:text-slate-600">
+            Top Tools Used ▸
+          </summary>
+          <div className="mt-3">
+            <ToolUsageChart data={chartData.toolUsage} />
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/ToolUsageChart.tsx
+++ b/src/components/ToolUsageChart.tsx
@@ -1,0 +1,37 @@
+import type { ChartDataPoint } from "@/types/insights";
+
+interface ToolUsageChartProps {
+  data: ChartDataPoint[];
+  max?: number;
+}
+
+export default function ToolUsageChart({ data, max = 6 }: ToolUsageChartProps) {
+  if (!data || data.length === 0) return null;
+
+  const topItems = data.slice(0, max);
+  const maxValue = Math.max(...topItems.map((d) => d.value));
+
+  return (
+    <div className="space-y-1.5">
+      {topItems.map((item) => {
+        const pct = maxValue > 0 ? (item.value / maxValue) * 100 : 0;
+        return (
+          <div key={item.label} className="flex items-center gap-2">
+            <div className="w-20 shrink-0 text-xs text-slate-600 dark:text-slate-400">
+              {item.label}
+            </div>
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+              <div
+                className="h-full rounded-full bg-blue-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <div className="w-14 shrink-0 text-right text-xs font-medium text-slate-500 dark:text-slate-400">
+              {item.value.toLocaleString()}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/__tests__/chart-parser.test.ts
+++ b/src/lib/__tests__/chart-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseChartData } from "../chart-parser";
+import { parseChartData, normalizeChartData } from "../chart-parser";
 
 const SAMPLE_HTML = `
 <html><body>
@@ -109,5 +109,89 @@ describe("parseChartData", () => {
     expect(result.requestTypes).toBeUndefined();
     expect(result.languages).toBeUndefined();
     expect(result.sessionTypes).toBeUndefined();
+  });
+});
+
+describe("normalizeChartData", () => {
+  it("returns null for null", () => {
+    expect(normalizeChartData(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(normalizeChartData(undefined)).toBeNull();
+  });
+
+  it("returns null for non-objects", () => {
+    expect(normalizeChartData("string")).toBeNull();
+    expect(normalizeChartData(42)).toBeNull();
+    expect(normalizeChartData([])).toBeNull();
+  });
+
+  it("returns a clean ChartData for a valid object", () => {
+    const input = {
+      toolUsage: [
+        { label: "Bash", value: 100 },
+        { label: "Read", value: 50 },
+      ],
+    };
+    expect(normalizeChartData(input)).toEqual(input);
+  });
+
+  it("filters out malformed items in a series", () => {
+    const input = {
+      toolUsage: [
+        { label: "Bash", value: 100 },
+        { label: "Missing value" },
+        { value: 50 },
+        "not an object",
+        null,
+        { label: "Read", value: 50 },
+      ],
+    };
+    expect(normalizeChartData(input)).toEqual({
+      toolUsage: [
+        { label: "Bash", value: 100 },
+        { label: "Read", value: 50 },
+      ],
+    });
+  });
+
+  it("drops a series entirely if all items are invalid", () => {
+    const input = {
+      toolUsage: [{ label: "x" }, { value: 1 }],
+      languages: [{ label: "TypeScript", value: 1 }],
+    };
+    expect(normalizeChartData(input)).toEqual({
+      languages: [{ label: "TypeScript", value: 1 }],
+    });
+  });
+
+  it("ignores unknown top-level keys", () => {
+    const input = {
+      toolUsage: [{ label: "Bash", value: 100 }],
+      someFutureKey: [{ label: "x", value: 1 }],
+    };
+    expect(normalizeChartData(input)).toEqual({
+      toolUsage: [{ label: "Bash", value: 100 }],
+    });
+  });
+
+  it("returns null if every series is invalid or missing", () => {
+    expect(normalizeChartData({})).toBeNull();
+    expect(normalizeChartData({ toolUsage: "broken" })).toBeNull();
+    expect(normalizeChartData({ toolUsage: [{ bad: true }] })).toBeNull();
+  });
+
+  it("rejects non-finite numbers (NaN, Infinity)", () => {
+    const input = {
+      toolUsage: [
+        { label: "A", value: NaN },
+        { label: "B", value: Infinity },
+        { label: "C", value: 42 },
+      ],
+    };
+    expect(normalizeChartData(input)).toEqual({
+      toolUsage: [{ label: "C", value: 42 }],
+    });
   });
 });

--- a/src/lib/__tests__/chart-parser.test.ts
+++ b/src/lib/__tests__/chart-parser.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { parseChartData } from "../chart-parser";
+
+const SAMPLE_HTML = `
+<html><body>
+  <div class="chart-card">
+    <div class="chart-title">What You Wanted</div>
+    <div class="bar-row">
+      <div class="bar-label">Bug Fix</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">27</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">Code Review</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">16</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Top Tools Used</div>
+    <div class="bar-row">
+      <div class="bar-label">Bash</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">2922</div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label">Read</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">1318</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Languages</div>
+    <div class="bar-row">
+      <div class="bar-label">TypeScript</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">1345</div>
+    </div>
+  </div>
+  <div class="chart-card">
+    <div class="chart-title">Session Types</div>
+    <div class="bar-row">
+      <div class="bar-label">Multi Task</div>
+      <div class="bar-track"><div class="bar-fill"></div></div>
+      <div class="bar-value">40</div>
+    </div>
+  </div>
+</body></html>
+`;
+
+describe("parseChartData", () => {
+  it("extracts tool usage from 'Top Tools Used' chart", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.toolUsage).toEqual([
+      { label: "Bash", value: 2922 },
+      { label: "Read", value: 1318 },
+    ]);
+  });
+
+  it("extracts request types from 'What You Wanted' chart", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.requestTypes).toEqual([
+      { label: "Bug Fix", value: 27 },
+      { label: "Code Review", value: 16 },
+    ]);
+  });
+
+  it("extracts languages", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.languages).toEqual([{ label: "TypeScript", value: 1345 }]);
+  });
+
+  it("extracts session types", () => {
+    const result = parseChartData(SAMPLE_HTML);
+    expect(result.sessionTypes).toEqual([{ label: "Multi Task", value: 40 }]);
+  });
+
+  it("returns empty object when no charts present", () => {
+    const result = parseChartData("<html><body><p>no charts</p></body></html>");
+    expect(result).toEqual({});
+  });
+
+  it("handles comma-formatted numbers", () => {
+    const html = `
+      <div class="chart-card">
+        <div class="chart-title">Top Tools Used</div>
+        <div class="bar-row">
+          <div class="bar-label">Bash</div>
+          <div class="bar-value">2,922</div>
+        </div>
+      </div>
+    `;
+    const result = parseChartData(html);
+    expect(result.toolUsage?.[0]).toEqual({ label: "Bash", value: 2922 });
+  });
+
+  it("omits keys for charts that aren't in the HTML", () => {
+    const html = `
+      <div class="chart-card">
+        <div class="chart-title">Top Tools Used</div>
+        <div class="bar-row">
+          <div class="bar-label">Bash</div>
+          <div class="bar-value">100</div>
+        </div>
+      </div>
+    `;
+    const result = parseChartData(html);
+    expect(result.toolUsage).toBeDefined();
+    expect(result.requestTypes).toBeUndefined();
+    expect(result.languages).toBeUndefined();
+    expect(result.sessionTypes).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/redaction.test.ts
+++ b/src/lib/__tests__/redaction.test.ts
@@ -134,10 +134,8 @@ describe("applyRedactions", () => {
 
     const result = applyRedactions(data, decisions);
     expect(result.project_areas.areas[0].name).toBe("[redacted]");
-    // Should also replace in description (consistent replacement)
-    expect(result.project_areas.areas[0].description).toBe(
-      "The [redacted] is great",
-    );
+    // v2: when project name is redacted, description is fully wiped
+    expect(result.project_areas.areas[0].description).toBe("[redacted]");
   });
 
   it("should replace aliased text with alias value", () => {
@@ -250,6 +248,52 @@ describe("applyRedactions", () => {
     expect(result.what_works.impressive_workflows[0].title).toBe(
       "[redacted] deployment",
     );
+  });
+
+  it("also redacts project description when project name is redacted", () => {
+    const data: InsightsData = {
+      at_a_glance: {
+        whats_working: "",
+        whats_hindering: "",
+        quick_wins: "",
+        ambitious_workflows: "",
+      },
+      interaction_style: { narrative: "", key_pattern: "" },
+      project_areas: {
+        areas: [
+          {
+            name: "SecretProject",
+            session_count: 10,
+            description: "A secret health insurance app with Stripe payments",
+          },
+        ],
+      },
+      what_works: { intro: "", impressive_workflows: [] },
+      friction_analysis: { intro: "", categories: [] },
+      suggestions: {
+        claude_md_additions: [],
+        features_to_try: [],
+        usage_patterns: [],
+      },
+      on_the_horizon: { intro: "", opportunities: [] },
+      fun_ending: { headline: "", detail: "" },
+    };
+
+    const decisions: RedactionItem[] = [
+      {
+        id: "1",
+        text: "SecretProject",
+        type: "project_name",
+        context: "",
+        sectionKey: "project_areas",
+        action: "redact",
+      },
+    ];
+
+    const result = applyRedactions(data, decisions);
+    const area = result.project_areas.areas[0];
+    expect(area.name).toBe("[redacted]");
+    expect(area.description).toBe("[redacted]");
   });
 });
 

--- a/src/lib/__tests__/skill-detector.test.ts
+++ b/src/lib/__tests__/skill-detector.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { detectSkills } from "../skill-detector";
+import type { InsightsData, ChartData } from "@/types/insights";
+
+function makeData(narrativeText: string): InsightsData {
+  return {
+    at_a_glance: {
+      whats_working: "",
+      whats_hindering: "",
+      quick_wins: "",
+      ambitious_workflows: "",
+    },
+    interaction_style: { narrative: narrativeText, key_pattern: "" },
+    project_areas: { areas: [] },
+    what_works: { intro: "", impressive_workflows: [] },
+    friction_analysis: { intro: "", categories: [] },
+    suggestions: {
+      claude_md_additions: [],
+      features_to_try: [],
+      usage_patterns: [],
+    },
+    on_the_horizon: { intro: "", opportunities: [] },
+    fun_ending: { headline: "", detail: "" },
+  };
+}
+
+describe("detectSkills", () => {
+  it("detects parallel_agents from narrative text", () => {
+    const data = makeData(
+      "You used parallel agents to run multiple test suites simultaneously.",
+    );
+    const result = detectSkills(data, {});
+    expect(result).toContain("parallel_agents");
+  });
+
+  it("detects parallel_agents from TaskCreate in tool usage", () => {
+    const data = makeData("No mentions here.");
+    const chartData: ChartData = {
+      toolUsage: [
+        { label: "Bash", value: 100 },
+        { label: "TaskCreate", value: 191 },
+      ],
+    };
+    const result = detectSkills(data, chartData);
+    expect(result).toContain("parallel_agents");
+  });
+
+  it("detects worktrees", () => {
+    const data = makeData("You created git worktrees for isolation.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("worktrees");
+  });
+
+  it("detects custom_skills from SKILL.md mention", () => {
+    const data = makeData("You published a SKILL.md file for reuse.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("custom_skills");
+  });
+
+  it("detects hooks", () => {
+    const data = makeData("You configured pre-commit hooks.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("hooks");
+  });
+
+  it("detects mcp_servers", () => {
+    const data = makeData("Playwright MCP server configuration.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("mcp_servers");
+  });
+
+  it("detects playwright", () => {
+    const data = makeData("You ran browser tests with Playwright.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("playwright");
+  });
+
+  it("detects plan_mode", () => {
+    const data = makeData("Used plan mode for complex refactors.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("plan_mode");
+  });
+
+  it("detects code_review", () => {
+    const data = makeData("Ran code review with a review agent.");
+    const result = detectSkills(data, {});
+    expect(result).toContain("code_review");
+  });
+
+  it("returns empty array when nothing detected", () => {
+    const data = makeData("Just a normal session.");
+    const result = detectSkills(data, {});
+    expect(result).toEqual([]);
+  });
+
+  it("deduplicates results", () => {
+    const data = makeData(
+      "parallel agents, parallel agents, and more parallel agents",
+    );
+    const result = detectSkills(data, {});
+    const count = result.filter((s) => s === "parallel_agents").length;
+    expect(count).toBe(1);
+  });
+
+  it("detects multiple skills from the same text", () => {
+    const data = makeData(
+      "You used parallel agents with Playwright MCP and worktrees for isolation.",
+    );
+    const result = detectSkills(data, {});
+    expect(result).toContain("parallel_agents");
+    expect(result).toContain("playwright");
+    expect(result).toContain("mcp_servers");
+    expect(result).toContain("worktrees");
+  });
+});

--- a/src/lib/chart-parser.ts
+++ b/src/lib/chart-parser.ts
@@ -49,3 +49,50 @@ export function parseChartData(html: string): ChartData {
 
   return result;
 }
+
+function isChartDataPoint(value: unknown): value is ChartDataPoint {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { label?: unknown }).label === "string" &&
+    typeof (value as { value?: unknown }).value === "number" &&
+    Number.isFinite((value as { value: number }).value)
+  );
+}
+
+function normalizeSeries(raw: unknown): ChartDataPoint[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const clean = raw.filter(isChartDataPoint);
+  return clean.length > 0 ? clean : undefined;
+}
+
+/**
+ * Normalize an unknown input (e.g. a Prisma `Json?` field) into a clean
+ * ChartData object. Returns null for null/undefined/non-object inputs.
+ * Silently drops any series whose entries don't match the expected shape.
+ *
+ * Use at boundaries where untrusted JSON enters the UI (detail page,
+ * homepage list) to protect chart components from malformed data.
+ */
+export function normalizeChartData(raw: unknown): ChartData | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "object") return null;
+
+  const obj = raw as Record<string, unknown>;
+  const result: ChartData = {};
+
+  const toolUsage = normalizeSeries(obj.toolUsage);
+  if (toolUsage) result.toolUsage = toolUsage;
+
+  const requestTypes = normalizeSeries(obj.requestTypes);
+  if (requestTypes) result.requestTypes = requestTypes;
+
+  const languages = normalizeSeries(obj.languages);
+  if (languages) result.languages = languages;
+
+  const sessionTypes = normalizeSeries(obj.sessionTypes);
+  if (sessionTypes) result.sessionTypes = sessionTypes;
+
+  // If no valid series survived, return null so consumers can hide the UI
+  return Object.keys(result).length > 0 ? result : null;
+}

--- a/src/lib/chart-parser.ts
+++ b/src/lib/chart-parser.ts
@@ -1,0 +1,51 @@
+import * as cheerio from "cheerio";
+import type { ChartData, ChartDataPoint } from "@/types/insights";
+
+/**
+ * Parse chart data from a Claude Code HTML insights report.
+ *
+ * The HTML report contains multiple `.chart-card` elements, each with a
+ * `.chart-title` and one or more `.bar-row` children. Each bar row has
+ * a `.bar-label` and `.bar-value`. We extract the four chart types we
+ * know about by matching the chart title.
+ */
+export function parseChartData(html: string): ChartData {
+  const $ = cheerio.load(html);
+  const result: ChartData = {};
+
+  $(".chart-card").each((_, card) => {
+    const title = $(card).find(".chart-title").first().text().trim();
+    const rows: ChartDataPoint[] = [];
+
+    $(card)
+      .find(".bar-row")
+      .each((_, row) => {
+        const label = $(row).find(".bar-label").text().trim();
+        const valueText = $(row).find(".bar-value").text().trim();
+        const value = parseInt(valueText.replace(/,/g, ""), 10);
+
+        if (label && !isNaN(value)) {
+          rows.push({ label, value });
+        }
+      });
+
+    if (rows.length === 0) return;
+
+    // Map chart title to our structured field
+    const titleLower = title.toLowerCase();
+    if (titleLower.includes("tools used") || titleLower.includes("top tools")) {
+      result.toolUsage = rows;
+    } else if (
+      titleLower.includes("what you wanted") ||
+      titleLower.includes("request")
+    ) {
+      result.requestTypes = rows;
+    } else if (titleLower.includes("language")) {
+      result.languages = rows;
+    } else if (titleLower.includes("session type")) {
+      result.sessionTypes = rows;
+    }
+  });
+
+  return result;
+}

--- a/src/lib/redaction.ts
+++ b/src/lib/redaction.ts
@@ -137,6 +137,26 @@ export function applyRedactions(
   // Walk every string field in the clone and apply replacements
   applyToObject(clone as unknown as Record<string, unknown>, replaceInString);
 
+  // v2: If a project name is marked for full redaction, also clear its description
+  const redactedProjectNames = new Set(
+    decisions
+      .filter(
+        (d) =>
+          d.type === "project_name" &&
+          d.sectionKey === "project_areas" &&
+          d.action === "redact",
+      )
+      .map((d) => d.text),
+  );
+
+  if (redactedProjectNames.size > 0 && clone.project_areas?.areas) {
+    for (const area of clone.project_areas.areas) {
+      if (area.name === "[redacted]") {
+        area.description = "[redacted]";
+      }
+    }
+  }
+
   return clone;
 }
 

--- a/src/lib/skill-detector.ts
+++ b/src/lib/skill-detector.ts
@@ -1,0 +1,121 @@
+import type { InsightsData, ChartData, SkillKey } from "@/types/insights";
+
+/**
+ * Collect all text content from parsed insights data into a single searchable string.
+ */
+function collectText(data: InsightsData): string {
+  const parts: string[] = [];
+
+  const walk = (obj: unknown): void => {
+    if (typeof obj === "string") {
+      parts.push(obj);
+    } else if (Array.isArray(obj)) {
+      obj.forEach(walk);
+    } else if (obj !== null && typeof obj === "object") {
+      Object.values(obj).forEach(walk);
+    }
+  };
+
+  walk(data);
+  return parts.join(" ").toLowerCase();
+}
+
+interface SkillRule {
+  key: SkillKey;
+  textPatterns?: string[];
+  toolPatterns?: string[];
+}
+
+const RULES: SkillRule[] = [
+  {
+    key: "parallel_agents",
+    textPatterns: ["parallel agent", "parallel sub-agent", "agent workflow"],
+    toolPatterns: ["TaskCreate"],
+  },
+  {
+    key: "worktrees",
+    textPatterns: ["worktree", "git worktree"],
+  },
+  {
+    key: "custom_skills",
+    textPatterns: ["skill.md", "custom skill", "slash command"],
+  },
+  {
+    key: "hooks",
+    textPatterns: [
+      "pre-commit hook",
+      "post-tool hook",
+      "pre-tool hook",
+      "hooks configured",
+      "hook configured",
+      "configured hooks",
+    ],
+  },
+  {
+    key: "mcp_servers",
+    textPatterns: ["mcp server", "mcp "],
+  },
+  {
+    key: "playwright",
+    textPatterns: ["playwright", "browser test"],
+  },
+  {
+    key: "headless_mode",
+    textPatterns: [
+      "headless mode",
+      "headless claude",
+      "non-interactive claude",
+    ],
+  },
+  {
+    key: "plan_mode",
+    textPatterns: ["plan mode", "implementation plan"],
+  },
+  {
+    key: "code_review",
+    textPatterns: ["code review", "review agent", "codex cli review"],
+  },
+  {
+    key: "subagents",
+    textPatterns: ["subagent", "sub-agent"],
+    toolPatterns: ["Agent"],
+  },
+];
+
+/**
+ * Scan parsed insights data and chart data for mentions of Claude Code features.
+ * Returns an array of detected skill keys (deduplicated).
+ */
+export function detectSkills(
+  data: InsightsData,
+  chartData: ChartData,
+): SkillKey[] {
+  const text = collectText(data);
+  const toolNames = new Set((chartData.toolUsage ?? []).map((t) => t.label));
+
+  const detected = new Set<SkillKey>();
+
+  for (const rule of RULES) {
+    // Check text patterns
+    if (rule.textPatterns) {
+      for (const pattern of rule.textPatterns) {
+        if (text.includes(pattern.toLowerCase())) {
+          detected.add(rule.key);
+          break;
+        }
+      }
+    }
+
+    // Check tool patterns (exact match on tool names)
+    if (!detected.has(rule.key) && rule.toolPatterns) {
+      for (const pattern of rule.toolPatterns) {
+        if (toolNames.has(pattern)) {
+          detected.add(rule.key);
+          break;
+        }
+      }
+    }
+  }
+
+  return Array.from(detected);
+}

--- a/src/types/api-contracts.ts
+++ b/src/types/api-contracts.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal shapes asserted by GET /api/insights and GET /api/insights/[slug].
+ * These exist to make the v2 scalar fields a compile-time contract — if a
+ * refactor ever drops one of these fields from a route response, TypeScript
+ * will complain.
+ */
+import type { ChartData, SkillKey } from "./insights";
+
+export interface InsightReportListItemContract {
+  slug: string;
+  detectedSkills: SkillKey[] | string[];
+  dayCount: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+}
+
+export interface InsightReportDetailContract extends InsightReportListItemContract {
+  chartData: ChartData | null | unknown; // unknown because Prisma Json? is `any`/`JsonValue`
+}

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -208,3 +208,25 @@ export const SKILL_METADATA: Record<SkillKey, SkillMetadata> = {
     colorClass: "bg-teal-100 text-teal-700",
   },
 };
+
+/**
+ * Type guard: returns true if the given value is a known SkillKey.
+ * Use at any boundary where untrusted data (DB rows, API responses) enters
+ * a context that expects a typed SkillKey.
+ */
+export function isSkillKey(value: unknown): value is SkillKey {
+  return (
+    typeof value === "string" &&
+    (SKILL_KEYS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Normalize an unknown input (e.g. `string[]` from Prisma) into a clean
+ * `SkillKey[]`, silently dropping any values that aren't recognized.
+ * Returns an empty array for null/undefined/non-array inputs.
+ */
+export function normalizeSkills(raw: unknown): SkillKey[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isSkillKey);
+}

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -106,6 +106,8 @@ export interface ParsedInsightsReport {
   };
   data: InsightsData;
   detectedRedactions: RedactionItem[];
+  chartData?: ChartData;
+  detectedSkills?: SkillKey[];
 }
 
 // v2: Chart data parsed from HTML report

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -107,3 +107,102 @@ export interface ParsedInsightsReport {
   data: InsightsData;
   detectedRedactions: RedactionItem[];
 }
+
+// v2: Chart data parsed from HTML report
+export interface ChartDataPoint {
+  label: string;
+  value: number;
+}
+
+export interface ChartData {
+  toolUsage?: ChartDataPoint[];
+  requestTypes?: ChartDataPoint[];
+  languages?: ChartDataPoint[];
+  sessionTypes?: ChartDataPoint[];
+}
+
+// v2: Closed set of detectable Claude Code skills/features
+export const SKILL_KEYS = [
+  "parallel_agents",
+  "worktrees",
+  "custom_skills",
+  "hooks",
+  "mcp_servers",
+  "playwright",
+  "headless_mode",
+  "plan_mode",
+  "code_review",
+  "subagents",
+] as const;
+
+export type SkillKey = (typeof SKILL_KEYS)[number];
+
+export interface SkillMetadata {
+  key: SkillKey;
+  label: string;
+  icon: string;
+  colorClass: string;
+}
+
+export const SKILL_METADATA: Record<SkillKey, SkillMetadata> = {
+  parallel_agents: {
+    key: "parallel_agents",
+    label: "Parallel Agents",
+    icon: "🔀",
+    colorClass: "bg-violet-100 text-violet-700",
+  },
+  worktrees: {
+    key: "worktrees",
+    label: "Worktrees",
+    icon: "🌳",
+    colorClass: "bg-green-100 text-green-700",
+  },
+  custom_skills: {
+    key: "custom_skills",
+    label: "Custom Skills",
+    icon: "⚡",
+    colorClass: "bg-amber-100 text-amber-700",
+  },
+  hooks: {
+    key: "hooks",
+    label: "Hooks",
+    icon: "🪝",
+    colorClass: "bg-sky-100 text-sky-700",
+  },
+  mcp_servers: {
+    key: "mcp_servers",
+    label: "MCP Servers",
+    icon: "🔌",
+    colorClass: "bg-slate-100 text-slate-700",
+  },
+  playwright: {
+    key: "playwright",
+    label: "Playwright",
+    icon: "🎭",
+    colorClass: "bg-pink-100 text-pink-700",
+  },
+  headless_mode: {
+    key: "headless_mode",
+    label: "Headless Mode",
+    icon: "🤖",
+    colorClass: "bg-indigo-100 text-indigo-700",
+  },
+  plan_mode: {
+    key: "plan_mode",
+    label: "Plan Mode",
+    icon: "📋",
+    colorClass: "bg-emerald-100 text-emerald-700",
+  },
+  code_review: {
+    key: "code_review",
+    label: "Code Review",
+    icon: "📝",
+    colorClass: "bg-red-100 text-red-700",
+  },
+  subagents: {
+    key: "subagents",
+    label: "Subagents",
+    icon: "🧩",
+    colorClass: "bg-teal-100 text-teal-700",
+  },
+};


### PR DESCRIPTION
## Summary

Transforms Insightful's report display from text-heavy walls into scannable, data-rich pages. Implements the 23-task plan from `docs/superpowers/plans/2026-04-04-readability-redesign-plan.md`.

- **New parsers** — `chart-parser.ts` extracts tool/language/request/session bar charts from report HTML; `skill-detector.ts` identifies 10 Claude Code features (parallel agents, worktrees, custom skills, hooks, MCP servers, Playwright, headless, plan mode, code review, subagents) from narrative text + tool usage
- **New schema fields** — `chartData Json?` + `detectedSkills String[]` on `InsightReport` (migration already applied to Supabase)
- **New components** — `SkillBadges`, `ToolUsageChart`, `SnapshotCard`, `CollapsibleSection`, `ContributorRow`
- **Rebuilt homepage** — replaces card grid with contributor-focused list showing per-week normalized stats and skill badges
- **Rebuilt detail page** — `SnapshotCard` at top (stats + skills + key pattern + collapsible tool chart) followed by `CollapsibleSection`s with 2-3 line summaries
- **Strengthened redaction** — when a project name is redacted, its description is now also wiped
- **Upload review improvement** — shows full section content before publishing (using new `readOnly` prop on `SectionRenderer`)

## What's not in this PR

- Tasks 19 and 21 from the plan were no-ops: the GET routes use Prisma `include` (not explicit `select`), so the new scalar fields flow through automatically. Implicit behavior worth addressing — see follow-up commits below.
- Tasks 22 (manual e2e) and 23 (deploy) are deliberately left for post-merge testing on the live site per pre-launch posture.

## Test plan

- [x] 46/46 unit tests passing (7 new chart-parser tests + 12 new skill-detector tests + 1 new redaction test + 26 existing)
- [x] `npm run build` clean
- [ ] After merge: upload a fresh report at insightharness.com/upload and verify `chartData` + `detectedSkills` populate on the detail page
- [ ] Verify homepage renders the ContributorRow list with skill badges
- [ ] Verify detail page SnapshotCard shows stats + skills + key pattern, and sections are collapsible with At a Glance open by default