### PR TITLE
feat: terminal-style logo and >/ favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1e293b"/>
+  <text x="4" y="23" font-family="ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace" font-size="20" font-weight="700">
+    <tspan fill="#6366f1">&gt;</tspan><tspan fill="#94a3b8">/</tspan>
+  </text>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
   title: "Insight Harness — See How Developers Use Claude Code",
   description:
     "Browse real developer workflows — the tools, skills, plugins, and patterns they use across actual coding sessions. Upload your /insights report and share your profile.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,7 +13,6 @@ import {
   User,
   TrendingUp,
   Home,
-  Sparkles,
   ChevronDown,
   GitFork,
 } from "lucide-react";
@@ -47,14 +46,15 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-50 border-b border-slate-200 bg-white/80 backdrop-blur-lg dark:border-slate-800 dark:bg-slate-950/80">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6">
-        {/* Logo */}
+        {/* Logo — terminal invocation style */}
         <Link
           href="/"
-          className="flex items-center gap-2 text-xl font-bold tracking-tight text-slate-900 dark:text-white"
+          className="flex items-baseline gap-0 font-mono text-lg font-semibold tracking-tight"
         >
-          <Sparkles className="h-6 w-6 text-blue-600" />
-          <span>
-            Insight <span className="text-blue-600">Harness</span>
+          <span className="text-indigo-500">&gt;</span>
+          <span className="text-slate-400 dark:text-slate-500">/</span>
+          <span className="text-slate-900 dark:text-white">
+            insight-harness
           </span>
         </Link>
 


### PR DESCRIPTION
## Summary

- Header logo: monospace `>/insight-harness` with indigo `>`, gray `/`, dark/white text (matches terminal-1/terminal-2 from logo exploration)
- SVG favicon: `>/` mark on navy rounded rectangle (matches terminal-4 badge concept)
- Removed unused Sparkles import

From the logo project at `~/active/logos/` — using the "Dark — Clean" and "Light Mode" featured variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)