### PR TITLE
fix: comprehensive dark mode support across all pages

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="6" fill="#1e293b"/>
-  <text x="4" y="23" font-family="ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace" font-size="20" font-weight="700">
-    <tspan fill="#6366f1">&gt;</tspan><tspan fill="#94a3b8">/</tspan>
+  <rect width="32" height="32" rx="6" fill="#6366f1"/>
+  <text x="3" y="23" font-family="ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace" font-size="20" font-weight="700">
+    <tspan fill="#ffffff">&gt;</tspan><tspan fill="rgba(255,255,255,0.5)">/</tspan>
   </text>
 </svg>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -223,8 +223,8 @@ export default function InsightDetailPage() {
     return (
       <div className="mx-auto max-w-4xl px-4 py-16">
         <div className="space-y-4">
-          <div className="h-8 w-64 animate-pulse rounded bg-slate-200" />
-          <div className="h-4 w-96 animate-pulse rounded bg-slate-200" />
+          <div className="h-8 w-64 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+          <div className="h-4 w-96 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
           <div className="h-64 animate-pulse rounded-xl bg-slate-200" />
         </div>
       </div>
@@ -235,10 +235,10 @@ export default function InsightDetailPage() {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <div className="text-center">
-          <h2 className="mb-2 text-xl font-semibold text-slate-900">
+          <h2 className="mb-2 text-xl font-semibold text-slate-900 dark:text-white">
             Report not found
           </h2>
-          <p className="text-slate-500">
+          <p className="text-slate-500 dark:text-slate-400">
             {error || "This insight report doesn't exist."}
           </p>
           <Link
@@ -270,7 +270,7 @@ export default function InsightDetailPage() {
               className="rounded-full"
             />
           ) : (
-            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-lg font-bold text-blue-600">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-lg font-bold text-blue-600 dark:bg-blue-900 dark:text-blue-400">
               {(report.author.displayName ||
                 report.author.username)[0].toUpperCase()}
             </div>
@@ -279,7 +279,7 @@ export default function InsightDetailPage() {
         <div className="flex-1">
           <Link
             href={`/u/${report.author.username}`}
-            className="font-semibold text-slate-900 hover:text-blue-600"
+            className="font-semibold text-slate-900 hover:text-blue-600 dark:text-white"
           >
             {report.author.displayName || report.author.username}
           </Link>
@@ -296,7 +296,7 @@ export default function InsightDetailPage() {
         </div>
         <button
           onClick={handleShare}
-          className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50"
+          className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
         >
           <Share2 className="h-4 w-4" />
           {copied ? "Copied!" : "Share"}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,10 +140,10 @@ function ProfileCard({
     <Link
       href={`/insights/${insight.slug}`}
       className={clsx(
-        "group block rounded-xl bg-white border transition-all hover:shadow-lg hover:-translate-y-0.5",
+        "group block rounded-xl bg-white dark:bg-slate-900 border transition-all hover:shadow-lg hover:-translate-y-0.5",
         featured
-          ? "border-l-4 border-l-blue-500 border-slate-200 p-6 shadow-md"
-          : "border-slate-200 border-l-[3px] border-l-transparent p-5 shadow-sm hover:border-l-blue-400",
+          ? "border-l-4 border-l-blue-500 border-slate-200 dark:border-slate-700 p-6 shadow-md"
+          : "border-slate-200 dark:border-slate-700 border-l-[3px] border-l-transparent p-5 shadow-sm hover:border-l-blue-400",
       )}
     >
       {/* Header */}
@@ -170,7 +170,7 @@ function ProfileCard({
         <div>
           <div
             className={clsx(
-              "font-bold text-slate-900 group-hover:text-blue-600",
+              "font-bold text-slate-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400",
               featured ? "text-base" : "text-sm",
             )}
           >
@@ -186,24 +186,24 @@ function ProfileCard({
       {/* Stats */}
       <div className="flex flex-wrap gap-x-5 gap-y-1 mb-3">
         {sessionsWk && (
-          <div className="text-xs text-slate-500">
-            <span className="font-extrabold text-sm text-slate-800">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="font-extrabold text-sm text-slate-800 dark:text-slate-200">
               {sessionsWk}
             </span>{" "}
             sessions/wk
           </div>
         )}
         {msgsWk && (
-          <div className="text-xs text-slate-500">
-            <span className="font-extrabold text-sm text-slate-800">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="font-extrabold text-sm text-slate-800 dark:text-slate-200">
               {msgsWk}
             </span>{" "}
             messages/wk
           </div>
         )}
         {commitsWk && (
-          <div className="text-xs text-slate-500">
-            <span className="font-extrabold text-sm text-slate-800">
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            <span className="font-extrabold text-sm text-slate-800 dark:text-slate-200">
               {commitsWk}
             </span>{" "}
             commits/wk
@@ -222,16 +222,16 @@ function ProfileCard({
 
       {/* Key pattern */}
       {keyPattern && (
-        <p className="text-xs italic text-slate-500 truncate">
+        <p className="text-xs italic text-slate-500 dark:text-slate-400 truncate">
           &ldquo;{keyPattern}&rdquo;
         </p>
       )}
 
       {/* Strengths (featured only) */}
       {featured && insight.atAGlance && (
-        <div className="mt-3 pt-3 border-t border-slate-100">
-          <p className="text-xs text-slate-500 line-clamp-2">
-            <strong className="text-slate-600">
+        <div className="mt-3 pt-3 border-t border-slate-100 dark:border-slate-800">
+          <p className="text-xs text-slate-500 dark:text-slate-400 line-clamp-2">
+            <strong className="text-slate-600 dark:text-slate-300">
               {copy.profiles.strengthsLabel}
             </strong>{" "}
             {(insight.atAGlance as Record<string, string>).whats_working}
@@ -282,14 +282,14 @@ export default function HomePage() {
   const grid = insights.slice(1, 7);
 
   return (
-    <div className="min-h-screen bg-slate-50">
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
       {/* Hero */}
       <section className="py-12 text-center">
         <div className="mx-auto max-w-2xl px-4">
-          <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 sm:text-4xl">
+          <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white sm:text-4xl">
             {copy.hero.headline}
           </h1>
-          <p className="mt-3 text-base text-slate-500 sm:text-lg">
+          <p className="mt-3 text-base text-slate-500 dark:text-slate-400 sm:text-lg">
             {copy.hero.subtext}
           </p>
           <div className="mt-6 flex items-center justify-center gap-3">
@@ -301,7 +301,7 @@ export default function HomePage() {
             </a>
             <Link
               href="/upload"
-              className="inline-flex items-center gap-2 rounded-lg border-2 border-blue-600 px-5 py-2.5 text-sm font-semibold text-blue-600 hover:bg-blue-50 transition-colors"
+              className="inline-flex items-center gap-2 rounded-lg border-2 border-blue-600 px-5 py-2.5 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-950/30 transition-colors"
             >
               <Upload className="h-4 w-4" />
               {copy.hero.secondaryCta}
@@ -314,7 +314,7 @@ export default function HomePage() {
       <section id="profiles" className="mx-auto max-w-5xl px-4 pb-12 sm:px-6">
         {/* Sort Tabs */}
         <div className="mb-6 flex items-center gap-4">
-          <div className="inline-flex items-center gap-1 rounded-xl bg-slate-100 p-1">
+          <div className="inline-flex items-center gap-1 rounded-xl bg-slate-100 dark:bg-slate-800 p-1">
             {sortOptions.map(({ value, label, icon: Icon }) => (
               <button
                 key={value}
@@ -322,8 +322,8 @@ export default function HomePage() {
                 className={clsx(
                   "flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-all",
                   sort === value
-                    ? "bg-white text-slate-900 shadow-sm"
-                    : "text-slate-500 hover:text-slate-700",
+                    ? "bg-white dark:bg-slate-700 text-slate-900 dark:text-white shadow-sm"
+                    : "text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300",
                 )}
               >
                 <Icon className="h-4 w-4" />
@@ -338,17 +338,17 @@ export default function HomePage() {
             {Array.from({ length: 6 }).map((_, i) => (
               <div
                 key={i}
-                className="animate-pulse rounded-xl bg-white border border-slate-200 p-5"
+                className="animate-pulse rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-5"
               >
                 <div className="flex items-center gap-3 mb-3">
-                  <div className="h-9 w-9 rounded-full bg-slate-200" />
-                  <div className="h-4 w-24 rounded bg-slate-200" />
+                  <div className="h-9 w-9 rounded-full bg-slate-200 dark:bg-slate-700" />
+                  <div className="h-4 w-24 rounded bg-slate-200 dark:bg-slate-700" />
                 </div>
-                <div className="h-3 w-3/4 rounded bg-slate-100 mb-2" />
-                <div className="h-3 w-1/2 rounded bg-slate-100 mb-3" />
+                <div className="h-3 w-3/4 rounded bg-slate-100 dark:bg-slate-800 mb-2" />
+                <div className="h-3 w-1/2 rounded bg-slate-100 dark:bg-slate-800 mb-3" />
                 <div className="flex gap-2">
-                  <div className="h-5 w-20 rounded bg-slate-100" />
-                  <div className="h-5 w-16 rounded bg-slate-100" />
+                  <div className="h-5 w-20 rounded bg-slate-100 dark:bg-slate-800" />
+                  <div className="h-5 w-16 rounded bg-slate-100 dark:bg-slate-800" />
                 </div>
               </div>
             ))}
@@ -358,7 +358,7 @@ export default function HomePage() {
             {/* Featured */}
             {featured && (
               <div className="mb-6">
-                <div className="mb-2 text-xs font-bold uppercase tracking-widest text-slate-400">
+                <div className="mb-2 text-xs font-bold uppercase tracking-widest text-slate-400 dark:text-slate-500">
                   {copy.profiles.featuredLabel}
                 </div>
                 <ProfileCard insight={featured} featured />
@@ -368,7 +368,7 @@ export default function HomePage() {
             {/* Grid */}
             {grid.length > 0 && (
               <>
-                <h2 className="mb-4 text-lg font-bold text-slate-900">
+                <h2 className="mb-4 text-lg font-bold text-slate-900 dark:text-white">
                   {copy.profiles.recentHeading}
                 </h2>
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -381,10 +381,12 @@ export default function HomePage() {
           </>
         ) : (
           <div className="flex flex-col items-center justify-center py-20">
-            <h2 className="text-xl font-semibold text-slate-900 mb-2">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white mb-2">
               {copy.profiles.emptyTitle}
             </h2>
-            <p className="text-slate-500 mb-6">{copy.profiles.emptySubtext}</p>
+            <p className="text-slate-500 dark:text-slate-400 mb-6">
+              {copy.profiles.emptySubtext}
+            </p>
             <Link
               href="/upload"
               className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-medium text-white hover:bg-blue-700"
@@ -397,57 +399,66 @@ export default function HomePage() {
 
       {/* Harness Profile Upgrade */}
       <section className="mx-auto max-w-5xl px-4 pb-12 sm:px-6">
-        <div className="rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-8 shadow-sm">
           <div className="flex items-start gap-3 mb-5">
             <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 text-white text-lg">
               ⚡
             </div>
             <div>
-              <h3 className="text-lg font-bold text-slate-900">
+              <h3 className="text-lg font-bold text-slate-900 dark:text-white">
                 {copy.upgrade.heading}{" "}
-                <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm text-slate-600">
+                <code className="rounded bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 text-sm text-slate-600 dark:text-slate-300">
                   {copy.upgrade.skillName}
                 </code>
               </h3>
-              <p className="mt-1 text-sm text-slate-500">
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
                 {copy.upgrade.description}
               </p>
             </div>
           </div>
 
           {/* Comparison table */}
-          <div className="mb-6 overflow-hidden rounded-lg border border-slate-200">
+          <div className="mb-6 overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-slate-50">
+                <tr className="bg-slate-50 dark:bg-slate-800">
                   <th className="px-4 py-2.5 text-left text-xs font-bold uppercase tracking-wider text-slate-400">
                     {copy.upgrade.table.headers.feature}
                   </th>
                   <th className="px-4 py-2.5 text-center text-xs font-bold uppercase tracking-wider text-slate-400">
                     {copy.upgrade.table.headers.insights}
                   </th>
-                  <th className="px-4 py-2.5 text-center text-xs font-bold uppercase tracking-wider text-blue-600 bg-blue-50">
+                  <th className="px-4 py-2.5 text-center text-xs font-bold uppercase tracking-wider text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30">
                     {copy.upgrade.table.headers.harness}
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-100">
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
                 {copy.upgrade.table.shared.map((feature) => (
                   <tr key={feature}>
-                    <td className="px-4 py-2 text-slate-600">{feature}</td>
-                    <td className="px-4 py-2 text-center text-green-600">✓</td>
-                    <td className="px-4 py-2 text-center text-green-600 bg-blue-50/30">
+                    <td className="px-4 py-2 text-slate-600 dark:text-slate-300">
+                      {feature}
+                    </td>
+                    <td className="px-4 py-2 text-center text-green-600 dark:text-green-400">
+                      ✓
+                    </td>
+                    <td className="px-4 py-2 text-center text-green-600 dark:text-green-400 bg-blue-50/30 dark:bg-blue-950/20">
                       ✓
                     </td>
                   </tr>
                 ))}
                 {copy.upgrade.table.harnessOnly.map((feature) => (
-                  <tr key={feature} className="bg-slate-50/50">
-                    <td className="px-4 py-2 text-slate-700 font-medium">
+                  <tr
+                    key={feature}
+                    className="bg-slate-50/50 dark:bg-slate-800/50"
+                  >
+                    <td className="px-4 py-2 text-slate-700 dark:text-slate-200 font-medium">
                       {feature}
                     </td>
-                    <td className="px-4 py-2 text-center text-slate-300">—</td>
-                    <td className="px-4 py-2 text-center text-green-600 bg-blue-50/30 font-semibold">
+                    <td className="px-4 py-2 text-center text-slate-300 dark:text-slate-600">
+                      —
+                    </td>
+                    <td className="px-4 py-2 text-center text-green-600 dark:text-green-400 bg-blue-50/30 dark:bg-blue-950/20 font-semibold">
                       ✓
                     </td>
                   </tr>
@@ -458,21 +469,21 @@ export default function HomePage() {
 
           {/* Install + copy */}
           <div className="grid gap-4 sm:grid-cols-2">
-            <div className="rounded-lg bg-slate-50 border border-slate-200 p-4">
-              <div className="text-xs font-bold text-slate-600 mb-2">
+            <div className="rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-4">
+              <div className="text-xs font-bold text-slate-600 dark:text-slate-300 mb-2">
                 {copy.upgrade.installTitle}
               </div>
               <CopyBlock text={copy.upgrade.installCommand} />
               <p className="mt-2 text-[11px] text-slate-400">
                 {copy.upgrade.installHint}{" "}
-                <code className="bg-slate-200 px-1 rounded text-[10px]">
+                <code className="bg-slate-200 dark:bg-slate-700 px-1 rounded text-[10px]">
                   {copy.upgrade.installSlashCommand}
                 </code>{" "}
                 {copy.upgrade.installSuffix}
               </p>
             </div>
-            <div className="rounded-lg bg-slate-50 border border-slate-200 p-4">
-              <div className="text-xs font-bold text-slate-600 mb-2">
+            <div className="rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 p-4">
+              <div className="text-xs font-bold text-slate-600 dark:text-slate-300 mb-2">
                 {copy.upgrade.promptTitle}
               </div>
               <CopyBlock text={copy.upgrade.promptCommand} />
@@ -499,34 +510,38 @@ export default function HomePage() {
 
       {/* How It Works */}
       <section className="mx-auto max-w-5xl px-4 pb-16 sm:px-6">
-        <h2 className="mb-6 text-center text-lg font-bold text-slate-900">
+        <h2 className="mb-6 text-center text-lg font-bold text-slate-900 dark:text-white">
           {copy.howItWorks.heading}
         </h2>
         <div className="grid gap-5 sm:grid-cols-3">
           {copy.howItWorks.steps.map((step, i) => (
             <div
               key={i}
-              className="rounded-xl bg-white border border-slate-200 p-6 text-center shadow-sm"
+              className="rounded-xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 p-6 text-center shadow-sm"
             >
               <div className="mb-3 text-3xl">{step.icon}</div>
-              <div className="mb-1 text-xs font-bold uppercase tracking-widest text-blue-600">
+              <div className="mb-1 text-xs font-bold uppercase tracking-widest text-blue-600 dark:text-blue-400">
                 Step {i + 1}
               </div>
-              <h4 className="mb-2 text-sm font-bold text-slate-900">
+              <h4 className="mb-2 text-sm font-bold text-slate-900 dark:text-white">
                 {step.title}
               </h4>
-              <p className="text-xs text-slate-500">{step.description}</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                {step.description}
+              </p>
             </div>
           ))}
         </div>
       </section>
 
       {/* Footer CTA */}
-      <section className="bg-blue-50 py-12 text-center">
-        <h2 className="text-xl font-extrabold text-slate-900">
+      <section className="bg-blue-50 dark:bg-blue-950/30 py-12 text-center">
+        <h2 className="text-xl font-extrabold text-slate-900 dark:text-white">
           {copy.footerCta.heading}
         </h2>
-        <p className="mt-2 text-sm text-slate-500">{copy.footerCta.subtext}</p>
+        <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+          {copy.footerCta.subtext}
+        </p>
         <Link
           href="/upload"
           className="mt-5 inline-flex items-center gap-2 rounded-lg bg-blue-600 px-7 py-3 text-base font-semibold text-white hover:bg-blue-700 transition-colors"

--- a/src/app/u/[username]/page.tsx
+++ b/src/app/u/[username]/page.tsx
@@ -502,7 +502,7 @@ export default function UserProfilePage() {
                 <button
                   onClick={() => handleDelete(report.slug)}
                   disabled={deleting === report.slug}
-                  className="absolute right-3 top-3 rounded-lg border border-slate-200 bg-white/90 p-1.5 text-slate-400 opacity-0 transition-all hover:border-red-300 hover:bg-red-50 hover:text-red-600 group-hover:opacity-100 [div:hover>&]:opacity-100 dark:border-slate-700 dark:bg-slate-900/90"
+                  className="absolute right-3 top-3 rounded-lg border border-slate-200 bg-white/90 p-1.5 text-slate-400 opacity-0 transition-all hover:border-red-300 hover:bg-red-50 hover:text-red-600 dark:hover:border-red-700 dark:hover:bg-red-950/50 dark:hover:text-red-400 group-hover:opacity-100 [div:hover>&]:opacity-100 dark:border-slate-700 dark:bg-slate-900/90"
                   title="Delete report"
                 >
                   {deleting === report.slug ? (

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -470,10 +470,10 @@ export default function UploadPage() {
       <div className="flex min-h-[60vh] items-center justify-center">
         <div className="text-center">
           <Upload className="mx-auto mb-4 h-12 w-12 text-slate-400" />
-          <h2 className="mb-2 text-xl font-semibold text-slate-900">
+          <h2 className="mb-2 text-xl font-semibold text-slate-900 dark:text-white">
             Sign in to share your insights
           </h2>
-          <p className="text-slate-500">
+          <p className="text-slate-500 dark:text-slate-400">
             You need to be logged in to upload insights.
           </p>
         </div>
@@ -483,10 +483,10 @@ export default function UploadPage() {
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
-      <h1 className="mb-2 text-2xl font-bold text-slate-900">
+      <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
         Share Your Insights
       </h1>
-      <p className="mb-8 text-slate-500">
+      <p className="mb-8 text-slate-500 dark:text-slate-400">
         Upload your Claude Code insights report and share it with the community.
       </p>
 
@@ -502,8 +502,8 @@ export default function UploadPage() {
                 i === stepIndex
                   ? "bg-blue-600 text-white"
                   : i < stepIndex
-                    ? "bg-blue-100 text-blue-700 hover:bg-blue-200"
-                    : "bg-slate-100 text-slate-400",
+                    ? "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50"
+                    : "bg-slate-100 dark:bg-slate-800 text-slate-400",
               )}
             >
               {i < stepIndex ? <Check className="h-4 w-4" /> : s.icon}
@@ -513,7 +513,9 @@ export default function UploadPage() {
               <div
                 className={clsx(
                   "h-px w-8",
-                  i < stepIndex ? "bg-blue-300" : "bg-slate-200",
+                  i < stepIndex
+                    ? "bg-blue-300 dark:bg-blue-700"
+                    : "bg-slate-200 dark:bg-slate-700",
                 )}
               />
             )}
@@ -523,10 +525,10 @@ export default function UploadPage() {
 
       {/* Sticky navigation — visible on all steps except upload */}
       {step !== "upload" && (
-        <div className="sticky top-16 z-40 -mx-4 mb-6 flex items-center justify-between border-b border-slate-200 bg-white/95 px-4 py-3 backdrop-blur-sm">
+        <div className="sticky top-16 z-40 -mx-4 mb-6 flex items-center justify-between border-b border-slate-200 dark:border-slate-700 bg-white/95 dark:bg-slate-900/95 px-4 py-3 backdrop-blur-sm">
           <button
             onClick={() => setStep(steps[stepIndex - 1]?.key || "upload")}
-            className="flex items-center gap-2 rounded-lg border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:bg-slate-50"
+            className="flex items-center gap-2 rounded-lg border border-slate-200 dark:border-slate-700 px-4 py-2 text-sm font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
           >
             <ArrowLeft className="h-4 w-4" />
             Back
@@ -552,7 +554,7 @@ export default function UploadPage() {
       )}
 
       {error && (
-        <div className="mb-6 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-6 flex items-center gap-2 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 px-4 py-3 text-sm text-red-700 dark:text-red-400">
           <AlertTriangle className="h-4 w-4 shrink-0" />
           {error}
         </div>
@@ -571,14 +573,16 @@ export default function UploadPage() {
           className={clsx(
             "flex min-h-[300px] cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 transition-colors",
             dragOver
-              ? "border-blue-400 bg-blue-50"
-              : "border-slate-300 bg-slate-50 hover:border-slate-400",
+              ? "border-blue-400 bg-blue-50 dark:bg-blue-950/30"
+              : "border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-800/50 hover:border-slate-400 dark:hover:border-slate-500",
           )}
         >
           {loading ? (
             <div className="text-center">
               <div className="mx-auto mb-4 h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
-              <p className="text-slate-600">Parsing your insights...</p>
+              <p className="text-slate-600 dark:text-slate-300">
+                Parsing your insights...
+              </p>
             </div>
           ) : (
             <DropZoneContent
@@ -606,10 +610,10 @@ export default function UploadPage() {
 
           <div className="mb-4 flex items-center justify-between">
             <div>
-              <h2 className="text-lg font-semibold text-slate-900">
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
                 Review Detected Sensitive Data
               </h2>
-              <p className="text-sm text-slate-500">
+              <p className="text-sm text-slate-500 dark:text-slate-400">
                 {redactions.length} items detected. Choose what to redact before
                 sharing.
               </p>
@@ -617,13 +621,13 @@ export default function UploadPage() {
             <div className="flex gap-2">
               <button
                 onClick={applyAllRedactions}
-                className="rounded-lg bg-red-100 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-200"
+                className="rounded-lg bg-red-100 dark:bg-red-900/30 px-3 py-1.5 text-sm font-medium text-red-700 dark:text-red-400 hover:bg-red-200 dark:hover:bg-red-900/50"
               >
                 Redact All
               </button>
               <button
                 onClick={keepAll}
-                className="rounded-lg bg-green-100 px-3 py-1.5 text-sm font-medium text-green-700 hover:bg-green-200"
+                className="rounded-lg bg-green-100 dark:bg-green-900/30 px-3 py-1.5 text-sm font-medium text-green-700 dark:text-green-400 hover:bg-green-200 dark:hover:bg-green-900/50"
               >
                 Keep All
               </button>
@@ -631,11 +635,11 @@ export default function UploadPage() {
           </div>
 
           {/* Section Toggles */}
-          <div className="mb-6 rounded-lg border border-slate-200 bg-white p-4">
-            <h3 className="mb-3 text-sm font-semibold text-slate-700">
+          <div className="mb-6 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4">
+            <h3 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">
               Include/Exclude Sections
             </h3>
-            <p className="mb-3 text-xs text-slate-500">
+            <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
               Toggle off any sections you don&apos;t want to share publicly.
             </p>
             <div className="grid gap-2 sm:grid-cols-2">
@@ -650,8 +654,8 @@ export default function UploadPage() {
                     className={clsx(
                       "flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors",
                       disabled
-                        ? "border-slate-200 bg-slate-50 text-slate-400"
-                        : "border-green-200 bg-green-50 text-green-700",
+                        ? "border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-slate-400"
+                        : "border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30 text-green-700 dark:text-green-400",
                     )}
                   >
                     <span>{label}</span>
@@ -668,7 +672,7 @@ export default function UploadPage() {
             {/* Harness section toggles */}
             {parsed?.harnessData && (
               <>
-                <h4 className="mb-2 mt-4 text-xs font-semibold text-slate-500">
+                <h4 className="mb-2 mt-4 text-xs font-semibold text-slate-500 dark:text-slate-400">
                   Harness Sections
                 </h4>
                 <div className="grid gap-2 sm:grid-cols-2">
@@ -681,8 +685,8 @@ export default function UploadPage() {
                         className={clsx(
                           "flex items-center justify-between rounded-lg border px-3 py-2 text-sm font-medium transition-colors",
                           disabled
-                            ? "border-slate-200 bg-slate-50 text-slate-400"
-                            : "border-blue-200 bg-blue-50 text-blue-700",
+                            ? "border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50 text-slate-400"
+                            : "border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/30 text-blue-700 dark:text-blue-400",
                         )}
                       >
                         <span>{label}</span>
@@ -700,9 +704,9 @@ export default function UploadPage() {
           </div>
 
           {redactions.length === 0 ? (
-            <div className="rounded-lg border border-green-200 bg-green-50 p-6 text-center">
-              <Check className="mx-auto mb-2 h-8 w-8 text-green-600" />
-              <p className="text-green-700">
+            <div className="rounded-lg border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30 p-6 text-center">
+              <Check className="mx-auto mb-2 h-8 w-8 text-green-600 dark:text-green-400" />
+              <p className="text-green-700 dark:text-green-400">
                 No sensitive data detected. Your report looks clean!
               </p>
             </div>
@@ -714,10 +718,10 @@ export default function UploadPage() {
                   className={clsx(
                     "rounded-lg border p-4",
                     item.action === "redact"
-                      ? "border-red-200 bg-red-50"
+                      ? "border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30"
                       : item.action === "alias"
-                        ? "border-amber-200 bg-amber-50"
-                        : "border-green-200 bg-green-50",
+                        ? "border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-950/30"
+                        : "border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-950/30",
                   )}
                 >
                   <div className="mb-2 flex items-start justify-between">
@@ -726,20 +730,25 @@ export default function UploadPage() {
                         className={clsx(
                           "mb-1 inline-block rounded px-2 py-0.5 text-xs font-medium",
                           {
-                            project_name: "bg-purple-100 text-purple-700",
-                            file_path: "bg-blue-100 text-blue-700",
-                            github_url: "bg-slate-100 text-slate-700",
-                            email: "bg-amber-100 text-amber-700",
-                            code_snippet: "bg-teal-100 text-teal-700",
+                            project_name:
+                              "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400",
+                            file_path:
+                              "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400",
+                            github_url:
+                              "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200",
+                            email:
+                              "bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400",
+                            code_snippet:
+                              "bg-teal-100 dark:bg-teal-900/30 text-teal-700 dark:text-teal-400",
                           }[item.type],
                         )}
                       >
                         {item.type.replace("_", " ")}
                       </span>
-                      <p className="font-mono text-sm text-slate-900">
+                      <p className="font-mono text-sm text-slate-900 dark:text-white">
                         {item.text}
                       </p>
-                      <p className="mt-1 text-xs text-slate-500">
+                      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                         ...{item.context}...
                       </p>
                     </div>
@@ -750,7 +759,7 @@ export default function UploadPage() {
                           "rounded px-2.5 py-1 text-xs font-medium transition-colors",
                           item.action === "redact"
                             ? "bg-red-600 text-white"
-                            : "bg-slate-100 text-slate-600 hover:bg-red-100",
+                            : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-red-100 dark:hover:bg-red-900/30",
                         )}
                       >
                         <EyeOff className="inline h-3 w-3" /> Redact
@@ -767,7 +776,7 @@ export default function UploadPage() {
                           "rounded px-2.5 py-1 text-xs font-medium transition-colors",
                           item.action === "alias"
                             ? "bg-amber-600 text-white"
-                            : "bg-slate-100 text-slate-600 hover:bg-amber-100",
+                            : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-amber-100 dark:hover:bg-amber-900/30",
                         )}
                       >
                         Alias
@@ -778,7 +787,7 @@ export default function UploadPage() {
                           "rounded px-2.5 py-1 text-xs font-medium transition-colors",
                           item.action === "keep"
                             ? "bg-green-600 text-white"
-                            : "bg-slate-100 text-slate-600 hover:bg-green-100",
+                            : "bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-green-100 dark:hover:bg-green-900/30",
                         )}
                       >
                         <Eye className="inline h-3 w-3" /> Keep
@@ -786,7 +795,7 @@ export default function UploadPage() {
                     </div>
                   </div>
                   {item.action === "alias" && item.alias && (
-                    <p className="mt-2 text-xs text-amber-700">
+                    <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">
                       Will be replaced with: <strong>{item.alias}</strong>
                     </p>
                   )}
@@ -797,10 +806,10 @@ export default function UploadPage() {
 
           {/* Styled preview — matches how it will look when published */}
           <div className="mt-8">
-            <h3 className="mb-2 text-sm font-semibold text-slate-700">
+            <h3 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-200">
               Preview: How your report will appear
             </h3>
-            <p className="mb-4 text-xs text-slate-500">
+            <p className="mb-4 text-xs text-slate-500 dark:text-slate-400">
               This is what others will see. Review carefully before publishing.
             </p>
             <SnapshotCard
@@ -856,7 +865,7 @@ export default function UploadPage() {
             {/* Harness sections preview */}
             {parsed.harnessData && (
               <div className="mt-4">
-                <h3 className="mb-3 text-sm font-semibold text-slate-700">
+                <h3 className="mb-3 text-sm font-semibold text-slate-700 dark:text-slate-200">
                   Harness Profile
                 </h3>
                 <HarnessSections
@@ -874,10 +883,10 @@ export default function UploadPage() {
       {/* Step 3: Project Links */}
       {step === "projects" && (
         <div>
-          <h2 className="mb-2 text-lg font-semibold text-slate-900">
+          <h2 className="mb-2 text-lg font-semibold text-slate-900 dark:text-white">
             Add Project Links (Optional)
           </h2>
-          <p className="mb-6 text-sm text-slate-500">
+          <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
             Link projects you&apos;re building to showcase them alongside your
             insights.
           </p>
@@ -885,11 +894,13 @@ export default function UploadPage() {
           {projectLinks.map((link, i) => (
             <div
               key={i}
-              className="mb-3 flex items-center gap-3 rounded-lg border border-slate-200 bg-white p-3"
+              className="mb-3 flex items-center gap-3 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3"
             >
               <div className="flex-1">
-                <p className="font-medium text-slate-900">{link.name}</p>
-                <p className="text-xs text-slate-500">
+                <p className="font-medium text-slate-900 dark:text-white">
+                  {link.name}
+                </p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
                   {link.githubUrl || link.liveUrl || "No URL"}
                 </p>
               </div>
@@ -902,7 +913,7 @@ export default function UploadPage() {
             </div>
           ))}
 
-          <div className="rounded-lg border border-slate-200 bg-white p-4">
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4">
             <div className="grid gap-3">
               <input
                 placeholder="Project name"
@@ -910,7 +921,7 @@ export default function UploadPage() {
                 onChange={(e) =>
                   setNewLink({ ...newLink, name: e.target.value })
                 }
-                className="rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none"
+                className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:border-blue-400 focus:outline-none"
               />
               <input
                 placeholder="GitHub URL (optional)"
@@ -918,7 +929,7 @@ export default function UploadPage() {
                 onChange={(e) =>
                   setNewLink({ ...newLink, githubUrl: e.target.value })
                 }
-                className="rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none"
+                className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:border-blue-400 focus:outline-none"
               />
               <input
                 placeholder="Live URL (optional)"
@@ -926,7 +937,7 @@ export default function UploadPage() {
                 onChange={(e) =>
                   setNewLink({ ...newLink, liveUrl: e.target.value })
                 }
-                className="rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none"
+                className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:border-blue-400 focus:outline-none"
               />
               <input
                 placeholder="Short description (optional)"
@@ -934,7 +945,7 @@ export default function UploadPage() {
                 onChange={(e) =>
                   setNewLink({ ...newLink, description: e.target.value })
                 }
-                className="rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-blue-400 focus:outline-none"
+                className="rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-slate-900 dark:text-white placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:border-blue-400 focus:outline-none"
               />
               <button
                 onClick={addProjectLink}
@@ -952,10 +963,10 @@ export default function UploadPage() {
       {/* Step 4: Preview — shows exactly how the published page will look */}
       {step === "preview" && parsed && (
         <div>
-          <h2 className="mb-2 text-lg font-semibold text-slate-900">
+          <h2 className="mb-2 text-lg font-semibold text-slate-900 dark:text-white">
             Final Preview
           </h2>
-          <p className="mb-6 text-sm text-slate-500">
+          <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
             This is exactly how your report will appear. Hit Publish when ready.
           </p>
 
@@ -1015,7 +1026,7 @@ export default function UploadPage() {
           {/* Harness sections preview */}
           {parsed.harnessData && (
             <div className="mt-4">
-              <h3 className="mb-3 text-lg font-semibold text-slate-900">
+              <h3 className="mb-3 text-lg font-semibold text-slate-900 dark:text-white">
                 Harness Profile
               </h3>
               <HarnessSections

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -251,61 +251,69 @@ export const SKILL_METADATA: Record<SkillKey, SkillMetadata> = {
     key: "parallel_agents",
     label: "Parallel Agents",
     icon: "🔀",
-    colorClass: "bg-violet-100 text-violet-700",
+    colorClass:
+      "bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400",
   },
   worktrees: {
     key: "worktrees",
     label: "Worktrees",
     icon: "🌳",
-    colorClass: "bg-green-100 text-green-700",
+    colorClass:
+      "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
   },
   custom_skills: {
     key: "custom_skills",
     label: "Custom Skills",
     icon: "⚡",
-    colorClass: "bg-amber-100 text-amber-700",
+    colorClass:
+      "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
   },
   hooks: {
     key: "hooks",
     label: "Hooks",
     icon: "🪝",
-    colorClass: "bg-sky-100 text-sky-700",
+    colorClass: "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400",
   },
   mcp_servers: {
     key: "mcp_servers",
     label: "MCP Servers",
     icon: "🔌",
-    colorClass: "bg-slate-100 text-slate-700",
+    colorClass:
+      "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
   },
   playwright: {
     key: "playwright",
     label: "Playwright",
     icon: "🎭",
-    colorClass: "bg-pink-100 text-pink-700",
+    colorClass:
+      "bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-400",
   },
   headless_mode: {
     key: "headless_mode",
     label: "Headless Mode",
     icon: "🤖",
-    colorClass: "bg-indigo-100 text-indigo-700",
+    colorClass:
+      "bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-400",
   },
   plan_mode: {
     key: "plan_mode",
     label: "Plan Mode",
     icon: "📋",
-    colorClass: "bg-emerald-100 text-emerald-700",
+    colorClass:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
   },
   code_review: {
     key: "code_review",
     label: "Code Review",
     icon: "📝",
-    colorClass: "bg-red-100 text-red-700",
+    colorClass: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
   },
   subagents: {
     key: "subagents",
     label: "Subagents",
     icon: "🧩",
-    colorClass: "bg-teal-100 text-teal-700",
+    colorClass:
+      "bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400",
   },
 };
 


### PR DESCRIPTION
## Summary

Full dark mode audit and fix across all pages. Two pages were critically broken (zero dark mode support), now fully fixed.

| Page | Elements Fixed |
|------|---------------|
| Homepage | ~35 — page bg, hero, sort tabs, cards, skeleton, upgrade section, how-it-works |
| Upload page | ~40 — drop zone, step indicators, nav, redaction cards, toggles, form inputs |
| Detail page | 5 — loading skeletons, error state, author bar, share button |
| Profile page | 1 — delete button hover |
| Skill badges | 10 — all SKILL_METADATA colorClasses |

Also: favicon updated to indigo bg + white `>/` for better visibility in browser tabs.

## Test plan

- [ ] Toggle dark mode and check homepage — cards, tabs, hero, upgrade section
- [ ] Toggle dark mode and check upload flow — drop zone, redaction review, toggles, form inputs
- [ ] Check detail page in dark mode — author bar, share button, harness sections
- [ ] Check skill badges render correctly in dark mode
- [ ] Verify favicon is visible in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)