### PR TITLE
fix: show harness data in upload preview, sync username on login

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -31,6 +31,8 @@ import { applyRedactions } from "@/lib/redaction";
 import SectionRenderer from "@/components/SectionRenderer";
 import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
+import HarnessOverview from "@/components/HarnessOverview";
+import HarnessSections from "@/components/HarnessSections";
 
 type Step = "upload" | "redact" | "projects" | "preview";
 
@@ -729,6 +731,12 @@ export default function UploadPage() {
                   : parsed.data.project_areas
               }
             />
+            {/* Harness preview (only for insight-harness reports) */}
+            {parsed.harnessData && (
+              <div className="mt-4">
+                <HarnessOverview harnessData={parsed.harnessData} />
+              </div>
+            )}
             <div className="mt-4 space-y-3">
               {SECTION_OPTIONS.map(({ dataKey, sectionType, label }) => {
                 if (disabledSections[dataKey]) return null;
@@ -756,6 +764,15 @@ export default function UploadPage() {
                 );
               })}
             </div>
+            {/* Harness sections preview */}
+            {parsed.harnessData && (
+              <div className="mt-4">
+                <h3 className="mb-3 text-sm font-semibold text-slate-700">
+                  Harness Profile
+                </h3>
+                <HarnessSections harnessData={parsed.harnessData} />
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -866,6 +883,13 @@ export default function UploadPage() {
             }
           />
 
+          {/* Harness preview */}
+          {parsed.harnessData && (
+            <div className="mt-4">
+              <HarnessOverview harnessData={parsed.harnessData} />
+            </div>
+          )}
+
           <div className="mt-4 space-y-3">
             {SECTION_OPTIONS.map(({ dataKey, sectionType, label }) => {
               if (disabledSections[dataKey]) return null;
@@ -893,6 +917,16 @@ export default function UploadPage() {
               );
             })}
           </div>
+
+          {/* Harness sections preview */}
+          {parsed.harnessData && (
+            <div className="mt-4">
+              <h3 className="mb-3 text-lg font-semibold text-slate-900">
+                Harness Profile
+              </h3>
+              <HarnessSections harnessData={parsed.harnessData} />
+            </div>
+          )}
 
           <div className="mt-8 flex justify-end">
             <button

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -30,14 +30,16 @@ export default function CollapsibleSection({
         className="flex w-full items-start gap-4 p-5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50"
         type="button"
       >
-        <div
-          className={clsx(
-            "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl",
-            iconBgClass,
-          )}
-        >
-          {icon}
-        </div>
+        {icon ? (
+          <div
+            className={clsx(
+              "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-xl",
+              iconBgClass,
+            )}
+          >
+            {icon}
+          </div>
+        ) : null}
         <div className="min-w-0 flex-1">
           <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
             {title}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -18,7 +18,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const user = await prisma.user.upsert({
           where: { githubId },
           create: { githubId, username, displayName, avatarUrl },
-          update: { displayName, avatarUrl },
+          update: { username, displayName, avatarUrl },
         });
 
         token.sub = user.id;


### PR DESCRIPTION
## Summary

- Show `HarnessOverview` and `HarnessSections` in upload review + final preview steps (fixes QA test-2 failure — harness upload looked identical to /insights)
- Sync `username` from GitHub `profile.login` on every sign-in, not just first login (fixes stale usernames after GitHub renames)
- Hide blank icon container in `CollapsibleSection` when `icon=""` (fixes blank squares in upload preview)

## Test plan

- [ ] Upload an insight-harness report — verify autonomy box, feature pills, and harness sections appear in the review step
- [ ] Upload a plain /insights report — verify no harness sections appear
- [ ] Sign out and sign back in — verify your username updates to current GitHub login
- [ ] Check that section headers in upload preview no longer show blank icon squares

🤖 Generated with [Claude Code](https://claude.com/claude-code)