### PR TITLE
feat: UX fixes — per-week stats, date ranges, styled upload previews

### DIFF
--- a/agent/MEMORY.md
+++ b/agent/MEMORY.md
@@ -1,1 +1,19 @@
 # Memory (selectively loaded)
+
+## 2026-04-04
+
+- NextAuth v5 beta: signin requires POST with CSRF token; GET returns "UnknownAction"
+- NextAuth v5 middleware cannot import auth modules that use Prisma (edge runtime incompatible) — use edge-safe auth.config.ts
+- User upsert must happen in `jwt` callback (not `signIn` event) so `token.sub` has DB user ID on first login
+- Vercel env vars: use `printf` not `echo` — `echo` appends a trailing newline that breaks AUTH_SECRET, client IDs, etc.
+- Supabase Prisma: use `aws-1` pooler (not aws-0), append `?pgbouncer=true` on the transaction pooler URL
+- Prisma custom output path (`src/generated/prisma`) fails on Vercel — keep default `@prisma/client`
+- Prisma needs `binaryTargets = ["native", "rhel-openssl-3.0.x"]` for Vercel deployment
+- Add `prisma generate` to `package.json` build script for Vercel
+- React error #310 = hooks called conditionally; early returns must come AFTER all hooks
+- Codex CLI review: `codex review --base <sha> --title "..."` reviews against base commit
+- Chrome headless mobile screenshots clip at 375px due to scrollbar width — may not reflect real devices
+
+## 2026-04-05
+
+- SnapshotCard still accepts `chartData` prop in its interface but never renders it — kept to avoid breaking callers. If chart visualization is added to SnapshotCard later, wire it up; otherwise remove the prop in a cleanup pass.

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -303,8 +303,6 @@ export default function InsightDetailPage() {
           chartData={report.chartData}
           detectedSkills={report.detectedSkills}
           keyPattern={report.interactionStyle?.key_pattern ?? null}
-          dateRangeStart={report.dateRangeStart}
-          dateRangeEnd={report.dateRangeEnd}
           projectAreas={report.projectAreas}
         />
       </div>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -89,14 +89,6 @@ const SECTIONS: Array<{
     iconBgClass: "bg-indigo-100 dark:bg-indigo-900/30",
   },
   {
-    key: "project_areas",
-    label: "Project Areas",
-    dataKey: "projectAreas",
-    sectionType: "project_areas",
-    icon: "📁",
-    iconBgClass: "bg-slate-100 dark:bg-slate-800",
-  },
-  {
     key: "impressive_workflows",
     label: "Impressive Workflows",
     dataKey: "impressiveWorkflows",
@@ -280,11 +272,13 @@ export default function InsightDetailPage() {
           </Link>
           <div className="flex items-center gap-2 text-sm text-slate-500">
             <Calendar className="h-3.5 w-3.5" />
-            {new Date(report.publishedAt).toLocaleDateString("en-US", {
-              year: "numeric",
-              month: "long",
-              day: "numeric",
-            })}
+            {report.dateRangeStart && report.dateRangeEnd
+              ? `${new Date(report.dateRangeStart + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })} - ${new Date(report.dateRangeEnd + "T00:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`
+              : new Date(report.publishedAt).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
           </div>
         </div>
         <button
@@ -309,8 +303,18 @@ export default function InsightDetailPage() {
           chartData={report.chartData}
           detectedSkills={report.detectedSkills}
           keyPattern={report.interactionStyle?.key_pattern ?? null}
+          dateRangeStart={report.dateRangeStart}
+          dateRangeEnd={report.dateRangeEnd}
+          projectAreas={report.projectAreas}
         />
       </div>
+
+      {/* Project Links */}
+      {report.projectLinks.length > 0 && (
+        <div className="mb-6">
+          <ProjectLinks links={report.projectLinks} />
+        </div>
+      )}
 
       {/* Sections */}
       <div className="space-y-4">
@@ -344,13 +348,6 @@ export default function InsightDetailPage() {
           );
         })}
       </div>
-
-      {/* Project Links */}
-      {report.projectLinks.length > 0 && (
-        <div className="mt-8">
-          <ProjectLinks links={report.projectLinks} />
-        </div>
-      )}
 
       {/* Comments */}
       <div className="mt-12">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,8 @@ interface InsightSummary {
   slug: string;
   title: string;
   publishedAt: string;
+  dateRangeStart: string | null;
+  dateRangeEnd: string | null;
   dayCount?: number | null;
   messageCount?: number | null;
   linesAdded?: number | null;
@@ -52,6 +54,8 @@ export default function HomePage() {
             slug: r.slug as string,
             title: r.title as string,
             publishedAt: r.publishedAt as string,
+            dateRangeStart: (r.dateRangeStart as string) ?? null,
+            dateRangeEnd: (r.dateRangeEnd as string) ?? null,
             dayCount: r.dayCount as number | null,
             messageCount: r.messageCount as number | null,
             linesAdded: r.linesAdded as number | null,
@@ -138,6 +142,8 @@ export default function HomePage() {
               displayName={insight.author.displayName ?? null}
               avatarUrl={insight.author.avatarUrl ?? null}
               publishedAt={insight.publishedAt}
+              dateRangeStart={insight.dateRangeStart}
+              dateRangeEnd={insight.dateRangeEnd}
               dayCount={insight.dayCount ?? null}
               messageCount={insight.messageCount ?? null}
               linesAdded={insight.linesAdded ?? null}

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -611,8 +611,6 @@ export default function UploadPage() {
               chartData={normalizeChartData(parsed.chartData)}
               detectedSkills={normalizeSkills(parsed.detectedSkills)}
               keyPattern={parsed.data.interaction_style?.key_pattern ?? null}
-              dateRangeStart={parsed.stats.dateRangeStart ?? null}
-              dateRangeEnd={parsed.stats.dateRangeEnd ?? null}
               projectAreas={
                 disabledSections["project_areas"]
                   ? null
@@ -749,8 +747,6 @@ export default function UploadPage() {
             chartData={normalizeChartData(parsed.chartData)}
             detectedSkills={normalizeSkills(parsed.detectedSkills)}
             keyPattern={parsed.data.interaction_style?.key_pattern ?? null}
-            dateRangeStart={parsed.stats.dateRangeStart ?? null}
-            dateRangeEnd={parsed.stats.dateRangeEnd ?? null}
             projectAreas={
               disabledSections["project_areas"]
                 ? null

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import {
@@ -23,8 +23,12 @@ import type {
   RedactionItem,
   InsightsData,
 } from "@/types/insights";
+import { normalizeSkills } from "@/types/insights";
+import { normalizeChartData } from "@/lib/chart-parser";
 import { applyRedactions } from "@/lib/redaction";
 import SectionRenderer from "@/components/SectionRenderer";
+import SnapshotCard from "@/components/SnapshotCard";
+import CollapsibleSection from "@/components/CollapsibleSection";
 
 type Step = "upload" | "redact" | "projects" | "preview";
 
@@ -56,6 +60,7 @@ export default function UploadPage() {
   const [error, setError] = useState<string | null>(null);
   const [publishing, setPublishing] = useState(false);
   const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Maps InsightsData keys to SectionRenderer sectionType and display label
   const SECTION_OPTIONS: {
@@ -340,6 +345,36 @@ export default function UploadPage() {
         ))}
       </div>
 
+      {/* Sticky navigation — visible on all steps except upload */}
+      {step !== "upload" && (
+        <div className="sticky top-16 z-40 -mx-4 mb-6 flex items-center justify-between border-b border-slate-200 bg-white/95 px-4 py-3 backdrop-blur-sm">
+          <button
+            onClick={() => setStep(steps[stepIndex - 1]?.key || "upload")}
+            className="flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </button>
+          {step === "preview" ? (
+            <button
+              onClick={handlePublish}
+              disabled={publishing}
+              className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:bg-slate-300"
+            >
+              {publishing ? "Publishing..." : "Publish Insights"}
+            </button>
+          ) : (
+            <button
+              onClick={() => setStep(steps[stepIndex + 1]?.key || "preview")}
+              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              Next
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+      )}
+
       {error && (
         <div className="mb-6 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           <AlertTriangle className="h-4 w-4 shrink-0" />
@@ -350,6 +385,7 @@ export default function UploadPage() {
       {/* Step 1: Upload */}
       {step === "upload" && (
         <div
+          onClick={() => !loading && fileInputRef.current?.click()}
           onDragOver={(e) => {
             e.preventDefault();
             setDragOver(true);
@@ -357,7 +393,7 @@ export default function UploadPage() {
           onDragLeave={() => setDragOver(false)}
           onDrop={handleDrop}
           className={clsx(
-            "flex min-h-[300px] flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-colors",
+            "flex min-h-[300px] cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-colors",
             dragOver
               ? "border-blue-400 bg-blue-50"
               : "border-slate-300 bg-slate-50 hover:border-slate-400",
@@ -380,15 +416,16 @@ export default function UploadPage() {
                   ~/.claude/usage-data/report.html
                 </code>
               </p>
-              <label className="cursor-pointer rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700">
-                Browse Files
-                <input
-                  type="file"
-                  accept=".html"
-                  onChange={handleFileInput}
-                  className="hidden"
-                />
-              </label>
+              <span className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-blue-700">
+                Click or drop file to upload
+              </span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".html"
+                onChange={handleFileInput}
+                className="hidden"
+              />
             </>
           )}
         </div>
@@ -555,36 +592,60 @@ export default function UploadPage() {
             </div>
           )}
 
-          {/* Full content preview */}
-          <div className="mt-8 space-y-6">
-            <h3 className="text-sm font-semibold text-slate-700">
-              Preview: Full Content
+          {/* Styled preview — matches how it will look when published */}
+          <div className="mt-8">
+            <h3 className="mb-2 text-sm font-semibold text-slate-700">
+              Preview: How your report will appear
             </h3>
-            <p className="text-xs text-slate-500">
+            <p className="mb-4 text-xs text-slate-500">
               This is what others will see. Review carefully before publishing.
             </p>
-            {SECTION_OPTIONS.map(({ dataKey, sectionType }) => {
-              if (disabledSections[dataKey]) return null;
-              const sectionData = parsed.data[dataKey];
-              if (!sectionData) return null;
-              return (
-                <div
-                  key={dataKey}
-                  className="rounded-lg border border-slate-200 bg-white p-4"
-                >
-                  <SectionRenderer
-                    slug="preview"
-                    sectionKey={dataKey}
-                    sectionType={sectionType}
-                    data={sectionData}
-                    reportId="preview"
-                    voteCount={0}
-                    voted={false}
-                    readOnly
-                  />
-                </div>
-              );
-            })}
+            <SnapshotCard
+              sessionCount={parsed.stats.sessionCount ?? null}
+              messageCount={parsed.stats.messageCount ?? null}
+              linesAdded={parsed.stats.linesAdded ?? null}
+              linesRemoved={parsed.stats.linesRemoved ?? null}
+              fileCount={parsed.stats.fileCount ?? null}
+              dayCount={parsed.stats.dayCount ?? null}
+              commitCount={parsed.stats.commitCount ?? null}
+              chartData={normalizeChartData(parsed.chartData)}
+              detectedSkills={normalizeSkills(parsed.detectedSkills)}
+              keyPattern={parsed.data.interaction_style?.key_pattern ?? null}
+              dateRangeStart={parsed.stats.dateRangeStart ?? null}
+              dateRangeEnd={parsed.stats.dateRangeEnd ?? null}
+              projectAreas={
+                disabledSections["project_areas"]
+                  ? null
+                  : parsed.data.project_areas
+              }
+            />
+            <div className="mt-4 space-y-3">
+              {SECTION_OPTIONS.map(({ dataKey, sectionType, label }) => {
+                if (disabledSections[dataKey]) return null;
+                if (dataKey === "project_areas") return null;
+                const sectionData = parsed.data[dataKey];
+                if (!sectionData) return null;
+                return (
+                  <CollapsibleSection
+                    key={dataKey}
+                    icon=""
+                    title={label}
+                    defaultOpen={dataKey === "at_a_glance"}
+                  >
+                    <SectionRenderer
+                      slug="preview"
+                      sectionKey={dataKey}
+                      sectionType={sectionType}
+                      data={sectionData}
+                      reportId="preview"
+                      voteCount={0}
+                      voted={false}
+                      readOnly
+                    />
+                  </CollapsibleSection>
+                );
+              })}
+            </div>
           </div>
         </div>
       )}
@@ -667,61 +728,50 @@ export default function UploadPage() {
         </div>
       )}
 
-      {/* Step 4: Preview */}
+      {/* Step 4: Preview — shows exactly how the published page will look */}
       {step === "preview" && parsed && (
         <div>
           <h2 className="mb-2 text-lg font-semibold text-slate-900">
-            Preview Your Insights
+            Final Preview
           </h2>
           <p className="mb-6 text-sm text-slate-500">
-            This is how your insights will appear to others. Review and publish
-            when ready.
+            This is exactly how your report will appear. Hit Publish when ready.
           </p>
 
-          <div className="rounded-xl border border-slate-200 bg-white p-6">
-            {/* Stats banner */}
-            <div className="mb-6 flex flex-wrap gap-6 border-b border-slate-100 pb-4">
-              {parsed.stats.sessionCount && (
-                <div className="text-center">
-                  <div className="text-lg font-bold text-slate-900">
-                    {parsed.stats.sessionCount}
-                  </div>
-                  <div className="text-xs uppercase text-slate-500">
-                    Sessions
-                  </div>
-                </div>
-              )}
-              {parsed.stats.messageCount && (
-                <div className="text-center">
-                  <div className="text-lg font-bold text-slate-900">
-                    {parsed.stats.messageCount.toLocaleString()}
-                  </div>
-                  <div className="text-xs uppercase text-slate-500">
-                    Messages
-                  </div>
-                </div>
-              )}
-              {parsed.stats.commitCount && (
-                <div className="text-center">
-                  <div className="text-lg font-bold text-slate-900">
-                    {parsed.stats.commitCount}
-                  </div>
-                  <div className="text-xs uppercase text-slate-500">
-                    Commits
-                  </div>
-                </div>
-              )}
-            </div>
+          <SnapshotCard
+            sessionCount={parsed.stats.sessionCount ?? null}
+            messageCount={parsed.stats.messageCount ?? null}
+            linesAdded={parsed.stats.linesAdded ?? null}
+            linesRemoved={parsed.stats.linesRemoved ?? null}
+            fileCount={parsed.stats.fileCount ?? null}
+            dayCount={parsed.stats.dayCount ?? null}
+            commitCount={parsed.stats.commitCount ?? null}
+            chartData={normalizeChartData(parsed.chartData)}
+            detectedSkills={normalizeSkills(parsed.detectedSkills)}
+            keyPattern={parsed.data.interaction_style?.key_pattern ?? null}
+            dateRangeStart={parsed.stats.dateRangeStart ?? null}
+            dateRangeEnd={parsed.stats.dateRangeEnd ?? null}
+            projectAreas={
+              disabledSections["project_areas"]
+                ? null
+                : parsed.data.project_areas
+            }
+          />
 
-            {/* Section previews — render all enabled sections */}
-            <div className="space-y-8">
-              {SECTION_OPTIONS.map(({ dataKey, sectionType }) => {
-                if (disabledSections[dataKey]) return null;
-                const sectionData = parsed.data[dataKey];
-                if (!sectionData) return null;
-                return (
+          <div className="mt-4 space-y-3">
+            {SECTION_OPTIONS.map(({ dataKey, sectionType, label }) => {
+              if (disabledSections[dataKey]) return null;
+              if (dataKey === "project_areas") return null;
+              const sectionData = parsed.data[dataKey];
+              if (!sectionData) return null;
+              return (
+                <CollapsibleSection
+                  key={dataKey}
+                  icon=""
+                  title={label}
+                  defaultOpen={dataKey === "at_a_glance"}
+                >
                   <SectionRenderer
-                    key={dataKey}
                     slug="preview"
                     sectionKey={dataKey}
                     sectionType={sectionType}
@@ -729,13 +779,14 @@ export default function UploadPage() {
                     reportId="preview"
                     voteCount={0}
                     voted={false}
+                    readOnly
                   />
-                );
-              })}
-            </div>
+                </CollapsibleSection>
+              );
+            })}
           </div>
 
-          <div className="mt-6 flex justify-end">
+          <div className="mt-8 flex justify-end">
             <button
               onClick={handlePublish}
               disabled={publishing}
@@ -744,28 +795,6 @@ export default function UploadPage() {
               {publishing ? "Publishing..." : "Publish Insights"}
             </button>
           </div>
-        </div>
-      )}
-
-      {/* Navigation */}
-      {step !== "upload" && (
-        <div className="mt-8 flex justify-between">
-          <button
-            onClick={() => setStep(steps[stepIndex - 1]?.key || "upload")}
-            className="flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back
-          </button>
-          {step !== "preview" && (
-            <button
-              onClick={() => setStep(steps[stepIndex + 1]?.key || "preview")}
-              className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
-            >
-              Next
-              <ArrowRight className="h-4 w-4" />
-            </button>
-          )}
         </div>
       )}
     </div>

--- a/src/components/ContributorRow.tsx
+++ b/src/components/ContributorRow.tsx
@@ -105,12 +105,15 @@ export default function ContributorRow({
 
         {/* Per-week stats */}
         <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600 dark:text-slate-400">
+          <span className="font-medium text-slate-400 dark:text-slate-500">
+            per week:
+          </span>
           {msgsPerWeek != null && (
             <span>
               <strong className="text-slate-800 dark:text-slate-200">
                 {msgsPerWeek}
               </strong>{" "}
-              msgs/wk
+              msgs
             </span>
           )}
           {commitsPerWeek != null && (
@@ -118,17 +121,17 @@ export default function ContributorRow({
               <strong className="text-slate-800 dark:text-slate-200">
                 {commitsPerWeek}
               </strong>{" "}
-              commits/wk
+              commits
             </span>
           )}
           {linesAddedPerWeek != null && (
             <span className="text-green-600 dark:text-green-400">
-              +{linesAddedPerWeek}/wk
+              +{linesAddedPerWeek}
             </span>
           )}
           {linesRemovedPerWeek != null && (
             <span className="text-red-600 dark:text-red-400">
-              -{linesRemovedPerWeek}/wk
+              -{linesRemovedPerWeek}
             </span>
           )}
         </div>

--- a/src/components/ContributorRow.tsx
+++ b/src/components/ContributorRow.tsx
@@ -10,6 +10,8 @@ interface ContributorRowProps {
   displayName: string | null;
   avatarUrl: string | null;
   publishedAt: string;
+  dateRangeStart: string | null;
+  dateRangeEnd: string | null;
   dayCount: number | null;
   messageCount: number | null;
   linesAdded: number | null;
@@ -19,8 +21,32 @@ interface ContributorRowProps {
   detectedSkills: SkillKey[];
 }
 
-function formatDate(dateStr: string) {
-  return new Date(dateStr).toLocaleDateString("en-US", {
+function perWeek(value: number | null, dayCount: number | null): string | null {
+  if (value == null || dayCount == null || dayCount === 0) return null;
+  const weeks = dayCount / 7;
+  if (weeks === 0) return null;
+  return Math.round(value / weeks).toLocaleString();
+}
+
+function formatDateRange(
+  start: string | null,
+  end: string | null,
+  publishedAt: string,
+): string {
+  const fmt = (d: string) =>
+    new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    });
+  const fmtYear = (d: string) =>
+    new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  if (start && end) return `${fmt(start)} - ${fmtYear(end)}`;
+  if (end) return `Through ${fmtYear(end)}`;
+  return new Date(publishedAt).toLocaleDateString("en-US", {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -33,6 +59,8 @@ export default function ContributorRow({
   displayName,
   avatarUrl,
   publishedAt,
+  dateRangeStart,
+  dateRangeEnd,
   dayCount,
   messageCount,
   linesAdded,
@@ -41,17 +69,10 @@ export default function ContributorRow({
   commitCount,
   detectedSkills,
 }: ContributorRowProps) {
-  // Per-week normalization for comparability
-  const msgsPerWeek =
-    messageCount && dayCount && dayCount > 0
-      ? Math.round(messageCount / (dayCount / 7))
-      : null;
-
-  const totalLines = (linesAdded ?? 0) + (linesRemoved ?? 0);
-  const linesPerWeek =
-    totalLines && dayCount && dayCount > 0
-      ? Math.round(totalLines / (dayCount / 7))
-      : null;
+  const msgsPerWeek = perWeek(messageCount, dayCount);
+  const commitsPerWeek = perWeek(commitCount, dayCount);
+  const linesAddedPerWeek = perWeek(linesAdded, dayCount);
+  const linesRemovedPerWeek = perWeek(linesRemoved, dayCount);
 
   return (
     <Link
@@ -77,52 +98,37 @@ export default function ContributorRow({
           {displayName || username}
         </div>
         <div className="text-xs text-slate-400">
-          @{username} · {formatDate(publishedAt)}
-          {dayCount != null && ` · ${dayCount} days tracked`}
+          @{username} ·{" "}
+          {formatDateRange(dateRangeStart, dateRangeEnd, publishedAt)}
+          {dayCount != null && ` · ${dayCount} days`}
         </div>
 
-        {/* Stats row */}
+        {/* Per-week stats */}
         <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-600 dark:text-slate-400">
           {msgsPerWeek != null && (
             <span>
               <strong className="text-slate-800 dark:text-slate-200">
-                {msgsPerWeek.toLocaleString()}
+                {msgsPerWeek}
               </strong>{" "}
               msgs/wk
             </span>
           )}
-          {linesPerWeek != null && (
+          {commitsPerWeek != null && (
             <span>
               <strong className="text-slate-800 dark:text-slate-200">
-                {linesPerWeek.toLocaleString()}
+                {commitsPerWeek}
               </strong>{" "}
-              lines/wk
+              commits/wk
             </span>
           )}
-          {linesAdded != null && (
+          {linesAddedPerWeek != null && (
             <span className="text-green-600 dark:text-green-400">
-              +{linesAdded.toLocaleString()} added
+              +{linesAddedPerWeek}/wk
             </span>
           )}
-          {linesRemoved != null && (
+          {linesRemovedPerWeek != null && (
             <span className="text-red-600 dark:text-red-400">
-              -{linesRemoved.toLocaleString()} removed
-            </span>
-          )}
-          {fileCount != null && (
-            <span>
-              <strong className="text-slate-800 dark:text-slate-200">
-                {fileCount}
-              </strong>{" "}
-              files
-            </span>
-          )}
-          {commitCount != null && (
-            <span>
-              <strong className="text-slate-800 dark:text-slate-200">
-                {commitCount}
-              </strong>{" "}
-              commits
+              -{linesRemovedPerWeek}/wk
             </span>
           )}
         </div>
@@ -130,9 +136,6 @@ export default function ContributorRow({
         {/* Skills badges */}
         {detectedSkills.length > 0 && (
           <div className="mt-2">
-            <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
-              Skills Used
-            </div>
             <SkillBadges skills={detectedSkills} size="sm" />
           </div>
         )}

--- a/src/components/SectionRenderer.tsx
+++ b/src/components/SectionRenderer.tsx
@@ -124,28 +124,28 @@ function AtAGlanceSection({
 }) {
   const items = [
     {
-      label: "What's Working",
+      label: "Strengths",
       text: data.whats_working,
       color:
         "border-l-green-500 bg-green-50/50 dark:bg-green-950/20 dark:border-l-green-600",
       iconColor: "text-green-600 dark:text-green-400",
     },
     {
-      label: "What's Hindering",
+      label: "Challenges",
       text: data.whats_hindering,
       color:
         "border-l-red-500 bg-red-50/50 dark:bg-red-950/20 dark:border-l-red-600",
       iconColor: "text-red-600 dark:text-red-400",
     },
     {
-      label: "Quick Wins",
+      label: "Opportunities",
       text: data.quick_wins,
       color:
         "border-l-amber-500 bg-amber-50/50 dark:bg-amber-950/20 dark:border-l-amber-600",
       iconColor: "text-amber-600 dark:text-amber-400",
     },
     {
-      label: "Ambitious Workflows",
+      label: "Next Frontiers",
       text: data.ambitious_workflows,
       color:
         "border-l-purple-500 bg-purple-50/50 dark:bg-purple-950/20 dark:border-l-purple-600",

--- a/src/components/SnapshotCard.tsx
+++ b/src/components/SnapshotCard.tsx
@@ -1,6 +1,5 @@
-import type { ChartData, SkillKey } from "@/types/insights";
+import type { ChartData, SkillKey, InsightsData } from "@/types/insights";
 import SkillBadges from "./SkillBadges";
-import ToolUsageChart from "./ToolUsageChart";
 
 interface SnapshotCardProps {
   sessionCount: number | null;
@@ -13,6 +12,32 @@ interface SnapshotCardProps {
   chartData: ChartData | null;
   detectedSkills: SkillKey[];
   keyPattern: string | null;
+  dateRangeStart: string | null;
+  dateRangeEnd: string | null;
+  projectAreas: InsightsData["project_areas"] | null;
+}
+
+function perWeek(value: number | null, dayCount: number | null): string | null {
+  if (value == null || dayCount == null || dayCount === 0) return null;
+  const weeks = dayCount / 7;
+  if (weeks === 0) return null;
+  return Math.round(value / weeks).toLocaleString();
+}
+
+function formatDateRange(
+  start: string | null,
+  end: string | null,
+): string | null {
+  if (!start && !end) return null;
+  const fmt = (d: string) =>
+    new Date(d + "T00:00:00").toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  if (start && end) return `${fmt(start)} - ${fmt(end)}`;
+  if (end) return `Through ${fmt(end)}`;
+  return `From ${fmt(start!)}`;
 }
 
 function StatCell({
@@ -42,51 +67,94 @@ export default function SnapshotCard({
   fileCount,
   dayCount,
   commitCount,
-  chartData,
   detectedSkills,
   keyPattern,
+  dateRangeStart,
+  dateRangeEnd,
+  projectAreas,
 }: SnapshotCardProps) {
-  const msgsPerWeek =
-    messageCount && dayCount ? Math.round(messageCount / (dayCount / 7)) : null;
+  const dateRange = formatDateRange(dateRangeStart, dateRangeEnd);
+
+  const sessionsPerWeek = perWeek(sessionCount, dayCount);
+  const msgsPerWeek = perWeek(messageCount, dayCount);
+  const filesPerWeek = perWeek(fileCount, dayCount);
+  const commitsPerWeek = perWeek(commitCount, dayCount);
+  const linesAddedPerWeek = perWeek(linesAdded, dayCount);
+  const linesRemovedPerWeek = perWeek(linesRemoved, dayCount);
+
+  const areas = projectAreas?.areas ?? [];
 
   return (
-    <div className="mb-8 rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
-      {/* Stats bar */}
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
+      {/* Date range */}
+      {dateRange && (
+        <div className="mb-4 text-xs font-medium text-slate-500 dark:text-slate-400">
+          {dateRange}
+          {dayCount != null && ` (${dayCount} days)`}
+        </div>
+      )}
+
+      {/* Per-week stats */}
       <div className="flex flex-wrap gap-6 pb-5">
-        {sessionCount != null && (
-          <StatCell value={sessionCount} label="Sessions" />
-        )}
-        {messageCount != null && (
-          <StatCell value={messageCount.toLocaleString()} label="Messages" />
+        {sessionsPerWeek != null && (
+          <StatCell value={sessionsPerWeek} label="Sessions/wk" />
         )}
         {msgsPerWeek != null && (
-          <StatCell value={msgsPerWeek.toLocaleString()} label="Msgs/Week" />
+          <StatCell value={msgsPerWeek} label="Msgs/wk" />
         )}
-        {linesAdded != null && (
+        {commitsPerWeek != null && (
+          <StatCell value={commitsPerWeek} label="Commits/wk" />
+        )}
+        {filesPerWeek != null && (
+          <StatCell value={filesPerWeek} label="Files/wk" />
+        )}
+        {linesAddedPerWeek != null && (
           <StatCell
-            value={`+${linesAdded.toLocaleString()}`}
-            label="Lines Added"
+            value={`+${linesAddedPerWeek}`}
+            label="Added/wk"
             className="text-green-600 dark:text-green-400"
           />
         )}
-        {linesRemoved != null && (
+        {linesRemovedPerWeek != null && (
           <StatCell
-            value={`-${linesRemoved.toLocaleString()}`}
-            label="Removed"
+            value={`-${linesRemovedPerWeek}`}
+            label="Removed/wk"
             className="text-red-600 dark:text-red-400"
           />
         )}
-        {fileCount != null && <StatCell value={fileCount} label="Files" />}
-        {commitCount != null && (
-          <StatCell value={commitCount} label="Commits" />
-        )}
       </div>
 
-      {/* Skills badges */}
-      {detectedSkills.length > 0 && (
+      {/* Projects */}
+      {areas.length > 0 && (
         <div className="border-t border-slate-100 pt-5 dark:border-slate-800">
           <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-            Skills & Features Used
+            Projects
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {areas.map((area) => (
+              <div
+                key={area.name}
+                className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
+              >
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  {area.name}
+                </span>
+                {area.session_count != null && (
+                  <span className="ml-1.5 text-xs text-slate-400">
+                    {area.session_count} sessions
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Skills & Plugins */}
+      {detectedSkills.length > 0 && (
+        <div className="mt-5 border-t border-slate-100 pt-5 dark:border-slate-800">
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+            Skills & Plugins
           </h3>
           <SkillBadges skills={detectedSkills} />
         </div>
@@ -99,18 +167,6 @@ export default function SnapshotCard({
             &ldquo;{keyPattern}&rdquo;
           </p>
         </div>
-      )}
-
-      {/* Tool usage chart — collapsed by default */}
-      {chartData?.toolUsage && chartData.toolUsage.length > 0 && (
-        <details className="mt-5 border-t border-slate-100 pt-4 dark:border-slate-800">
-          <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-slate-400 hover:text-slate-600">
-            Top Tools Used ▸
-          </summary>
-          <div className="mt-3">
-            <ToolUsageChart data={chartData.toolUsage} />
-          </div>
-        </details>
       )}
     </div>
   );

--- a/src/components/SnapshotCard.tsx
+++ b/src/components/SnapshotCard.tsx
@@ -12,8 +12,6 @@ interface SnapshotCardProps {
   chartData: ChartData | null;
   detectedSkills: SkillKey[];
   keyPattern: string | null;
-  dateRangeStart: string | null;
-  dateRangeEnd: string | null;
   projectAreas: InsightsData["project_areas"] | null;
 }
 
@@ -22,22 +20,6 @@ function perWeek(value: number | null, dayCount: number | null): string | null {
   const weeks = dayCount / 7;
   if (weeks === 0) return null;
   return Math.round(value / weeks).toLocaleString();
-}
-
-function formatDateRange(
-  start: string | null,
-  end: string | null,
-): string | null {
-  if (!start && !end) return null;
-  const fmt = (d: string) =>
-    new Date(d + "T00:00:00").toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
-  if (start && end) return `${fmt(start)} - ${fmt(end)}`;
-  if (end) return `Through ${fmt(end)}`;
-  return `From ${fmt(start!)}`;
 }
 
 function StatCell({
@@ -69,12 +51,8 @@ export default function SnapshotCard({
   commitCount,
   detectedSkills,
   keyPattern,
-  dateRangeStart,
-  dateRangeEnd,
   projectAreas,
 }: SnapshotCardProps) {
-  const dateRange = formatDateRange(dateRangeStart, dateRangeEnd);
-
   const sessionsPerWeek = perWeek(sessionCount, dayCount);
   const msgsPerWeek = perWeek(messageCount, dayCount);
   const filesPerWeek = perWeek(fileCount, dayCount);
@@ -82,53 +60,62 @@ export default function SnapshotCard({
   const linesAddedPerWeek = perWeek(linesAdded, dayCount);
   const linesRemovedPerWeek = perWeek(linesRemoved, dayCount);
 
-  const areas = projectAreas?.areas ?? [];
+  // Filter out known plugins/tools from project areas
+  const KNOWN_TOOLS = new Set([
+    "superpowers",
+    "claude-code-plugins",
+    "claude-code",
+    "plugins",
+    "mcp-servers",
+    "mcp",
+    ".claude",
+  ]);
+  const areas = (projectAreas?.areas ?? []).filter(
+    (a) => !KNOWN_TOOLS.has(a.name.toLowerCase()),
+  );
 
   return (
     <div className="rounded-2xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900/50">
-      {/* Date range */}
-      {dateRange && (
-        <div className="mb-4 text-xs font-medium text-slate-500 dark:text-slate-400">
-          {dateRange}
-          {dayCount != null && ` (${dayCount} days)`}
-        </div>
-      )}
-
       {/* Per-week stats */}
-      <div className="flex flex-wrap gap-6 pb-5">
-        {sessionsPerWeek != null && (
-          <StatCell value={sessionsPerWeek} label="Sessions/wk" />
-        )}
-        {msgsPerWeek != null && (
-          <StatCell value={msgsPerWeek} label="Msgs/wk" />
-        )}
-        {commitsPerWeek != null && (
-          <StatCell value={commitsPerWeek} label="Commits/wk" />
-        )}
-        {filesPerWeek != null && (
-          <StatCell value={filesPerWeek} label="Files/wk" />
-        )}
-        {linesAddedPerWeek != null && (
-          <StatCell
-            value={`+${linesAddedPerWeek}`}
-            label="Added/wk"
-            className="text-green-600 dark:text-green-400"
-          />
-        )}
-        {linesRemovedPerWeek != null && (
-          <StatCell
-            value={`-${linesRemovedPerWeek}`}
-            label="Removed/wk"
-            className="text-red-600 dark:text-red-400"
-          />
-        )}
+      <div className="pb-5">
+        <div className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+          Weekly Averages
+        </div>
+        <div className="flex flex-wrap gap-6">
+          {sessionsPerWeek != null && (
+            <StatCell value={sessionsPerWeek} label="Sessions" />
+          )}
+          {msgsPerWeek != null && (
+            <StatCell value={msgsPerWeek} label="Messages" />
+          )}
+          {commitsPerWeek != null && (
+            <StatCell value={commitsPerWeek} label="Commits" />
+          )}
+          {filesPerWeek != null && (
+            <StatCell value={filesPerWeek} label="Files" />
+          )}
+          {linesAddedPerWeek != null && (
+            <StatCell
+              value={`+${linesAddedPerWeek}`}
+              label="Added"
+              className="text-green-600 dark:text-green-400"
+            />
+          )}
+          {linesRemovedPerWeek != null && (
+            <StatCell
+              value={`-${linesRemovedPerWeek}`}
+              label="Removed"
+              className="text-red-600 dark:text-red-400"
+            />
+          )}
+        </div>
       </div>
 
       {/* Projects */}
       {areas.length > 0 && (
         <div className="border-t border-slate-100 pt-5 dark:border-slate-800">
           <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-            Projects
+            Project Areas
           </h3>
           <div className="flex flex-wrap gap-2">
             {areas.map((area) => (
@@ -150,11 +137,11 @@ export default function SnapshotCard({
         </div>
       )}
 
-      {/* Skills & Plugins */}
+      {/* Features Used */}
       {detectedSkills.length > 0 && (
         <div className="mt-5 border-t border-slate-100 pt-5 dark:border-slate-800">
           <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-            Skills & Plugins
+            Features Used
           </h3>
           <SkillBadges skills={detectedSkills} />
         </div>


### PR DESCRIPTION
## Summary

Addresses UX feedback from testing the v2 redesign on the live site.

- **Upload flow**: entire drop zone is now clickable (not just Browse Files button). Next/Back/Publish buttons are sticky near the top of the page, not buried below long content. Review step (step 2) and Preview step (step 4) now render the report using the same SnapshotCard + CollapsibleSection components as the published page — users see exactly what will be published.
- **SnapshotCard overhaul**: all stats normalized to per-week (sessions/wk, msgs/wk, commits/wk, files/wk, lines added/wk, lines removed/wk). Shows date range the insight covers. Projects displayed prominently in the card. "Top Tools Used" replaced with "Skills & Plugins".
- **Detail page**: date range shown in author bar instead of just upload date. Project Areas moved from collapsible sections into SnapshotCard. Project Links moved above sections.
- **Homepage**: ContributorRow now shows date range and per-week stats consistently.

## Test plan

- [x] 55/55 unit tests passing
- [x] `npm run build` clean
- [ ] Upload a fresh report — verify drop zone is clickable, sticky nav works, preview shows styled components
- [ ] Detail page — verify per-week stats, date range, projects in snapshot card
- [ ] Homepage — verify per-week stats and date ranges on contributor rows