### PR TITLE
fix: harness upload UX, validation, delete reports

### DIFF
--- a/src/app/api/insights/[slug]/route.ts
+++ b/src/app/api/insights/[slug]/route.ts
@@ -144,6 +144,13 @@ export async function PUT(
       "suggestions",
       "onTheHorizon",
       "funEnding",
+      // v3: Harness fields
+      "totalTokens",
+      "durationHours",
+      "avgSessionMinutes",
+      "prCount",
+      "autonomyLabel",
+      "harnessData",
     ];
 
     for (const field of allowedFields) {

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import type { InsightReportListItemContract } from "@/types/api-contracts";
+import { normalizeHarnessData } from "@/types/insights";
+import type { Prisma } from "@prisma/client";
 const SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
@@ -253,7 +255,10 @@ export async function POST(request: Request) {
         avgSessionMinutes: avgSessionMinutes ?? null,
         prCount: prCount ?? null,
         autonomyLabel: autonomyLabel ?? null,
-        harnessData: harnessData ?? undefined,
+        harnessData:
+          (normalizeHarnessData(
+            harnessData,
+          ) as unknown as Prisma.InputJsonValue) ?? undefined,
         ...(Array.isArray(projectLinks) && projectLinks.length > 0
           ? {
               projectLinks: {

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -12,6 +12,7 @@ import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
 import {
   normalizeSkills,
+  normalizeHarnessData,
   type InsightsData,
   type ChartData,
   type SkillKey,
@@ -204,6 +205,7 @@ export default function InsightDetailPage() {
         if (raw) {
           raw.detectedSkills = normalizeSkills(raw.detectedSkills);
           raw.chartData = normalizeChartData(raw.chartData);
+          raw.harnessData = normalizeHarnessData(raw.harnessData);
         }
         setReport(raw);
       })

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -13,6 +13,7 @@ import {
   X,
   Check,
   Globe,
+  Trash2,
 } from "lucide-react";
 import InsightCard from "@/components/InsightCard";
 
@@ -284,7 +285,31 @@ export default function UserProfilePage() {
   const [error, setError] = useState(false);
   const [editing, setEditing] = useState(false);
 
+  const [deleting, setDeleting] = useState<string | null>(null);
+
   const isOwnProfile = session?.user?.username === username;
+
+  const handleDelete = async (slug: string) => {
+    if (!confirm("Delete this report? This cannot be undone.")) return;
+    setDeleting(slug);
+    try {
+      const res = await fetch(`/api/insights/${slug}`, { method: "DELETE" });
+      if (!res.ok) throw new Error("Failed to delete");
+      setProfile((prev) =>
+        prev
+          ? {
+              ...prev,
+              reports: prev.reports.filter((r) => r.slug !== slug),
+              totalReports: prev.totalReports - 1,
+            }
+          : prev,
+      );
+    } catch {
+      alert("Failed to delete report. Please try again.");
+    } finally {
+      setDeleting(null);
+    }
+  };
 
   useEffect(() => {
     fetch(`/api/users/${username}`)
@@ -455,24 +480,39 @@ export default function UserProfilePage() {
       {profile.reports.length > 0 ? (
         <div className="grid gap-4 sm:grid-cols-2">
           {profile.reports.map((report) => (
-            <InsightCard
-              key={report.slug}
-              slug={report.slug}
-              title={report.title}
-              authorUsername={profile.username}
-              authorAvatar={profile.avatarUrl}
-              authorDisplayName={profile.displayName}
-              publishedAt={report.publishedAt}
-              dateRangeStart={report.dateRangeStart}
-              dateRangeEnd={report.dateRangeEnd}
-              sessionCount={report.sessionCount}
-              messageCount={report.messageCount}
-              commitCount={report.commitCount}
-              whatsWorkingPreview={report.whatsWorkingPreview}
-              voteCount={report.voteCount}
-              commentCount={report.commentCount}
-              sectionTags={report.sectionTags}
-            />
+            <div key={report.slug} className="relative">
+              <InsightCard
+                slug={report.slug}
+                title={report.title}
+                authorUsername={profile.username}
+                authorAvatar={profile.avatarUrl}
+                authorDisplayName={profile.displayName}
+                publishedAt={report.publishedAt}
+                dateRangeStart={report.dateRangeStart}
+                dateRangeEnd={report.dateRangeEnd}
+                sessionCount={report.sessionCount}
+                messageCount={report.messageCount}
+                commitCount={report.commitCount}
+                whatsWorkingPreview={report.whatsWorkingPreview}
+                voteCount={report.voteCount}
+                commentCount={report.commentCount}
+                sectionTags={report.sectionTags}
+              />
+              {isOwnProfile && (
+                <button
+                  onClick={() => handleDelete(report.slug)}
+                  disabled={deleting === report.slug}
+                  className="absolute right-3 top-3 rounded-lg border border-slate-200 bg-white/90 p-1.5 text-slate-400 opacity-0 transition-all hover:border-red-300 hover:bg-red-50 hover:text-red-600 group-hover:opacity-100 [div:hover>&]:opacity-100 dark:border-slate-700 dark:bg-slate-900/90"
+                  title="Delete report"
+                >
+                  {deleting === report.slug ? (
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-red-400 border-t-transparent" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                </button>
+              )}
+            </div>
           ))}
         </div>
       ) : (

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -18,12 +18,14 @@ import {
   Link as LinkIcon,
   Plus,
   Trash2,
+  Sparkles,
 } from "lucide-react";
 import clsx from "clsx";
 import type {
   ParsedInsightsReport,
   RedactionItem,
   InsightsData,
+  HarnessData,
 } from "@/types/insights";
 import { normalizeSkills } from "@/types/insights";
 import { normalizeChartData } from "@/lib/chart-parser";
@@ -95,6 +97,27 @@ function CopyablePathBlock({
       </div>
     </div>
   );
+}
+
+function stripDisabledHarnessSections(
+  data: HarnessData,
+  disabled: Record<string, boolean>,
+): HarnessData {
+  const copy = { ...data };
+  for (const key of Object.keys(disabled)) {
+    if (disabled[key] && key in copy) {
+      const k = key as keyof HarnessData;
+      const val = copy[k];
+      if (Array.isArray(val)) {
+        (copy as Record<string, unknown>)[key] = [];
+      } else if (typeof val === "object" && val !== null) {
+        (copy as Record<string, unknown>)[key] = {};
+      } else if (typeof val === "string") {
+        (copy as Record<string, unknown>)[key] = "";
+      }
+    }
+  }
+  return copy;
 }
 
 function DropZoneContent({
@@ -229,6 +252,22 @@ export default function UploadPage() {
     { dataKey: "fun_ending", sectionType: "fun_ending", label: "Fun Ending" },
   ];
 
+  // Harness-specific sections that can be toggled off.
+  // Keys match HarnessData fields that get nulled when disabled.
+  const HARNESS_SECTION_OPTIONS: { key: keyof HarnessData; label: string }[] = [
+    { key: "skillInventory", label: "Skills & Commands" },
+    { key: "toolUsage", label: "Tool Usage" },
+    { key: "hookDefinitions", label: "Hooks & Safety" },
+    { key: "plugins", label: "Plugins" },
+    { key: "fileOpStyle", label: "File Operation Style" },
+    { key: "agentDispatch", label: "Agent Dispatch" },
+    { key: "cliTools", label: "CLI Tools" },
+    { key: "languages", label: "Languages" },
+    { key: "models", label: "Models" },
+    { key: "mcpServers", label: "MCP Servers" },
+    { key: "writeupSections", label: "Writeup Analysis" },
+  ];
+
   const toggleSection = (key: string) => {
     setDisabledSections((prev) => ({ ...prev, [key]: !prev[key] }));
   };
@@ -340,7 +379,10 @@ export default function UploadPage() {
           year: "numeric",
         });
       }
-      const title = `${firstName}'s Claude Code Insights - ${titleDate}`;
+      const isHarness = parsed.reportType === "insight-harness";
+      const title = isHarness
+        ? `${firstName}'s Insight Harness - ${titleDate}`
+        : `${firstName}'s Claude Code Insights - ${titleDate}`;
 
       // Map InsightsData snake_case keys to Prisma camelCase fields
       // and remove disabled sections
@@ -390,7 +432,9 @@ export default function UploadPage() {
             parsed.harnessData?.stats.avgSessionMinutes ?? null,
           prCount: parsed.harnessData?.stats.prCount ?? null,
           autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
-          harnessData: parsed.harnessData ?? null,
+          harnessData: parsed.harnessData
+            ? stripDisabledHarnessSections(parsed.harnessData, disabledSections)
+            : null,
         }),
       });
 
@@ -548,6 +592,18 @@ export default function UploadPage() {
       {/* Step 2: Redaction Review */}
       {step === "redact" && parsed && (
         <div>
+          {/* Report type indicator */}
+          {parsed.reportType === "insight-harness" && (
+            <div className="mb-4 flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-400">
+              <Sparkles className="h-4 w-4 shrink-0" />
+              <span>
+                <strong>Insight Harness report detected</strong> — includes
+                token usage, tool breakdowns, skills, hooks, and more alongside
+                your /insights narrative.
+              </span>
+            </div>
+          )}
+
           <div className="mb-4 flex items-center justify-between">
             <div>
               <h2 className="text-lg font-semibold text-slate-900">
@@ -608,6 +664,39 @@ export default function UploadPage() {
                 );
               })}
             </div>
+
+            {/* Harness section toggles */}
+            {parsed?.harnessData && (
+              <>
+                <h4 className="mb-2 mt-4 text-xs font-semibold text-slate-500">
+                  Harness Sections
+                </h4>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {HARNESS_SECTION_OPTIONS.map(({ key, label }) => {
+                    const disabled = !!disabledSections[key];
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => toggleSection(key)}
+                        className={clsx(
+                          "flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors",
+                          disabled
+                            ? "border-slate-200 bg-slate-50 text-slate-400"
+                            : "border-blue-200 bg-blue-50 text-blue-700",
+                        )}
+                      >
+                        <span>{label}</span>
+                        {disabled ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </>
+            )}
           </div>
 
           {redactions.length === 0 ? (
@@ -770,7 +859,12 @@ export default function UploadPage() {
                 <h3 className="mb-3 text-sm font-semibold text-slate-700">
                   Harness Profile
                 </h3>
-                <HarnessSections harnessData={parsed.harnessData} />
+                <HarnessSections
+                  harnessData={stripDisabledHarnessSections(
+                    parsed.harnessData,
+                    disabledSections,
+                  )}
+                />
               </div>
             )}
           </div>
@@ -924,7 +1018,12 @@ export default function UploadPage() {
               <h3 className="mb-3 text-lg font-semibold text-slate-900">
                 Harness Profile
               </h3>
-              <HarnessSections harnessData={parsed.harnessData} />
+              <HarnessSections
+                harnessData={stripDisabledHarnessSections(
+                  parsed.harnessData,
+                  disabledSections,
+                )}
+              />
             </div>
           )}
 

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -330,3 +330,56 @@ export function normalizeSkills(raw: unknown): SkillKey[] {
   if (!Array.isArray(raw)) return [];
   return raw.filter(isSkillKey);
 }
+
+/**
+ * Validate that an unknown value from the DB (Prisma Json?) looks like
+ * HarnessData. Returns the typed value if it passes, or null if malformed.
+ * Checks for the required top-level keys with correct types.
+ */
+export function normalizeHarnessData(raw: unknown): HarnessData | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+
+  // Check a few required structural keys to confirm it's HarnessData
+  if (typeof obj.stats !== "object" || obj.stats === null) return null;
+  if (typeof obj.autonomy !== "object" || obj.autonomy === null) return null;
+  if (!Array.isArray(obj.featurePills)) return null;
+
+  // Fill in defaults for optional/array fields that may be missing
+  return {
+    stats: obj.stats as HarnessData["stats"],
+    autonomy: obj.autonomy as HarnessData["autonomy"],
+    featurePills: obj.featurePills as HarnessData["featurePills"],
+    toolUsage: (obj.toolUsage as Record<string, number>) ?? {},
+    skillInventory: (obj.skillInventory as HarnessData["skillInventory"]) ?? [],
+    hookDefinitions:
+      (obj.hookDefinitions as HarnessData["hookDefinitions"]) ?? [],
+    hookFrequency: (obj.hookFrequency as Record<string, number>) ?? {},
+    plugins: (obj.plugins as HarnessData["plugins"]) ?? [],
+    harnessFiles: (obj.harnessFiles as string[]) ?? [],
+    fileOpStyle: (obj.fileOpStyle as HarnessData["fileOpStyle"]) ?? {
+      readPct: 0,
+      editPct: 0,
+      writePct: 0,
+      grepCount: 0,
+      globCount: 0,
+      style: "",
+    },
+    agentDispatch: (obj.agentDispatch as HarnessData["agentDispatch"]) ?? null,
+    cliTools: (obj.cliTools as Record<string, number>) ?? {},
+    languages: (obj.languages as Record<string, number>) ?? {},
+    models: (obj.models as Record<string, number>) ?? {},
+    permissionModes: (obj.permissionModes as Record<string, number>) ?? {},
+    mcpServers: (obj.mcpServers as Record<string, number>) ?? {},
+    gitPatterns: (obj.gitPatterns as HarnessData["gitPatterns"]) ?? {
+      prCount: 0,
+      commitCount: 0,
+      linesAdded: "0",
+      branchPrefixes: {},
+    },
+    versions: (obj.versions as string[]) ?? [],
+    writeupSections:
+      (obj.writeupSections as HarnessData["writeupSections"]) ?? [],
+    integrityHash: (obj.integrityHash as string) ?? "",
+  };
+}


### PR DESCRIPTION
## Summary

- Harness reports get "Insight Harness" title (was "Claude Code Insights")
- Blue banner confirms harness report detected during upload review
- 11 harness section toggles (skills, hooks, plugins, etc.) so users control what's published
- `normalizeHarnessData()` validates JSON shape on API boundary and detail page
- PUT route accepts harness fields for editing
- Delete button on own reports in profile page

## Test plan

- [ ] Upload insight-harness — see blue "detected" banner and section toggles
- [ ] Toggle off a harness section — verify it's excluded from published report
- [ ] Upload /insights — no harness banner or toggles appear
- [ ] Delete a report from profile page — confirm dialog, report removed
- [ ] Verify harness report title says "Insight Harness" not "Claude Code Insights"

🤖 Generated with [Claude Code](https://claude.com/claude-code)