### PR TITLE
feat: parse, store, and display insight-harness reports

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,6 +52,15 @@ model InsightReport {
   chartData       Json?
   detectedSkills  String[]   @default([])
 
+  // v3: Harness report fields
+  reportType        String   @default("insights")
+  totalTokens       Int?
+  durationHours     Int?
+  avgSessionMinutes Float?
+  prCount           Int?
+  autonomyLabel     String?
+  harnessData       Json?
+
   // Content sections (stored as redacted JSON)
   atAGlance          Json?
   interactionStyle   Json?

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -205,6 +205,14 @@ export async function POST(request: Request) {
       projectLinks,
       chartData,
       detectedSkills,
+      // v3: Harness fields
+      reportType,
+      totalTokens,
+      durationHours,
+      avgSessionMinutes,
+      prCount,
+      autonomyLabel,
+      harnessData,
     } = body;
 
     // Auto-generate title if not provided
@@ -239,6 +247,13 @@ export async function POST(request: Request) {
         funEnding: funEnding ?? undefined,
         chartData: chartData ?? undefined,
         detectedSkills: detectedSkills ?? [],
+        reportType: reportType ?? "insights",
+        totalTokens: totalTokens ?? null,
+        durationHours: durationHours ?? null,
+        avgSessionMinutes: avgSessionMinutes ?? null,
+        prCount: prCount ?? null,
+        autonomyLabel: autonomyLabel ?? null,
+        harnessData: harnessData ?? undefined,
         ...(Array.isArray(projectLinks) && projectLinks.length > 0
           ? {
               projectLinks: {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { parseInsightsHtml } from "@/lib/parser";
+import { isHarnessReport, parseHarnessHtml } from "@/lib/harness-parser";
 import { detectRedactions } from "@/lib/redaction";
 import { parseChartData } from "@/lib/chart-parser";
 import { detectSkills } from "@/lib/skill-detector";
@@ -83,28 +84,63 @@ export async function POST(request: Request) {
 
     const html = await file.text();
 
-    // Parse using the cheerio-based parser
-    const parsed = parseInsightsHtml(html);
+    // Detect report type
+    const isHarness = isHarnessReport(html);
 
-    // Extract chart data and detect skills
-    const chartData = parseChartData(html);
+    // For harness reports, extract the embedded /insights tab content
+    // and parse that — the top-level HTML has harness-specific selectors
+    // that would confuse the insights parser (wrong .stat/.subtitle elements).
+    let insightsHtml = html;
+    if (isHarness) {
+      const $doc = cheerio.load(html);
+      const insightsTab = $doc("#tab-insights");
+      if (insightsTab.length) {
+        // Wrap in minimal HTML so the parser can find selectors
+        insightsHtml = `<html><body>${insightsTab.html()}</body></html>`;
+      }
+    }
+
+    // Parse the /insights data from the appropriate HTML source
+    const parsed = parseInsightsHtml(insightsHtml);
+
+    // Extract chart data and detect skills from the insights HTML
+    const chartData = parseChartData(insightsHtml);
     const detectedSkills = detectSkills(parsed.data, chartData);
 
     // Detect sensitive data using the redaction engine
     const detectedRedactions = detectRedactions(parsed.data);
 
-    // Extract enhanced stats from the stats row
-    const enhancedStats = extractEnhancedStats(html);
+    // Extract enhanced stats — for harness reports, use harness stats grid;
+    // for plain insights, use the insights stats row
+    const enhancedStats = extractEnhancedStats(isHarness ? html : insightsHtml);
+
+    // Parse harness-specific data if applicable
+    const harnessData = isHarness ? parseHarnessHtml(html) : undefined;
+
+    // For harness reports, override stats with harness-level data
+    // since the embedded insights tab may have stale/different stats
+    const stats = {
+      ...parsed.stats,
+      ...enhancedStats,
+      ...(harnessData
+        ? {
+            sessionCount:
+              parsed.stats.sessionCount || harnessData.stats.totalTokens > 0
+                ? parsed.stats.sessionCount
+                : 0,
+            dayCount: enhancedStats.dayCount ?? 30,
+          }
+        : {}),
+    };
 
     return NextResponse.json({
-      stats: {
-        ...parsed.stats,
-        ...enhancedStats,
-      },
+      stats,
       data: parsed.data,
       detectedRedactions,
       chartData,
       detectedSkills,
+      reportType: isHarness ? "insight-harness" : "insights",
+      harnessData,
     });
   } catch (error) {
     console.error("POST /api/upload error:", error);

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -15,8 +15,11 @@ import {
   type InsightsData,
   type ChartData,
   type SkillKey,
+  type HarnessData,
 } from "@/types/insights";
 import { normalizeChartData } from "@/lib/chart-parser";
+import HarnessOverview from "@/components/HarnessOverview";
+import HarnessSections from "@/components/HarnessSections";
 
 interface ReportData {
   id: string;
@@ -43,6 +46,14 @@ interface ReportData {
   suggestions: InsightsData["suggestions"] | null;
   onTheHorizon: InsightsData["on_the_horizon"] | null;
   funEnding: InsightsData["fun_ending"] | null;
+  // v3: Harness fields
+  reportType: string;
+  totalTokens: number | null;
+  durationHours: number | null;
+  avgSessionMinutes: number | null;
+  prCount: number | null;
+  autonomyLabel: string | null;
+  harnessData: HarnessData | null;
   author: {
     username: string;
     displayName: string | null;
@@ -307,10 +318,27 @@ export default function InsightDetailPage() {
         />
       </div>
 
+      {/* Harness Overview (tokens, autonomy, feature pills) */}
+      {report.harnessData && (
+        <div className="mb-8">
+          <HarnessOverview harnessData={report.harnessData} />
+        </div>
+      )}
+
       {/* Project Links */}
       {report.projectLinks.length > 0 && (
         <div className="mb-6">
           <ProjectLinks links={report.projectLinks} />
+        </div>
+      )}
+
+      {/* Harness Dashboard Sections */}
+      {report.harnessData && (
+        <div className="mb-8">
+          <h2 className="mb-4 text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Harness Profile
+          </h2>
+          <HarnessSections harnessData={report.harnessData} />
         </div>
       )}
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -380,6 +380,15 @@ export default function UploadPage() {
           projectLinks,
           chartData: parsed.chartData,
           detectedSkills: parsed.detectedSkills,
+          // v3: Harness fields
+          reportType: parsed.reportType ?? "insights",
+          totalTokens: parsed.harnessData?.stats.totalTokens ?? null,
+          durationHours: parsed.harnessData?.stats.durationHours ?? null,
+          avgSessionMinutes:
+            parsed.harnessData?.stats.avgSessionMinutes ?? null,
+          prCount: parsed.harnessData?.stats.prCount ?? null,
+          autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
+          harnessData: parsed.harnessData ?? null,
         }),
       });
 

--- a/src/components/HarnessOverview.tsx
+++ b/src/components/HarnessOverview.tsx
@@ -1,0 +1,125 @@
+import type { HarnessData } from "@/types/insights";
+
+interface HarnessOverviewProps {
+  harnessData: HarnessData;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function StatCell({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="text-center">
+      <div className="text-lg font-bold text-slate-900 dark:text-slate-100">
+        {value}
+      </div>
+      <div className="mt-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export default function HarnessOverview({ harnessData }: HarnessOverviewProps) {
+  const { stats, autonomy, featurePills } = harnessData;
+
+  return (
+    <div className="space-y-4">
+      {/* Extra stats row */}
+      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900/50">
+        <div className="mb-3 text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+          Harness Stats
+        </div>
+        <div className="flex flex-wrap gap-6">
+          {stats.totalTokens > 0 && (
+            <StatCell value={formatNumber(stats.totalTokens)} label="Tokens" />
+          )}
+          {stats.durationHours > 0 && (
+            <StatCell value={`${stats.durationHours}h`} label="Duration" />
+          )}
+          {stats.avgSessionMinutes > 0 && (
+            <StatCell
+              value={`${Math.round(stats.avgSessionMinutes)}m`}
+              label="Avg Session"
+            />
+          )}
+          {stats.skillsUsedCount > 0 && (
+            <StatCell value={stats.skillsUsedCount.toString()} label="Skills" />
+          )}
+          {stats.hooksCount > 0 && (
+            <StatCell value={stats.hooksCount.toString()} label="Hooks" />
+          )}
+          {stats.prCount > 0 && (
+            <StatCell value={stats.prCount.toString()} label="PRs" />
+          )}
+        </div>
+      </div>
+
+      {/* Autonomy box */}
+      {autonomy.label && (
+        <div className="rounded-xl bg-gradient-to-br from-slate-800 to-slate-900 p-5 text-white dark:from-slate-700 dark:to-slate-800">
+          <div className="text-xl font-bold">{autonomy.label}</div>
+          <div className="mt-1 text-sm text-slate-300">
+            {autonomy.description}
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 border-t border-white/10 pt-3">
+            {autonomy.userMessages > 0 && (
+              <div className="text-xs text-slate-400">
+                <span className="font-semibold text-white">
+                  {autonomy.userMessages.toLocaleString()}
+                </span>{" "}
+                user msgs
+              </div>
+            )}
+            {autonomy.assistantMessages > 0 && (
+              <div className="text-xs text-slate-400">
+                <span className="font-semibold text-white">
+                  {autonomy.assistantMessages.toLocaleString()}
+                </span>{" "}
+                assistant msgs
+              </div>
+            )}
+            {autonomy.turnCount > 0 && (
+              <div className="text-xs text-slate-400">
+                <span className="font-semibold text-white">
+                  {autonomy.turnCount.toLocaleString()}
+                </span>{" "}
+                turns
+              </div>
+            )}
+            {autonomy.errorRate && autonomy.errorRate !== "0%" && (
+              <div className="text-xs text-slate-400">
+                <span className="font-semibold text-white">
+                  {autonomy.errorRate}
+                </span>{" "}
+                error rate
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Feature pills */}
+      {featurePills.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {featurePills.map((pill) => (
+            <span
+              key={pill.name}
+              className={`rounded-full px-3 py-1 text-xs font-semibold ${
+                pill.active
+                  ? "border border-green-200 bg-green-50 text-green-700 dark:border-green-800 dark:bg-green-950/30 dark:text-green-400"
+                  : "border border-slate-200 bg-slate-50 text-slate-400 dark:border-slate-700 dark:bg-slate-800/50"
+              }`}
+            >
+              {pill.name}
+              {pill.value && ` (${pill.value})`}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/HarnessSections.tsx
+++ b/src/components/HarnessSections.tsx
@@ -1,0 +1,486 @@
+import type { HarnessData } from "@/types/insights";
+import CollapsibleSection from "./CollapsibleSection";
+
+interface HarnessSectionsProps {
+  harnessData: HarnessData;
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+function BarChart({
+  data,
+  color = "bg-blue-500",
+}: {
+  data: Record<string, number>;
+  color?: string;
+}) {
+  const entries = Object.entries(data)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 12);
+  if (entries.length === 0)
+    return <p className="text-sm text-slate-400 italic">No data</p>;
+  const max = entries[0][1];
+
+  return (
+    <div className="space-y-1.5">
+      {entries.map(([label, value]) => (
+        <div key={label} className="flex items-center gap-2">
+          <div className="w-24 truncate text-xs font-mono text-slate-600 dark:text-slate-400">
+            {label}
+          </div>
+          <div className="flex-1 h-2 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
+            <div
+              className={`h-full rounded-full ${color}`}
+              style={{ width: `${Math.max(3, (value / max) * 100)}%` }}
+            />
+          </div>
+          <div className="w-12 text-right text-xs font-mono text-slate-400">
+            {formatNumber(value)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DataTable({
+  headers,
+  rows,
+}: {
+  headers: string[];
+  rows: (string | number)[][];
+}) {
+  if (rows.length === 0)
+    return <p className="text-sm text-slate-400 italic">None</p>;
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 dark:border-slate-700">
+            {headers.map((h) => (
+              <th
+                key={h}
+                className="pb-2 text-left text-[10px] font-semibold uppercase tracking-wide text-slate-400"
+              >
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr
+              key={i}
+              className="border-b border-slate-100 dark:border-slate-800"
+            >
+              {row.map((cell, j) => (
+                <td
+                  key={j}
+                  className={`py-2 pr-4 text-slate-600 dark:text-slate-400 ${j === 0 ? "font-mono text-xs" : "text-xs"}`}
+                >
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PluginCards({ plugins }: { plugins: HarnessData["plugins"] }) {
+  if (plugins.length === 0)
+    return <p className="text-sm text-slate-400 italic">No plugins</p>;
+  return (
+    <div className="grid gap-2 sm:grid-cols-2">
+      {plugins.map((p) => (
+        <div
+          key={p.name}
+          className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
+        >
+          <div className="flex items-center justify-between">
+            <span className="font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+              {p.name}
+            </span>
+            <span
+              className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                p.active
+                  ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                  : "bg-slate-100 text-slate-400 dark:bg-slate-800"
+              }`}
+            >
+              {p.active ? "on" : "off"}
+            </span>
+          </div>
+          {(p.version || p.marketplace) && (
+            <div className="mt-0.5 text-[11px] text-slate-400">
+              {p.version && `v${p.version}`}
+              {p.version && p.marketplace && " · "}
+              {p.marketplace}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function HarnessSections({ harnessData }: HarnessSectionsProps) {
+  const {
+    toolUsage,
+    skillInventory,
+    hookDefinitions,
+    hookFrequency,
+    plugins,
+    harnessFiles,
+    fileOpStyle,
+    agentDispatch,
+    cliTools,
+    languages,
+    models,
+    permissionModes,
+    mcpServers,
+    gitPatterns,
+    versions,
+    writeupSections,
+  } = harnessData;
+
+  return (
+    <div className="space-y-4">
+      {/* Skills Inventory */}
+      {skillInventory.length > 0 && (
+        <CollapsibleSection
+          icon=""
+          title="Skills & Commands"
+          defaultOpen={false}
+        >
+          <DataTable
+            headers={["Skill", "Source", "Calls"]}
+            rows={skillInventory.map((s) => [s.name, s.source, s.calls])}
+          />
+        </CollapsibleSection>
+      )}
+
+      {/* Tool Usage */}
+      {Object.keys(toolUsage).length > 0 && (
+        <CollapsibleSection icon="" title="Tool Usage" defaultOpen={false}>
+          <BarChart data={toolUsage} color="bg-blue-500" />
+        </CollapsibleSection>
+      )}
+
+      {/* Hooks */}
+      {hookDefinitions.length > 0 && (
+        <CollapsibleSection icon="" title="Hooks & Safety" defaultOpen={false}>
+          <DataTable
+            headers={["Event", "Matcher", "Script"]}
+            rows={hookDefinitions.map((h) => [h.event, h.matcher, h.script])}
+          />
+          {Object.keys(hookFrequency).length > 0 && (
+            <div className="mt-4">
+              <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                Execution Frequency
+              </h4>
+              <BarChart data={hookFrequency} color="bg-amber-500" />
+            </div>
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* Plugins */}
+      {plugins.length > 0 && (
+        <CollapsibleSection icon="" title="Plugins" defaultOpen={false}>
+          <PluginCards plugins={plugins} />
+        </CollapsibleSection>
+      )}
+
+      {/* File Operation Style */}
+      {fileOpStyle.style && (
+        <CollapsibleSection
+          icon=""
+          title="File Operation Style"
+          defaultOpen={false}
+        >
+          <div className="flex flex-wrap gap-6">
+            <div className="text-center">
+              <div className="font-mono text-sm font-semibold text-slate-700 dark:text-slate-300">
+                {fileOpStyle.readPct}:{fileOpStyle.editPct}:
+                {fileOpStyle.writePct}
+              </div>
+              <div className="text-[10px] text-slate-400">
+                Read : Edit : Write
+              </div>
+            </div>
+            <div className="text-center">
+              <div className="font-mono text-sm font-semibold text-slate-700 dark:text-slate-300">
+                {fileOpStyle.grepCount}:{fileOpStyle.globCount}
+              </div>
+              <div className="text-[10px] text-slate-400">Grep : Glob</div>
+            </div>
+            <div className="text-center">
+              <div className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+                {fileOpStyle.style}
+              </div>
+              <div className="text-[10px] text-slate-400">Style</div>
+            </div>
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Agent Dispatch */}
+      {agentDispatch && agentDispatch.totalAgents > 0 && (
+        <CollapsibleSection
+          icon=""
+          title={`Agent Dispatch (${agentDispatch.totalAgents} agents)`}
+          defaultOpen={false}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Object.keys(agentDispatch.types).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  Agent Types
+                </h4>
+                <BarChart data={agentDispatch.types} color="bg-indigo-500" />
+              </div>
+            )}
+            {Object.keys(agentDispatch.models).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  Model Tiering
+                </h4>
+                <BarChart data={agentDispatch.models} color="bg-purple-500" />
+                {agentDispatch.backgroundPct > 0 && (
+                  <p className="mt-1 text-xs text-slate-400">
+                    {agentDispatch.backgroundPct}% run in background
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+          {agentDispatch.customAgents.length > 0 && (
+            <div className="mt-3">
+              <h4 className="mb-1 text-xs font-semibold text-slate-500">
+                Custom Agents
+              </h4>
+              <div className="flex flex-wrap gap-1.5">
+                {agentDispatch.customAgents.map((a) => (
+                  <span
+                    key={a}
+                    className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                  >
+                    {a}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* CLI Tools */}
+      {Object.keys(cliTools).length > 0 && (
+        <CollapsibleSection icon="" title="CLI Tools" defaultOpen={false}>
+          <BarChart data={cliTools} color="bg-teal-500" />
+        </CollapsibleSection>
+      )}
+
+      {/* Languages & Models side by side */}
+      {(Object.keys(languages).length > 0 ||
+        Object.keys(models).length > 0) && (
+        <CollapsibleSection
+          icon=""
+          title="Languages & Models"
+          defaultOpen={false}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Object.keys(languages).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  Languages
+                </h4>
+                <BarChart data={languages} color="bg-green-500" />
+              </div>
+            )}
+            {Object.keys(models).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  Models
+                </h4>
+                <BarChart data={models} color="bg-purple-500" />
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Permission Modes & MCP */}
+      {(Object.keys(permissionModes).length > 0 ||
+        Object.keys(mcpServers).length > 0) && (
+        <CollapsibleSection
+          icon=""
+          title="Permissions & MCP"
+          defaultOpen={false}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Object.keys(permissionModes).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  Permission Modes
+                </h4>
+                {Object.entries(permissionModes)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([mode, pct]) => (
+                    <div
+                      key={mode}
+                      className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
+                    >
+                      <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                        {mode}
+                      </span>
+                      <span className="text-xs text-slate-400">{pct}%</span>
+                    </div>
+                  ))}
+              </div>
+            )}
+            {Object.keys(mcpServers).length > 0 && (
+              <div>
+                <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                  MCP Servers
+                </h4>
+                {Object.entries(mcpServers)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([server, calls]) => (
+                    <div
+                      key={server}
+                      className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
+                    >
+                      <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                        {server}
+                      </span>
+                      <span className="text-xs text-slate-400">
+                        {formatNumber(calls)} calls
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            )}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Git Patterns */}
+      {(gitPatterns.prCount > 0 || gitPatterns.commitCount > 0) && (
+        <CollapsibleSection icon="" title="Git Patterns" defaultOpen={false}>
+          <div className="mb-3 flex flex-wrap gap-4 text-sm text-slate-600 dark:text-slate-400">
+            <span>
+              <strong className="text-slate-900 dark:text-slate-100">
+                {gitPatterns.prCount}
+              </strong>{" "}
+              PRs
+            </span>
+            <span>
+              <strong className="text-slate-900 dark:text-slate-100">
+                {gitPatterns.commitCount}
+              </strong>{" "}
+              commits
+            </span>
+            {gitPatterns.linesAdded !== "0" && (
+              <span>
+                <strong className="text-slate-900 dark:text-slate-100">
+                  {gitPatterns.linesAdded}
+                </strong>{" "}
+                lines added
+              </span>
+            )}
+          </div>
+          {Object.keys(gitPatterns.branchPrefixes).length > 0 && (
+            <div>
+              <h4 className="mb-1 text-xs font-semibold text-slate-500">
+                Branch Conventions
+              </h4>
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(gitPatterns.branchPrefixes)
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([prefix, count]) => (
+                    <span
+                      key={prefix}
+                      className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                    >
+                      {prefix} ({count})
+                    </span>
+                  ))}
+              </div>
+            </div>
+          )}
+        </CollapsibleSection>
+      )}
+
+      {/* Harness Files */}
+      {harnessFiles.length > 0 && (
+        <CollapsibleSection
+          icon=""
+          title="Harness File Ecosystem"
+          defaultOpen={false}
+        >
+          <div className="space-y-1">
+            {harnessFiles.map((f) => (
+              <div
+                key={f}
+                className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
+              >
+                {f}
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Versions */}
+      {versions.length > 0 && (
+        <CollapsibleSection
+          icon=""
+          title="Claude Code Versions"
+          defaultOpen={false}
+        >
+          <div className="flex flex-wrap gap-1.5">
+            {versions.map((v) => (
+              <span
+                key={v}
+                className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+              >
+                {v}
+              </span>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Writeup Sections */}
+      {writeupSections.length > 0 && (
+        <CollapsibleSection
+          icon=""
+          title="Writeup Analysis"
+          defaultOpen={false}
+        >
+          <div className="space-y-6">
+            {writeupSections.map((section) => (
+              <div key={section.title}>
+                <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+                  {section.title}
+                </h4>
+                <div
+                  className="prose prose-sm max-w-none text-slate-600 dark:text-slate-400 [&_p]:mb-2 [&_li]:mb-1 [&_.tip]:rounded-r-lg [&_.tip]:border-l-[3px] [&_.tip]:border-blue-500 [&_.tip]:bg-blue-50 [&_.tip]:p-3 [&_.tip]:text-sm [&_.tip]:text-blue-700 dark:[&_.tip]:bg-blue-950/30 dark:[&_.tip]:text-blue-400"
+                  dangerouslySetInnerHTML={{ __html: section.contentHtml }}
+                />
+              </div>
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/harness-parser.test.ts
+++ b/src/lib/__tests__/harness-parser.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { resolve } from "path";
+import { isHarnessReport, parseHarnessHtml } from "../harness-parser";
+import { parseInsightsHtml } from "../parser";
+
+// Read the real HTML files for testing — these live on the developer's machine
+// and won't exist in CI. Tests that need them use `it.skipIf` to degrade
+// gracefully rather than fail.
+const HARNESS_REPORT_PATH = resolve(
+  process.env.HOME ?? "~",
+  ".claude/usage-data/insight-harness.html",
+);
+const INSIGHTS_REPORT_PATH = resolve(
+  process.env.HOME ?? "~",
+  ".claude/usage-data/report.html",
+);
+
+const hasHarnessFile = existsSync(HARNESS_REPORT_PATH);
+const hasInsightsFile = existsSync(INSIGHTS_REPORT_PATH);
+
+let harnessHtml = "";
+let insightsHtml = "";
+if (hasHarnessFile) harnessHtml = readFileSync(HARNESS_REPORT_PATH, "utf-8");
+if (hasInsightsFile) insightsHtml = readFileSync(INSIGHTS_REPORT_PATH, "utf-8");
+
+// Shorthand for tests requiring the real harness file
+const ith = it.skipIf(!hasHarnessFile);
+
+describe("isHarnessReport", () => {
+  ith("should detect insight-harness HTML as harness report", () => {
+    expect(isHarnessReport(harnessHtml)).toBe(true);
+  });
+
+  it.skipIf(!hasInsightsFile)(
+    "should detect plain insights HTML as NOT harness report",
+    () => {
+      expect(isHarnessReport(insightsHtml)).toBe(false);
+    },
+  );
+
+  it("should return false for empty/minimal HTML", () => {
+    expect(isHarnessReport("")).toBe(false);
+    expect(isHarnessReport("<html><body></body></html>")).toBe(false);
+  });
+});
+
+describe("parseHarnessHtml", () => {
+  ith("should parse the real harness report without throwing", () => {
+    expect(() => parseHarnessHtml(harnessHtml)).not.toThrow();
+  });
+
+  describe("stats", () => {
+    ith("should extract harness stats from the stats grid", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.stats.totalTokens).toBeGreaterThan(0);
+      expect(result.stats.durationHours).toBeGreaterThanOrEqual(0);
+      expect(result.stats.skillsUsedCount).toBeGreaterThanOrEqual(0);
+      expect(result.stats.hooksCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("autonomy", () => {
+    ith("should extract autonomy data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.autonomy.label).toBeTruthy();
+      expect(
+        ["Fire-and-Forget", "Directive", "Collaborative"].includes(
+          result.autonomy.label,
+        ),
+      ).toBe(true);
+      expect(result.autonomy.description).toBeTruthy();
+    });
+
+    ith("should extract autonomy message counts", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.autonomy.userMessages).toBeGreaterThanOrEqual(0);
+      expect(result.autonomy.assistantMessages).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("feature pills", () => {
+    ith("should extract feature pills", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.featurePills.length).toBeGreaterThan(0);
+      for (const pill of result.featurePills) {
+        expect(pill.name).toBeTruthy();
+        expect(typeof pill.active).toBe("boolean");
+      }
+    });
+  });
+
+  describe("tool usage", () => {
+    ith("should extract tool usage bar chart data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(Object.keys(result.toolUsage).length).toBeGreaterThan(0);
+      const tools = Object.keys(result.toolUsage);
+      const hasCommonTool = tools.some((t) =>
+        ["Read", "Edit", "Bash", "Grep", "Glob", "Write"].includes(t),
+      );
+      expect(hasCommonTool).toBe(true);
+    });
+  });
+
+  describe("skill inventory", () => {
+    ith("should extract skill entries", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.skillInventory.length).toBeGreaterThanOrEqual(0);
+      if (result.skillInventory.length > 0) {
+        const first = result.skillInventory[0];
+        expect(first.name).toBeTruthy();
+        expect(first.calls).toBeGreaterThanOrEqual(0);
+        expect(["custom", "plugin", "unknown"]).toContain(first.source);
+      }
+    });
+  });
+
+  describe("hook definitions", () => {
+    ith("should extract hook definitions", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.hookDefinitions.length).toBeGreaterThanOrEqual(0);
+      if (result.hookDefinitions.length > 0) {
+        const first = result.hookDefinitions[0];
+        expect(first.event).toBeTruthy();
+        expect(first.script).toBeTruthy();
+      }
+    });
+  });
+
+  describe("plugins", () => {
+    ith("should extract plugin data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.plugins.length).toBeGreaterThanOrEqual(0);
+      if (result.plugins.length > 0) {
+        expect(result.plugins[0].name).toBeTruthy();
+        expect(typeof result.plugins[0].active).toBe("boolean");
+      }
+    });
+  });
+
+  describe("file operation style", () => {
+    ith("should extract file operation ratios", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.fileOpStyle).toBeDefined();
+      expect(result.fileOpStyle.readPct).toBeGreaterThanOrEqual(0);
+      expect(result.fileOpStyle.editPct).toBeGreaterThanOrEqual(0);
+      expect(result.fileOpStyle.writePct).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("CLI tools", () => {
+    ith("should extract CLI tool usage", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(Object.keys(result.cliTools).length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("languages and models", () => {
+    ith("should extract language data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(Object.keys(result.languages).length).toBeGreaterThanOrEqual(0);
+    });
+
+    ith("should extract model data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(Object.keys(result.models).length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("git patterns", () => {
+    ith("should extract git pattern data", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.gitPatterns).toBeDefined();
+      expect(result.gitPatterns.prCount).toBeGreaterThanOrEqual(0);
+      expect(result.gitPatterns.commitCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe("writeup sections", () => {
+    ith("should extract writeup sections", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.writeupSections.length).toBeGreaterThan(0);
+      const first = result.writeupSections[0];
+      expect(first.title).toBeTruthy();
+      expect(first.contentHtml).toBeTruthy();
+    });
+  });
+
+  describe("integrity hash", () => {
+    ith("should extract the integrity hash", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.integrityHash).toBeTruthy();
+    });
+  });
+
+  describe("versions", () => {
+    ith("should extract version tags", () => {
+      const result = parseHarnessHtml(harnessHtml);
+      expect(result.versions.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  it("should handle minimal HTML gracefully", () => {
+    const minimal = "<html><body><div class='container'></div></body></html>";
+    const result = parseHarnessHtml(minimal);
+    expect(result.stats.totalTokens).toBe(0);
+    expect(result.autonomy.label).toBe("");
+    expect(result.featurePills).toEqual([]);
+    expect(result.skillInventory).toEqual([]);
+    expect(result.hookDefinitions).toEqual([]);
+    expect(result.plugins).toEqual([]);
+    expect(result.writeupSections).toEqual([]);
+    expect(result.integrityHash).toBe("");
+  });
+});
+
+describe("insights parser with harness HTML", () => {
+  ith(
+    "should still extract /insights data from the embedded insights tab",
+    () => {
+      const result = parseInsightsHtml(harnessHtml);
+      expect(result.stats.sessionCount).toBeGreaterThanOrEqual(0);
+    },
+  );
+});

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -1,0 +1,533 @@
+import * as cheerio from "cheerio";
+import type {
+  HarnessData,
+  HarnessStats,
+  HarnessAutonomy,
+  HarnessFeaturePill,
+  HarnessSkillEntry,
+  HarnessHookDef,
+  HarnessPlugin,
+  HarnessFileOpStyle,
+  HarnessAgentDispatch,
+  HarnessGitPatterns,
+  HarnessWriteupSection,
+} from "@/types/insights";
+
+/**
+ * Detect whether an HTML string is an insight-harness report (vs plain /insights).
+ * Checks for the integrity manifest script tag unique to harness reports.
+ */
+export function isHarnessReport(html: string): boolean {
+  return html.includes('id="insight-harness-integrity"');
+}
+
+/**
+ * Parse an insight-harness HTML report into structured HarnessData.
+ */
+export function parseHarnessHtml(html: string): HarnessData {
+  const $ = cheerio.load(html);
+
+  return {
+    stats: parseHarnessStats($),
+    autonomy: parseAutonomy($),
+    featurePills: parseFeaturePills($),
+    toolUsage: parseBarChart($, "Tool Usage"),
+    skillInventory: parseSkillInventory($),
+    hookDefinitions: parseHookDefinitions($),
+    hookFrequency: parseBarChart($, "Hook Execution Frequency"),
+    plugins: parsePlugins($),
+    harnessFiles: parseHarnessFiles($),
+    fileOpStyle: parseFileOpStyle($),
+    agentDispatch: parseAgentDispatch($),
+    cliTools: parseBarChart($, "CLI Tools"),
+    languages: parseBarChart($, "Languages"),
+    models: parseBarChart($, "Models"),
+    permissionModes: parseKvSection($, "Permission Modes"),
+    mcpServers: parseKvSection($, "MCP Servers"),
+    gitPatterns: parseGitPatterns($),
+    versions: parseVersionTags($, "Claude Code Versions"),
+    writeupSections: parseWriteupSections($),
+    integrityHash: parseIntegrityHash($),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stats Grid
+// ---------------------------------------------------------------------------
+
+function parseHarnessStats($: cheerio.CheerioAPI): HarnessStats {
+  const statValues: Record<string, string> = {};
+  $(".stats-grid .stat").each((_, el) => {
+    const label = $(el).find(".stat-label").text().trim().toLowerCase();
+    const value = $(el).find(".stat-value").text().trim();
+    statValues[label] = value;
+  });
+
+  return {
+    totalTokens: parseNumericValue(statValues["tokens"] ?? "0"),
+    durationHours:
+      parseInt(statValues["duration"]?.replace(/h$/i, "") ?? "0", 10) || 0,
+    avgSessionMinutes:
+      parseFloat(statValues["avg session"]?.replace(/m$/i, "") ?? "0") || 0,
+    skillsUsedCount: parseInt(statValues["skills used"] ?? "0", 10) || 0,
+    hooksCount: parseInt(statValues["hooks"] ?? "0", 10) || 0,
+    prCount: parseInt(statValues["prs"] ?? "0", 10) || 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Autonomy Box
+// ---------------------------------------------------------------------------
+
+function parseAutonomy($: cheerio.CheerioAPI): HarnessAutonomy {
+  const box = $(".autonomy-box");
+  const label = box.find(".autonomy-label").text().trim();
+  const desc = box.find(".autonomy-desc").text().trim();
+
+  const stats: Record<string, string> = {};
+  box.find(".autonomy-stat").each((_, el) => {
+    const text = $(el).text().trim();
+    const strong = $(el).find("strong").text().trim();
+    // "1234 user msgs" -> key="user msgs", value="1234"
+    const remainder = text.replace(strong, "").trim();
+    stats[remainder] = strong;
+  });
+
+  return {
+    label,
+    description: desc,
+    userMessages: parseInt(stats["user msgs"] ?? "0", 10) || 0,
+    assistantMessages: parseInt(stats["assistant msgs"] ?? "0", 10) || 0,
+    turnCount: parseInt(stats["turns measured"] ?? "0", 10) || 0,
+    errorRate: Object.keys(stats).find((k) => k.includes("error"))
+      ? stats[Object.keys(stats).find((k) => k.includes("error"))!]
+      : "0%",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Feature Pills
+// ---------------------------------------------------------------------------
+
+function parseFeaturePills($: cheerio.CheerioAPI): HarnessFeaturePill[] {
+  const pills: HarnessFeaturePill[] = [];
+  $(".pills .pill").each((_, el) => {
+    const text = $(el).text().trim();
+    const active = $(el).hasClass("on");
+    // "Task Agents (12%)" -> name="Task Agents", value="12%"
+    const match = text.match(/^(.+?)\s*\((.+?)\)$/);
+    if (match) {
+      pills.push({ name: match[1].trim(), active, value: match[2].trim() });
+    } else {
+      pills.push({ name: text, active, value: "" });
+    }
+  });
+  return pills;
+}
+
+// ---------------------------------------------------------------------------
+// Bar Charts (Tool Usage, CLI Tools, Languages, Models)
+// ---------------------------------------------------------------------------
+
+function parseBarChart(
+  $: cheerio.CheerioAPI,
+  sectionTitle: string,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  const section = findSectionByTitle($, sectionTitle);
+  if (!section) return result;
+
+  section.find(".bar-row").each((_, el) => {
+    const label = $(el).find(".bar-label").text().trim();
+    const value = $(el).find(".bar-value").text().trim();
+    if (label) {
+      result[label] = parseNumericValue(value);
+    }
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Skills Inventory
+// ---------------------------------------------------------------------------
+
+function parseSkillInventory($: cheerio.CheerioAPI): HarnessSkillEntry[] {
+  const skills: HarnessSkillEntry[] = [];
+  const section = findSectionByTitle($, "Skills");
+  if (!section) return skills;
+
+  section.find("tbody tr").each((_, el) => {
+    const cells = $(el).find("td");
+    if (cells.length < 2) return;
+
+    const nameCell = cells.eq(0);
+    const name = nameCell.find(".mono.accent").text().trim();
+    const calls = parseInt(cells.eq(1).text().trim(), 10) || 0;
+
+    // Determine source from badge
+    let source = "unknown";
+    const badge = nameCell.find(".badge");
+    if (badge.hasClass("custom")) source = "custom";
+    else if (badge.hasClass("plugin")) source = "plugin";
+
+    const description = nameCell.find(".meta").text().trim();
+
+    if (name) {
+      skills.push({ name, calls, source, description });
+    }
+  });
+
+  return skills;
+}
+
+// ---------------------------------------------------------------------------
+// Hook Definitions
+// ---------------------------------------------------------------------------
+
+function parseHookDefinitions($: cheerio.CheerioAPI): HarnessHookDef[] {
+  const hooks: HarnessHookDef[] = [];
+  const section = findSectionByTitle($, "Hooks");
+  if (!section) return hooks;
+
+  section.find("tbody tr").each((_, el) => {
+    const cells = $(el).find("td");
+    if (cells.length < 3) return;
+    const event = cells.eq(0).text().trim();
+    const matcher = cells.eq(1).text().trim();
+    const script = cells.eq(2).text().trim();
+    if (event && !cells.eq(0).hasClass("empty")) {
+      hooks.push({ event, matcher, script });
+    }
+  });
+
+  return hooks;
+}
+
+// ---------------------------------------------------------------------------
+// Plugins
+// ---------------------------------------------------------------------------
+
+function parsePlugins($: cheerio.CheerioAPI): HarnessPlugin[] {
+  const plugins: HarnessPlugin[] = [];
+  $(".plugin-card").each((_, el) => {
+    const name = $(el).find(".plugin-name").text().trim();
+    const badge = $(el).find(".badge");
+    const active = badge.hasClass("active");
+    const meta = $(el).find(".meta").text().trim();
+    // "v1.0.3 · compound-engineering"
+    const versionMatch = meta.match(/^v([\d.]+)/);
+    const version = versionMatch ? versionMatch[1] : "";
+    const marketplace = meta.replace(/^v[\d.]+\s*·\s*/, "").trim();
+
+    if (name) {
+      plugins.push({ name, version, marketplace, active });
+    }
+  });
+  return plugins;
+}
+
+// ---------------------------------------------------------------------------
+// Harness Files
+// ---------------------------------------------------------------------------
+
+function parseHarnessFiles($: cheerio.CheerioAPI): string[] {
+  const files: string[] = [];
+  const section = findSectionByTitle($, "Harness File Ecosystem");
+  if (!section) return files;
+
+  section.find(".file-item").each((_, el) => {
+    const text = $(el).text().trim();
+    if (text) files.push(text);
+  });
+  return files;
+}
+
+// ---------------------------------------------------------------------------
+// File Operation Style
+// ---------------------------------------------------------------------------
+
+function parseFileOpStyle($: cheerio.CheerioAPI): HarnessFileOpStyle {
+  const section = findSectionByTitle($, "File Operation Style");
+  if (!section) {
+    return {
+      readPct: 0,
+      editPct: 0,
+      writePct: 0,
+      grepCount: 0,
+      globCount: 0,
+      style: "",
+    };
+  }
+
+  const donutItems = section.find(".donut-item");
+  let readPct = 0,
+    editPct = 0,
+    writePct = 0,
+    grepCount = 0,
+    globCount = 0;
+  let style = "";
+
+  donutItems.each((i, el) => {
+    const ratio = $(el).find(".ratio").text().trim();
+    const label = $(el).find(".label").text().trim().toLowerCase();
+
+    if (
+      label.includes("read") &&
+      label.includes("edit") &&
+      label.includes("write")
+    ) {
+      // "45:40:15" -> read:edit:write
+      const parts = ratio.split(":").map((s) => parseInt(s.trim(), 10) || 0);
+      readPct = parts[0] ?? 0;
+      editPct = parts[1] ?? 0;
+      writePct = parts[2] ?? 0;
+    } else if (label.includes("grep") && label.includes("glob")) {
+      const parts = ratio.split(":").map((s) => parseInt(s.trim(), 10) || 0);
+      grepCount = parts[0] ?? 0;
+      globCount = parts[1] ?? 0;
+    } else {
+      // Style label like "Surgical Editor"
+      style = ratio;
+    }
+  });
+
+  return { readPct, editPct, writePct, grepCount, globCount, style };
+}
+
+// ---------------------------------------------------------------------------
+// Agent Dispatch
+// ---------------------------------------------------------------------------
+
+function parseAgentDispatch(
+  $: cheerio.CheerioAPI,
+): HarnessAgentDispatch | null {
+  const section = findSectionByTitle($, "Agent Dispatch");
+  if (!section) return null;
+
+  const countText = section.find(".section-header .count").text().trim();
+  const countMatch = countText.match(/(\d+)/);
+  const totalAgents = countMatch ? parseInt(countMatch[1], 10) : 0;
+
+  const types: Record<string, number> = {};
+  const models: Record<string, number> = {};
+  let backgroundPct = 0;
+  const customAgents: string[] = [];
+
+  // Parse the two-col layout
+  const columns = section.find(".two-col > div");
+  columns.each((_, col) => {
+    const heading = $(col).find("h3").text().trim().toLowerCase();
+    if (heading.includes("agent types")) {
+      $(col)
+        .find(".kv-row")
+        .each((__, row) => {
+          const key = $(row).find(".mono").text().trim();
+          const val = $(row).find(".meta").text().trim();
+          if (key) types[key] = parseInt(val, 10) || 0;
+        });
+    } else if (heading.includes("model tiering")) {
+      $(col)
+        .find(".kv-row")
+        .each((__, row) => {
+          const key = $(row).find(".mono").text().trim();
+          const val = $(row).find(".meta").text().trim();
+          if (key) models[key] = parseInt(val, 10) || 0;
+        });
+      const bgMeta = $(col).find(".meta").last().text();
+      const bgMatch = bgMeta.match(/(\d+)%/);
+      if (bgMatch) backgroundPct = parseInt(bgMatch[1], 10);
+    }
+  });
+
+  // Custom agents
+  const customSection = section
+    .find("h3")
+    .filter((_, el) => $(el).text().toLowerCase().includes("custom agent"));
+  if (customSection.length) {
+    customSection
+      .next(".tags")
+      .find(".tag")
+      .each((_, el) => {
+        customAgents.push($(el).text().trim());
+      });
+  }
+
+  return { totalAgents, types, models, backgroundPct, customAgents };
+}
+
+// ---------------------------------------------------------------------------
+// Key-Value Sections (Permission Modes, MCP Servers)
+// ---------------------------------------------------------------------------
+
+function parseKvSection(
+  $: cheerio.CheerioAPI,
+  sectionTitle: string,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  const section = findSectionByTitle($, sectionTitle);
+  if (!section) return result;
+
+  section.find(".kv-row").each((_, el) => {
+    const key = $(el).find(".mono").text().trim();
+    const valText = $(el).find(".meta").text().trim();
+    const numMatch = valText.match(/([\d,.]+)/);
+    if (key && numMatch) {
+      result[key] = parseNumericValue(numMatch[1]);
+    }
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Git Patterns
+// ---------------------------------------------------------------------------
+
+function parseGitPatterns($: cheerio.CheerioAPI): HarnessGitPatterns {
+  const section = findSectionByTitle($, "Git Patterns");
+  const branchPrefixes: Record<string, number> = {};
+
+  if (!section) {
+    return { prCount: 0, commitCount: 0, linesAdded: "0", branchPrefixes };
+  }
+
+  // Parse summary meta: "12 PRs · 45 commits · 1.2K lines added"
+  const meta = section.find(".meta").first().text();
+  const prMatch = meta.match(/([\d,]+)\s*PRs/);
+  const commitMatch = meta.match(/([\d,]+)\s*commits/);
+  const linesMatch = meta.match(/([\d,.]+[KM]?)\s*lines added/);
+
+  // Branch convention tags: "feat/ (12)"
+  section.find(".tags .tag").each((_, el) => {
+    const text = $(el).text().trim();
+    const match = text.match(/^(.+?)\s*\((\d+)\)$/);
+    if (match) {
+      branchPrefixes[match[1].trim()] = parseInt(match[2], 10);
+    }
+  });
+
+  return {
+    prCount: prMatch ? parseNumericValue(prMatch[1]) : 0,
+    commitCount: commitMatch ? parseNumericValue(commitMatch[1]) : 0,
+    linesAdded: linesMatch ? linesMatch[1] : "0",
+    branchPrefixes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Version Tags
+// ---------------------------------------------------------------------------
+
+function parseVersionTags(
+  $: cheerio.CheerioAPI,
+  sectionTitle: string,
+): string[] {
+  const versions: string[] = [];
+  const section = findSectionByTitle($, sectionTitle);
+  if (!section) return versions;
+
+  section.find(".tags .tag").each((_, el) => {
+    versions.push($(el).text().trim());
+  });
+  return versions;
+}
+
+// ---------------------------------------------------------------------------
+// Writeup Sections
+// ---------------------------------------------------------------------------
+
+function parseWriteupSections($: cheerio.CheerioAPI): HarnessWriteupSection[] {
+  const sections: HarnessWriteupSection[] = [];
+  const writeupTab = $("#tab-writeup");
+  if (!writeupTab.length) return sections;
+
+  writeupTab.find(".writeup-section").each((_, el) => {
+    const title = $(el).find("h2").first().text().trim();
+    // Get inner HTML minus the h2
+    const clone = $(el).clone();
+    clone.find("h2").first().remove();
+    // Sanitize: strip script tags, event handlers, and iframes
+    clone.find("script, iframe, object, embed").remove();
+    clone
+      .find("[onclick], [onerror], [onload], [onmouseover]")
+      .each((_, node) => {
+        const $node = $(node);
+        $node.removeAttr("onclick");
+        $node.removeAttr("onerror");
+        $node.removeAttr("onload");
+        $node.removeAttr("onmouseover");
+      });
+    const contentHtml = clone.html()?.trim() ?? "";
+    if (title) {
+      sections.push({ title, contentHtml });
+    }
+  });
+
+  return sections;
+}
+
+// ---------------------------------------------------------------------------
+// Integrity Hash
+// ---------------------------------------------------------------------------
+
+function parseIntegrityHash($: cheerio.CheerioAPI): string {
+  const script = $("#insight-harness-integrity").html();
+  if (!script) return "";
+  try {
+    const data = JSON.parse(script);
+    return data.hash ?? "";
+  } catch {
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a <section> element by looking for a matching h2 text in .section-header.
+ * Falls back to searching all section > h2 elements.
+ */
+function findSectionByTitle(
+  $: cheerio.CheerioAPI,
+  title: string,
+): ReturnType<cheerio.CheerioAPI> | null {
+  const lowerTitle = title.toLowerCase();
+
+  // Try section-header h2 first
+  let found: ReturnType<cheerio.CheerioAPI> | null = null;
+  $("section").each((_, el) => {
+    const h2 = $(el).find(".section-header h2").text().trim().toLowerCase();
+    if (h2.includes(lowerTitle)) {
+      found = $(el);
+      return false; // break
+    }
+  });
+  if (found) return found;
+
+  // Fallback: any h2 containing the title, return its parent section
+  $("h2").each((_, el) => {
+    if ($(el).text().trim().toLowerCase().includes(lowerTitle)) {
+      const parent = $(el).closest("section");
+      if (parent.length) {
+        found = parent;
+        return false;
+      }
+    }
+  });
+
+  return found;
+}
+
+/**
+ * Parse a numeric value that may have K/M suffixes or commas.
+ */
+function parseNumericValue(s: string): number {
+  if (!s) return 0;
+  s = s.replace(/,/g, "").trim();
+  const upper = s.toUpperCase();
+  if (upper.endsWith("M")) return Math.round(parseFloat(s) * 1_000_000);
+  if (upper.endsWith("K")) return Math.round(parseFloat(s) * 1_000);
+  return Math.round(parseFloat(s)) || 0;
+}

--- a/src/types/api-contracts.ts
+++ b/src/types/api-contracts.ts
@@ -13,8 +13,17 @@ export interface InsightReportListItemContract {
   linesAdded: number | null;
   linesRemoved: number | null;
   fileCount: number | null;
+  // v3: Harness fields
+  reportType: string;
+  totalTokens: number | null;
+  autonomyLabel: string | null;
 }
 
 export interface InsightReportDetailContract extends InsightReportListItemContract {
   chartData: ChartData | null | unknown; // unknown because Prisma Json? is `any`/`JsonValue`
+  // v3: Harness detail fields
+  durationHours: number | null;
+  avgSessionMinutes: number | null;
+  prCount: number | null;
+  harnessData: unknown; // Prisma Json?
 }

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -108,6 +108,106 @@ export interface ParsedInsightsReport {
   detectedRedactions: RedactionItem[];
   chartData?: ChartData;
   detectedSkills?: SkillKey[];
+  reportType?: "insights" | "insight-harness";
+  harnessData?: HarnessData;
+}
+
+// ── Harness Data (insight-harness reports) ──────────────────────────────
+
+export interface HarnessStats {
+  totalTokens: number;
+  durationHours: number;
+  avgSessionMinutes: number;
+  skillsUsedCount: number;
+  hooksCount: number;
+  prCount: number;
+}
+
+export interface HarnessAutonomy {
+  label: string;
+  description: string;
+  userMessages: number;
+  assistantMessages: number;
+  turnCount: number;
+  errorRate: string;
+}
+
+export interface HarnessFeaturePill {
+  name: string;
+  active: boolean;
+  value: string;
+}
+
+export interface HarnessSkillEntry {
+  name: string;
+  calls: number;
+  source: string;
+  description: string;
+}
+
+export interface HarnessHookDef {
+  event: string;
+  matcher: string;
+  script: string;
+}
+
+export interface HarnessPlugin {
+  name: string;
+  version: string;
+  marketplace: string;
+  active: boolean;
+}
+
+export interface HarnessFileOpStyle {
+  readPct: number;
+  editPct: number;
+  writePct: number;
+  grepCount: number;
+  globCount: number;
+  style: string;
+}
+
+export interface HarnessAgentDispatch {
+  totalAgents: number;
+  types: Record<string, number>;
+  models: Record<string, number>;
+  backgroundPct: number;
+  customAgents: string[];
+}
+
+export interface HarnessGitPatterns {
+  prCount: number;
+  commitCount: number;
+  linesAdded: string;
+  branchPrefixes: Record<string, number>;
+}
+
+export interface HarnessWriteupSection {
+  title: string;
+  contentHtml: string;
+}
+
+export interface HarnessData {
+  stats: HarnessStats;
+  autonomy: HarnessAutonomy;
+  featurePills: HarnessFeaturePill[];
+  toolUsage: Record<string, number>;
+  skillInventory: HarnessSkillEntry[];
+  hookDefinitions: HarnessHookDef[];
+  hookFrequency: Record<string, number>;
+  plugins: HarnessPlugin[];
+  harnessFiles: string[];
+  fileOpStyle: HarnessFileOpStyle;
+  agentDispatch: HarnessAgentDispatch | null;
+  cliTools: Record<string, number>;
+  languages: Record<string, number>;
+  models: Record<string, number>;
+  permissionModes: Record<string, number>;
+  mcpServers: Record<string, number>;
+  gitPatterns: HarnessGitPatterns;
+  versions: string[];
+  writeupSections: HarnessWriteupSection[];
+  integrityHash: string;
 }
 
 // v2: Chart data parsed from HTML report


### PR DESCRIPTION
## Summary

- Add full support for the richer `/insight-harness` HTML format alongside existing `/insights` reports
- New cheerio-based harness parser extracts tokens, tools, skills, hooks, plugins, autonomy metrics, writeup sections, and more
- Prisma schema extended with `reportType`, `totalTokens`, `durationHours`, `prCount`, `autonomyLabel`, `harnessData` (Json)
- Detail page conditionally renders `HarnessOverview` (stats, autonomy box, feature pills) and `HarnessSections` (collapsible sections for all dashboard data)
- Upload API detects format, extracts `#tab-insights` for proper `/insights` parsing, parses harness data separately
- XSS sanitization on writeup HTML at parse time (strips scripts, iframes, event handlers)

## Test plan

- [ ] Upload a plain `/insights` report — verify existing flow unchanged
- [ ] Upload an `/insight-harness` report — verify harness sections appear on detail page
- [ ] Check autonomy box, feature pills, tool usage charts render correctly
- [ ] Verify skills, hooks, plugins, writeup sections display properly
- [ ] Confirm stats (sessions, messages, date range) parse correctly from embedded insights tab
- [ ] Test with minimal/empty HTML — no crashes
- [ ] Run `npx vitest run` — 77 tests pass
- [ ] Run `npx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)