### PR TITLE
fix: enable SVG avatars for demo profiles

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: "attachment",
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Next.js Image blocks SVGs by default. Adds `dangerouslyAllowSVG` + `contentDispositionType: "attachment"` so DiceBear avatars render for demo profiles.