### PR TITLE
fix: resolve username from DB for existing JWT sessions

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,6 +23,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
 
         token.sub = user.id;
         token.username = user.username;
+      } else if (token.sub && !token.username) {
+        // Existing session without username — look it up from DB
+        const user = await prisma.user.findUnique({
+          where: { id: token.sub },
+          select: { username: true },
+        });
+        if (user) token.username = user.username;
       }
       return token;
     },


### PR DESCRIPTION
## Summary
- Existing JWT sessions (created before username was added to the token) have `token.username` as undefined
- This causes the Profile link in the header to navigate to `/u/undefined` → "User not found"
- Fix: when `token.sub` exists but `token.username` is missing, look up the username from the DB

## Test plan
- [ ] Sign out and sign back in — profile link works
- [ ] For existing sessions, profile link should now resolve correctly after next page load