### PR TITLE
Fix report review visibility and publish UX

### DIFF
--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -102,7 +102,8 @@ export async function GET(request: Request) {
         ).length;
       }
 
-      const { votes: _votes, ...rest } = report;
+      const { votes: ignoredVotes, ...rest } = report;
+      void ignoredVotes;
       return {
         ...rest,
         voteCounts,
@@ -143,9 +144,22 @@ export async function GET(request: Request) {
       scored.sort((a, b) => b._trendingScore - a._trendingScore);
       results = scored
         .slice(skip, skip + limit)
-        .map(({ _trendingVotes, _trendingScore, ...rest }) => rest);
+        .map((result) => {
+          const {
+            _trendingVotes: ignoredTrendingVotes,
+            _trendingScore: ignoredTrendingScore,
+            ...rest
+          } = result;
+          void ignoredTrendingVotes;
+          void ignoredTrendingScore;
+          return rest;
+        });
     } else {
-      results = mapped.map(({ _trendingVotes, ...rest }) => rest);
+      results = mapped.map((result) => {
+        const { _trendingVotes: ignoredTrendingVotes, ...rest } = result;
+        void ignoredTrendingVotes;
+        return rest;
+      });
     }
 
     return NextResponse.json({
@@ -215,6 +229,7 @@ export async function POST(request: Request) {
       prCount,
       autonomyLabel,
       harnessData,
+      hiddenHarnessSections,
     } = body;
 
     // Auto-generate title if not provided
@@ -259,6 +274,8 @@ export async function POST(request: Request) {
           (normalizeHarnessData(
             harnessData,
           ) as unknown as Prisma.InputJsonValue) ?? undefined,
+        hiddenHarnessSections:
+          Array.isArray(hiddenHarnessSections) ? hiddenHarnessSections : [],
         ...(Array.isArray(projectLinks) && projectLinks.length > 0
           ? {
               projectLinks: {

--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -7,14 +7,21 @@ import { Eye, EyeOff, ArrowLeft, AlertTriangle } from "lucide-react";
 import type { HarnessData } from "@/types/insights";
 import { normalizeHarnessData } from "@/types/insights";
 import HeroStats from "@/components/HeroStats";
+import ActivityHeatmap from "@/components/ActivityHeatmap";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
-
+import CliToolsDonut from "@/components/CliToolsDonut";
+import GitPatternsDisplay from "@/components/GitPatternsDisplay";
+import PermissionModeDisplay from "@/components/PermissionModeDisplay";
+import HooksSafetyTable from "@/components/HooksSafetyTable";
+import ProjectLinks from "@/components/ProjectLinks";
+import MiniBarChart from "@/components/MiniBarChart";
 import CollapsibleSection from "@/components/CollapsibleSection";
 import SectionRenderer from "@/components/SectionRenderer";
 import Link from "next/link";
+import { getHiddenHarnessSections } from "@/lib/harness-section-visibility";
 
 interface ReportData {
   id: string;
@@ -29,6 +36,7 @@ interface ReportData {
   totalTokens: number | null;
   durationHours: number | null;
   harnessData: HarnessData | null;
+  hiddenHarnessSections: string[];
   atAGlance: unknown;
   interactionStyle: unknown;
   projectAreas: unknown;
@@ -37,6 +45,13 @@ interface ReportData {
   suggestions: unknown;
   onTheHorizon: unknown;
   author: { id: string; username: string; displayName: string | null };
+  projectLinks: Array<{
+    id: string;
+    name: string;
+    githubUrl: string | null;
+    liveUrl: string | null;
+    description: string | null;
+  }>;
 }
 
 // Section config for narrative sections
@@ -83,6 +98,31 @@ function EyeToggle({
   );
 }
 
+function HideableCard({
+  title,
+  hidden,
+  onToggle,
+  children,
+}: {
+  title: string;
+  hidden: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={hidden ? "opacity-40" : ""}>
+      <div className="mb-1 flex items-center gap-2">
+        <EyeToggle enabled={!hidden} onToggle={onToggle} />
+        <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
+          {title}
+        </span>
+        {hidden && <span className="text-xs text-red-500">Will be removed</span>}
+      </div>
+      {!hidden && children}
+    </div>
+  );
+}
+
 export default function EditReportPage() {
   const { slug } = useParams<{ slug: string }>();
   const router = useRouter();
@@ -112,6 +152,11 @@ export default function EditReportPage() {
             ? normalizeHarnessData(r.harnessData)
             : null;
           setReport(r);
+          setHiddenSections(
+            Object.fromEntries(
+              (r.hiddenHarnessSections ?? []).map((key: string) => [key, true]),
+            ),
+          );
         }
         setLoading(false);
       })
@@ -135,13 +180,7 @@ export default function EditReportPage() {
       }
     }
 
-    // Handle harness sub-section visibility via dedicated allowlisted field
-    const hiddenHarness = Object.entries(hiddenSections)
-      .filter(([key, hidden]) => hidden && key === "workflowData")
-      .map(([key]) => key);
-    if (hiddenHarness.length > 0) {
-      body.hiddenHarnessSections = hiddenHarness;
-    }
+    body.hiddenHarnessSections = getHiddenHarnessSections(hiddenSections);
 
     return body;
   };
@@ -298,42 +337,355 @@ export default function EditReportPage() {
       {/* Report preview with harness sections */}
       {isHarness && harnessData && (
         <>
-          <HeroStats
-            stats={harnessData.stats}
-            dayCount={report.dayCount}
-            sessionCount={
-              report.sessionCount || harnessData.stats?.sessionCount || 0
-            }
-          />
-          <HowIWorkCluster harnessData={harnessData} />
+          <HideableCard
+            title="Hero Stats"
+            hidden={!!hiddenSections["heroStats"]}
+            onToggle={() => toggleSection("heroStats")}
+          >
+            <HeroStats
+              stats={harnessData.stats}
+              dayCount={report.dayCount}
+              sessionCount={
+                report.sessionCount || harnessData.stats?.sessionCount || 0
+              }
+            />
+          </HideableCard>
+
+          <HideableCard
+            title="Activity Heatmap"
+            hidden={!!hiddenSections["activityHeatmap"]}
+            onToggle={() => toggleSection("activityHeatmap")}
+          >
+            <ActivityHeatmap
+              totalSessions={
+                report.sessionCount ?? harnessData.stats.sessionCount ?? undefined
+              }
+              totalTokens={harnessData.stats.totalTokens ?? undefined}
+              dayCount={report.dayCount ?? undefined}
+              slug={report.slug}
+              models={harnessData.models}
+            />
+          </HideableCard>
+
+          <HideableCard
+            title="How I Work"
+            hidden={!!hiddenSections["howIWork"]}
+            onToggle={() => toggleSection("howIWork")}
+          >
+            <HowIWorkCluster harnessData={harnessData} />
+          </HideableCard>
+
           {Object.keys(harnessData.toolUsage).length > 0 && (
-            <ToolUsageTreemap toolUsage={harnessData.toolUsage} />
+            <HideableCard
+              title="Tool Usage"
+              hidden={!!hiddenSections["toolUsage"]}
+              onToggle={() => toggleSection("toolUsage")}
+            >
+              <ToolUsageTreemap toolUsage={harnessData.toolUsage} />
+            </HideableCard>
           )}
-          {harnessData.skillInventory.length > 0 && (
-            <SkillCardGrid skillInventory={harnessData.skillInventory} />
-          )}
+
           {harnessData.workflowData && (
-            <div className={hiddenSections["workflowData"] ? "opacity-40" : ""}>
-              <div className="mb-1 flex items-center gap-2">
-                <EyeToggle
-                  enabled={!hiddenSections["workflowData"]}
-                  onToggle={() => toggleSection("workflowData")}
+            <HideableCard
+              title="Workflow Diagrams"
+              hidden={!!hiddenSections["workflowData"]}
+              onToggle={() => toggleSection("workflowData")}
+            >
+              <WorkflowDiagram
+                workflowData={harnessData.workflowData}
+                agentDispatch={harnessData.agentDispatch}
+              />
+            </HideableCard>
+          )}
+
+          {harnessData.skillInventory.length > 0 && (
+            <HideableCard
+              title="Skills"
+              hidden={!!hiddenSections["skillInventory"]}
+              onToggle={() => toggleSection("skillInventory")}
+            >
+              <SkillCardGrid skillInventory={harnessData.skillInventory} />
+            </HideableCard>
+          )}
+
+          {harnessData.plugins.length > 0 && (
+            <HideableCard
+              title="Plugins"
+              hidden={!!hiddenSections["plugins"]}
+              onToggle={() => toggleSection("plugins")}
+            >
+              <CollapsibleSection
+                icon="🔌"
+                iconBgClass="bg-teal-100 dark:bg-teal-900/30"
+                title="Plugins"
+                defaultOpen={true}
+              >
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {harnessData.plugins.map((plugin) => (
+                    <div
+                      key={plugin.name}
+                      className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
+                    >
+                      <div className="flex items-center justify-between">
+                        <span className="font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+                          {plugin.name}
+                        </span>
+                        <span
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                            plugin.active
+                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                              : "bg-slate-100 text-slate-400 dark:bg-slate-800"
+                          }`}
+                        >
+                          {plugin.active ? "on" : "off"}
+                        </span>
+                      </div>
+                      {(plugin.version || plugin.marketplace) && (
+                        <div className="mt-0.5 text-[11px] text-slate-400">
+                          {plugin.version && `v${plugin.version}`}
+                          {plugin.version && plugin.marketplace && " · "}
+                          {plugin.marketplace}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {Object.keys(harnessData.cliTools).length > 0 && (
+            <HideableCard
+              title="CLI Tools"
+              hidden={!!hiddenSections["cliTools"]}
+              onToggle={() => toggleSection("cliTools")}
+            >
+              <CliToolsDonut cliTools={harnessData.cliTools} />
+            </HideableCard>
+          )}
+
+          <HideableCard
+            title="Git Patterns"
+            hidden={!!hiddenSections["gitPatterns"]}
+            onToggle={() => toggleSection("gitPatterns")}
+          >
+            <GitPatternsDisplay gitPatterns={harnessData.gitPatterns} />
+          </HideableCard>
+
+          <HideableCard
+            title="Permission Mode & Safety"
+            hidden={!!hiddenSections["permissionModes"]}
+            onToggle={() => toggleSection("permissionModes")}
+          >
+            <PermissionModeDisplay
+              permissionModes={harnessData.permissionModes}
+              featurePills={harnessData.featurePills}
+            />
+          </HideableCard>
+
+          {harnessData.hookDefinitions.length > 0 && (
+            <HideableCard
+              title="Hooks & Safety"
+              hidden={!!hiddenSections["hookDefinitions"]}
+              onToggle={() => toggleSection("hookDefinitions")}
+            >
+              <HooksSafetyTable hookDefinitions={harnessData.hookDefinitions} />
+            </HideableCard>
+          )}
+
+          {harnessData.agentDispatch && harnessData.agentDispatch.totalAgents > 0 && (
+            <HideableCard
+              title="Agent Dispatch"
+              hidden={!!hiddenSections["agentDispatch"]}
+              onToggle={() => toggleSection("agentDispatch")}
+            >
+              <CollapsibleSection
+                icon="🤖"
+                iconBgClass="bg-indigo-100 dark:bg-indigo-900/30"
+                title={`Agent Dispatch (${harnessData.agentDispatch.totalAgents} agents)`}
+                defaultOpen={false}
+              >
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {Object.keys(harnessData.agentDispatch.types).length > 0 && (
+                    <div>
+                      <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                        Agent Types
+                      </h4>
+                      <MiniBarChart
+                        data={Object.entries(harnessData.agentDispatch.types).map(
+                          ([label, value]) => ({ label, value }),
+                        )}
+                        title=""
+                        color="bg-indigo-500"
+                      />
+                    </div>
+                  )}
+                  {Object.keys(harnessData.agentDispatch.models).length > 0 && (
+                    <div>
+                      <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                        Model Tiering
+                      </h4>
+                      <MiniBarChart
+                        data={Object.entries(harnessData.agentDispatch.models).map(
+                          ([label, value]) => ({ label, value }),
+                        )}
+                        title=""
+                        color="bg-purple-500"
+                      />
+                      {harnessData.agentDispatch.backgroundPct > 0 && (
+                        <p className="mt-1 text-xs text-slate-400">
+                          {harnessData.agentDispatch.backgroundPct}% run in
+                          background
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {Object.keys(harnessData.languages).length > 0 && (
+            <HideableCard
+              title="Languages"
+              hidden={!!hiddenSections["languages"]}
+              onToggle={() => toggleSection("languages")}
+            >
+              <CollapsibleSection
+                icon="💻"
+                iconBgClass="bg-green-100 dark:bg-green-900/30"
+                title="Languages"
+                defaultOpen={false}
+              >
+                <MiniBarChart
+                  data={Object.entries(harnessData.languages)
+                    .sort((a, b) => b[1] - a[1])
+                    .slice(0, 12)
+                    .map(([label, value]) => ({ label, value }))}
+                  title=""
+                  color="bg-green-500"
                 />
-                <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
-                  Workflow Diagrams
-                </span>
-                {hiddenSections["workflowData"] && (
-                  <span className="text-xs text-red-500">Will be removed</span>
-                )}
-              </div>
-              {!hiddenSections["workflowData"] && (
-                <>
-                  <WorkflowDiagram
-                    workflowData={harnessData.workflowData}
-                    agentDispatch={harnessData.agentDispatch}
-                  />
-                </>
-              )}
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {Object.keys(harnessData.mcpServers).length > 0 && (
+            <HideableCard
+              title="MCP Servers"
+              hidden={!!hiddenSections["mcpServers"]}
+              onToggle={() => toggleSection("mcpServers")}
+            >
+              <CollapsibleSection
+                icon="🔗"
+                iconBgClass="bg-cyan-100 dark:bg-cyan-900/30"
+                title="MCP Servers"
+                defaultOpen={false}
+              >
+                <div className="space-y-1">
+                  {Object.entries(harnessData.mcpServers)
+                    .sort((a, b) => b[1] - a[1])
+                    .map(([server, calls]) => (
+                      <div
+                        key={server}
+                        className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
+                      >
+                        <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                          {server}
+                        </span>
+                        <span className="text-xs text-slate-400">
+                          {calls.toLocaleString()} calls
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {harnessData.versions.length > 0 && (
+            <HideableCard
+              title="Claude Code Versions"
+              hidden={!!hiddenSections["versions"]}
+              onToggle={() => toggleSection("versions")}
+            >
+              <CollapsibleSection
+                icon="📦"
+                iconBgClass="bg-slate-100 dark:bg-slate-900/30"
+                title="Claude Code Versions"
+                defaultOpen={false}
+              >
+                <div className="flex flex-wrap gap-1.5">
+                  {harnessData.versions.map((version) => (
+                    <span
+                      key={version}
+                      className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                    >
+                      {version}
+                    </span>
+                  ))}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {harnessData.writeupSections.length > 0 && (
+            <HideableCard
+              title="Writeup Analysis"
+              hidden={!!hiddenSections["writeupSections"]}
+              onToggle={() => toggleSection("writeupSections")}
+            >
+              <CollapsibleSection
+                icon="📝"
+                iconBgClass="bg-blue-100 dark:bg-blue-900/30"
+                title="Writeup Analysis"
+                defaultOpen={false}
+              >
+                <div className="space-y-6">
+                  {harnessData.writeupSections.map((section) => (
+                    <div key={section.title}>
+                      <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+                        {section.title}
+                      </h4>
+                      <div
+                        className="prose prose-sm max-w-none text-slate-600 dark:text-slate-400 [&_p]:mb-2 [&_li]:mb-1"
+                        dangerouslySetInnerHTML={{ __html: section.contentHtml }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {harnessData.harnessFiles.length > 0 && (
+            <HideableCard
+              title="Harness File Ecosystem"
+              hidden={!!hiddenSections["harnessFiles"]}
+              onToggle={() => toggleSection("harnessFiles")}
+            >
+              <CollapsibleSection
+                icon="📁"
+                iconBgClass="bg-orange-100 dark:bg-orange-900/30"
+                title="Harness File Ecosystem"
+                defaultOpen={false}
+              >
+                <div className="space-y-1">
+                  {harnessData.harnessFiles.map((file) => (
+                    <div
+                      key={file}
+                      className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
+                    >
+                      {file}
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {report.projectLinks.length > 0 && (
+            <div className="mb-6">
+              <ProjectLinks links={report.projectLinks} />
             </div>
           )}
         </>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -32,6 +32,8 @@ import PermissionModeDisplay from "@/components/PermissionModeDisplay";
 import HooksSafetyTable from "@/components/HooksSafetyTable";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
+import MiniBarChart from "@/components/MiniBarChart";
+import { isHarnessSectionHidden } from "@/lib/harness-section-visibility";
 
 interface ReportData {
   id: string;
@@ -183,47 +185,6 @@ function getSectionSummary(
   }
 }
 
-/* ── Small bar chart for standard report chartData ── */
-function MiniBarChart({
-  data,
-  color = "bg-blue-500",
-  title,
-}: {
-  data: Array<{ label: string; value: number }>;
-  color?: string;
-  title: string;
-}) {
-  if (!data || data.length === 0) return null;
-  const max = Math.max(...data.map((d) => d.value), 1);
-  return (
-    <div>
-      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
-        {title}
-      </h4>
-      <div className="space-y-1">
-        {data.slice(0, 8).map((item) => (
-          <div key={item.label} className="flex items-center gap-2">
-            <span className="w-20 truncate text-xs text-slate-600 dark:text-slate-400">
-              {item.label}
-            </span>
-            <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
-              <div
-                className={`h-full rounded-full ${color}`}
-                style={{
-                  width: `${Math.max(3, (item.value / max) * 100)}%`,
-                }}
-              />
-            </div>
-            <span className="w-10 text-right text-xs text-slate-400">
-              {item.value}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export default function InsightDetailPage() {
   const params = useParams();
   const slug = params.slug as string;
@@ -296,6 +257,7 @@ export default function InsightDetailPage() {
   );
 
   const isHarness = report.reportType === "insight-harness";
+  const hiddenHarnessSections = report.hiddenHarnessSections ?? [];
 
   return (
     <div className="mx-auto max-w-4xl px-4 py-8">
@@ -366,41 +328,51 @@ export default function InsightDetailPage() {
       {isHarness && report.harnessData ? (
         <>
           {/* Hero Stats */}
-          <HeroStats
-            stats={report.harnessData.stats}
-            dayCount={report.dayCount}
-            sessionCount={
-              report.sessionCount ||
-              report.harnessData?.stats?.sessionCount ||
-              0
-            }
-          />
+          {!isHarnessSectionHidden(hiddenHarnessSections, "heroStats") && (
+            <HeroStats
+              stats={report.harnessData.stats}
+              dayCount={report.dayCount}
+              sessionCount={
+                report.sessionCount ||
+                report.harnessData?.stats?.sessionCount ||
+                0
+              }
+            />
+          )}
 
           {/* Activity Heatmap — generated from aggregate stats */}
-          <ActivityHeatmap
-            totalSessions={
-              report.sessionCount ??
-              report.harnessData?.stats?.sessionCount ??
-              undefined
-            }
-            totalTokens={report.totalTokens ?? undefined}
-            dayCount={report.dayCount ?? undefined}
-            dateRangeStart={report.dateRangeStart ?? undefined}
-            slug={slug}
-            models={report.harnessData?.models ?? undefined}
-          />
+          {!isHarnessSectionHidden(
+            hiddenHarnessSections,
+            "activityHeatmap",
+          ) && (
+            <ActivityHeatmap
+              totalSessions={
+                report.sessionCount ??
+                report.harnessData?.stats?.sessionCount ??
+                undefined
+              }
+              totalTokens={report.totalTokens ?? undefined}
+              dayCount={report.dayCount ?? undefined}
+              dateRangeStart={report.dateRangeStart ?? undefined}
+              slug={slug}
+              models={report.harnessData?.models ?? undefined}
+            />
+          )}
 
           {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
-          <HowIWorkCluster harnessData={report.harnessData} />
+          {!isHarnessSectionHidden(hiddenHarnessSections, "howIWork") && (
+            <HowIWorkCluster harnessData={report.harnessData} />
+          )}
 
           {/* Tool Usage Treemap */}
-          {Object.keys(report.harnessData.toolUsage).length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "toolUsage") &&
+            Object.keys(report.harnessData.toolUsage).length > 0 && (
             <ToolUsageTreemap toolUsage={report.harnessData.toolUsage} />
           )}
 
           {/* Workflow Diagrams */}
           {report.harnessData.workflowData &&
-            !(report.hiddenHarnessSections ?? []).includes("workflowData") && (
+            !isHarnessSectionHidden(hiddenHarnessSections, "workflowData") && (
               <WorkflowDiagram
                 workflowData={report.harnessData.workflowData}
                 agentDispatch={report.harnessData.agentDispatch}
@@ -409,12 +381,14 @@ export default function InsightDetailPage() {
             )}
 
           {/* Skills Card Grid */}
-          {report.harnessData.skillInventory.length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "skillInventory") &&
+            report.harnessData.skillInventory.length > 0 && (
             <SkillCardGrid skillInventory={report.harnessData.skillInventory} />
           )}
 
           {/* Plugins */}
-          {report.harnessData.plugins.length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "plugins") &&
+            report.harnessData.plugins.length > 0 && (
             <CollapsibleSection
               icon="🔌"
               iconBgClass="bg-teal-100 dark:bg-teal-900/30"
@@ -455,26 +429,37 @@ export default function InsightDetailPage() {
           )}
 
           {/* CLI Tools Donut */}
-          {Object.keys(report.harnessData.cliTools).length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "cliTools") &&
+            Object.keys(report.harnessData.cliTools).length > 0 && (
             <CliToolsDonut cliTools={report.harnessData.cliTools} />
           )}
 
           {/* Git Patterns */}
-          <GitPatternsDisplay gitPatterns={report.harnessData.gitPatterns} />
+          {!isHarnessSectionHidden(hiddenHarnessSections, "gitPatterns") && (
+            <GitPatternsDisplay gitPatterns={report.harnessData.gitPatterns} />
+          )}
 
           {/* Permission Mode & Safety */}
-          <PermissionModeDisplay
-            permissionModes={report.harnessData.permissionModes}
-            featurePills={report.harnessData.featurePills}
-          />
+          {!isHarnessSectionHidden(
+            hiddenHarnessSections,
+            "permissionModes",
+          ) && (
+            <PermissionModeDisplay
+              permissionModes={report.harnessData.permissionModes}
+              featurePills={report.harnessData.featurePills}
+            />
+          )}
 
           {/* Hooks & Safety */}
-          <HooksSafetyTable
-            hookDefinitions={report.harnessData.hookDefinitions}
-          />
+          {!isHarnessSectionHidden(hiddenHarnessSections, "hookDefinitions") && (
+            <HooksSafetyTable
+              hookDefinitions={report.harnessData.hookDefinitions}
+            />
+          )}
 
           {/* Agent Dispatch */}
-          {report.harnessData.agentDispatch &&
+          {!isHarnessSectionHidden(hiddenHarnessSections, "agentDispatch") &&
+            report.harnessData.agentDispatch &&
             report.harnessData.agentDispatch.totalAgents > 0 && (
               <CollapsibleSection
                 icon="🤖"
@@ -540,10 +525,11 @@ export default function InsightDetailPage() {
                   </div>
                 )}
               </CollapsibleSection>
-            )}
+          )}
 
           {/* Languages */}
-          {Object.keys(report.harnessData.languages).length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "languages") &&
+            Object.keys(report.harnessData.languages).length > 0 && (
             <CollapsibleSection
               icon="💻"
               iconBgClass="bg-green-100 dark:bg-green-900/30"
@@ -562,7 +548,8 @@ export default function InsightDetailPage() {
           )}
 
           {/* MCP Servers */}
-          {Object.keys(report.harnessData.mcpServers).length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "mcpServers") &&
+            Object.keys(report.harnessData.mcpServers).length > 0 && (
             <CollapsibleSection
               icon="🔗"
               iconBgClass="bg-cyan-100 dark:bg-cyan-900/30"
@@ -590,7 +577,8 @@ export default function InsightDetailPage() {
           )}
 
           {/* Versions */}
-          {report.harnessData.versions.length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "versions") &&
+            report.harnessData.versions.length > 0 && (
             <CollapsibleSection
               icon="📦"
               iconBgClass="bg-slate-100 dark:bg-slate-900/30"
@@ -611,7 +599,8 @@ export default function InsightDetailPage() {
           )}
 
           {/* Writeup Sections */}
-          {report.harnessData.writeupSections.length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "writeupSections") &&
+            report.harnessData.writeupSections.length > 0 && (
             <CollapsibleSection
               icon="📝"
               iconBgClass="bg-blue-100 dark:bg-blue-900/30"
@@ -637,7 +626,8 @@ export default function InsightDetailPage() {
           )}
 
           {/* Harness Files */}
-          {report.harnessData.harnessFiles.length > 0 && (
+          {!isHarnessSectionHidden(hiddenHarnessSections, "harnessFiles") &&
+            report.harnessData.harnessFiles.length > 0 && (
             <CollapsibleSection
               icon="📁"
               iconBgClass="bg-orange-100 dark:bg-orange-900/30"

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -28,19 +28,15 @@ import type {
   ParsedInsightsReport,
   RedactionItem,
   InsightsData,
-  HarnessData,
 } from "@/types/insights";
 import { applyRedactions } from "@/lib/redaction";
 import { normalizeChartData } from "@/lib/chart-parser";
 import { normalizeSkills } from "@/types/insights";
 import SectionRenderer from "@/components/SectionRenderer";
-import ModelDonutChart from "@/components/ModelDonutChart";
 import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
 import HeroStats from "@/components/HeroStats";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
-import AutonomyGauge from "@/components/AutonomyGauge";
-import FileOpStyleBar from "@/components/FileOpStyleBar";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import CliToolsDonut from "@/components/CliToolsDonut";
@@ -48,6 +44,13 @@ import GitPatternsDisplay from "@/components/GitPatternsDisplay";
 import PermissionModeDisplay from "@/components/PermissionModeDisplay";
 import HooksSafetyTable from "@/components/HooksSafetyTable";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
+import HowIWorkCluster from "@/components/HowIWorkCluster";
+import ProjectLinks from "@/components/ProjectLinks";
+import MiniBarChart from "@/components/MiniBarChart";
+import {
+  getHiddenHarnessSections,
+  stripHiddenHarnessData,
+} from "@/lib/harness-section-visibility";
 
 type Step = "upload" | "projects" | "review";
 
@@ -60,27 +63,6 @@ interface ProjectLinkInput {
 
 const INSIGHTS_PATH = "~/.claude/usage-data/report.html";
 const HARNESS_PATH = "~/.claude/usage-data/insight-harness.html";
-
-function stripDisabledHarnessSections(
-  data: HarnessData,
-  disabled: Record<string, boolean>,
-): HarnessData {
-  const copy = { ...data };
-  for (const key of Object.keys(disabled)) {
-    if (disabled[key] && key in copy) {
-      const k = key as keyof HarnessData;
-      const val = copy[k];
-      if (Array.isArray(val)) {
-        (copy as Record<string, unknown>)[key] = [];
-      } else if (typeof val === "object" && val !== null) {
-        (copy as Record<string, unknown>)[key] = {};
-      } else if (typeof val === "string") {
-        (copy as Record<string, unknown>)[key] = "";
-      }
-    }
-  }
-  return copy;
-}
 
 function CopyButton({
   text,
@@ -467,6 +449,7 @@ export default function UploadPage() {
     try {
       // Apply redactions client-side
       const redactedData = applyRedactions(parsed.data, redactions);
+      const hiddenHarnessSections = getHiddenHarnessSections(disabledSections);
 
       // Build the disabled sections set
       const disabledSet = new Set(
@@ -546,8 +529,9 @@ export default function UploadPage() {
           prCount: parsed.harnessData?.stats.prCount ?? null,
           autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
           harnessData: parsed.harnessData
-            ? stripDisabledHarnessSections(parsed.harnessData, disabledSections)
+            ? stripHiddenHarnessData(parsed.harnessData, hiddenHarnessSections)
             : null,
+          hiddenHarnessSections,
         }),
       });
 
@@ -580,6 +564,11 @@ export default function UploadPage() {
   ];
 
   const stepIndex = steps.findIndex((s) => s.key === step);
+  const normalizedChartData = parsed ? normalizeChartData(parsed.chartData) : null;
+  const previewProjectLinks = projectLinks.map((link, index) => ({
+    ...link,
+    id: `preview-${index}`,
+  }));
 
   // Computed values for the redaction summary bar
   const redactedCount = redactions.filter((r) => r.action === "redact").length;
@@ -1065,36 +1054,39 @@ export default function UploadPage() {
             Final Preview
           </h2>
           <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
-            This is exactly how your report will appear on your profile page.
-            Use the eye toggles to hide sections before publishing.
+            This mirrors your published report layout. Use the eye toggles to
+            hide cards before publishing.
           </p>
 
           {/* Redaction summary bar */}
-          <div className="mb-6 flex items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/50">
+          <div className="mb-6 flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800/60 dark:bg-amber-950/20">
+            <span className="text-lg text-amber-600 dark:text-amber-400">
+              ⚠
+            </span>
             <span
               className={clsx(
                 "text-sm font-medium",
                 allRedacted
                   ? "text-green-700 dark:text-green-400"
-                  : "text-amber-700 dark:text-amber-400",
+                  : "text-amber-800 dark:text-amber-300",
               )}
             >
-              {totalSensitive} potentially sensitive items detected,{" "}
-              {redactedCount} of {totalSensitive} redacted
+              {totalSensitive} potentially sensitive items detected in your
+              report, {redactedCount} of {totalSensitive} marked for redaction
             </span>
             {totalSensitive > 0 && (
               <div className="ml-auto flex gap-2">
                 <button
                   onClick={applyAllRedactions}
-                  className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                  className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
                 >
-                  Redact All
+                  Redact all sensitive items
                 </button>
                 <button
                   onClick={resetRedactions}
-                  className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                  className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
                 >
-                  Reset
+                  Reset to defaults
                 </button>
               </div>
             )}
@@ -1138,39 +1130,17 @@ export default function UploadPage() {
                   dayCount={parsed.stats.dayCount ?? undefined}
                   dateRangeStart={parsed.stats.dateRangeStart ?? undefined}
                   slug="preview"
+                  models={parsed.harnessData.models}
                 />
               </RedactableSection>
 
-              {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
+              {/* How I Work cluster */}
               <RedactableSection
                 title="How I Work"
                 enabled={!disabledSections["howIWork"]}
                 onToggle={() => toggleSection("howIWork")}
               >
-                <div className="mb-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
-                  <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
-                    How I Work
-                  </h3>
-                  <div className="grid gap-6 sm:grid-cols-3">
-                    {parsed.harnessData.autonomy.label && (
-                      <div className="flex items-center justify-center">
-                        <AutonomyGauge autonomy={parsed.harnessData.autonomy} />
-                      </div>
-                    )}
-                    {Object.keys(parsed.harnessData.models).length > 0 && (
-                      <div className="flex items-center justify-center">
-                        <ModelDonutChart models={parsed.harnessData.models} />
-                      </div>
-                    )}
-                    {parsed.harnessData.fileOpStyle.style && (
-                      <div className="flex items-center justify-center">
-                        <FileOpStyleBar
-                          fileOpStyle={parsed.harnessData.fileOpStyle}
-                        />
-                      </div>
-                    )}
-                  </div>
-                </div>
+                <HowIWorkCluster harnessData={parsed.harnessData} />
               </RedactableSection>
 
               {/* Tool Usage Treemap */}
@@ -1208,6 +1178,53 @@ export default function UploadPage() {
                   <SkillCardGrid
                     skillInventory={parsed.harnessData.skillInventory}
                   />
+                </RedactableSection>
+              )}
+
+              {/* Plugins */}
+              {parsed.harnessData.plugins.length > 0 && (
+                <RedactableSection
+                  title="Plugins"
+                  enabled={!disabledSections["plugins"]}
+                  onToggle={() => toggleSection("plugins")}
+                >
+                  <CollapsibleSection
+                    icon="🔌"
+                    iconBgClass="bg-teal-100 dark:bg-teal-900/30"
+                    title="Plugins"
+                    defaultOpen={true}
+                  >
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {parsed.harnessData.plugins.map((plugin) => (
+                        <div
+                          key={plugin.name}
+                          className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
+                        >
+                          <div className="flex items-center justify-between">
+                            <span className="font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+                              {plugin.name}
+                            </span>
+                            <span
+                              className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                                plugin.active
+                                  ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                                  : "bg-slate-100 text-slate-400 dark:bg-slate-800"
+                              }`}
+                            >
+                              {plugin.active ? "on" : "off"}
+                            </span>
+                          </div>
+                          {(plugin.version || plugin.marketplace) && (
+                            <div className="mt-0.5 text-[11px] text-slate-400">
+                              {plugin.version && `v${plugin.version}`}
+                              {plugin.version && plugin.marketplace && " · "}
+                              {plugin.marketplace}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </CollapsibleSection>
                 </RedactableSection>
               )}
 
@@ -1258,6 +1275,238 @@ export default function UploadPage() {
                 </RedactableSection>
               )}
 
+              {/* Agent Dispatch */}
+              {parsed.harnessData.agentDispatch &&
+                parsed.harnessData.agentDispatch.totalAgents > 0 && (
+                  <RedactableSection
+                    title="Agent Dispatch"
+                    enabled={!disabledSections["agentDispatch"]}
+                    onToggle={() => toggleSection("agentDispatch")}
+                  >
+                    <CollapsibleSection
+                      icon="🤖"
+                      iconBgClass="bg-indigo-100 dark:bg-indigo-900/30"
+                      title={`Agent Dispatch (${parsed.harnessData.agentDispatch.totalAgents} agents)`}
+                      defaultOpen={false}
+                    >
+                      <div className="grid gap-4 sm:grid-cols-2">
+                        {Object.keys(parsed.harnessData.agentDispatch.types)
+                          .length > 0 && (
+                          <div>
+                            <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                              Agent Types
+                            </h4>
+                            <MiniBarChart
+                              data={Object.entries(
+                                parsed.harnessData.agentDispatch.types,
+                              ).map(([label, value]) => ({ label, value }))}
+                              title=""
+                              color="bg-indigo-500"
+                            />
+                          </div>
+                        )}
+                        {Object.keys(parsed.harnessData.agentDispatch.models)
+                          .length > 0 && (
+                          <div>
+                            <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                              Model Tiering
+                            </h4>
+                            <MiniBarChart
+                              data={Object.entries(
+                                parsed.harnessData.agentDispatch.models,
+                              ).map(([label, value]) => ({ label, value }))}
+                              title=""
+                              color="bg-purple-500"
+                            />
+                            {parsed.harnessData.agentDispatch.backgroundPct >
+                              0 && (
+                              <p className="mt-1 text-xs text-slate-400">
+                                {
+                                  parsed.harnessData.agentDispatch
+                                    .backgroundPct
+                                }
+                                % run in background
+                              </p>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      {parsed.harnessData.agentDispatch.customAgents.length >
+                        0 && (
+                        <div className="mt-3">
+                          <h4 className="mb-1 text-xs font-semibold text-slate-500">
+                            Custom Agents
+                          </h4>
+                          <div className="flex flex-wrap gap-1.5">
+                            {parsed.harnessData.agentDispatch.customAgents.map(
+                              (agent) => (
+                                <span
+                                  key={agent}
+                                  className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                                >
+                                  {agent}
+                                </span>
+                              ),
+                            )}
+                          </div>
+                        </div>
+                      )}
+                    </CollapsibleSection>
+                  </RedactableSection>
+                )}
+
+              {/* Languages */}
+              {Object.keys(parsed.harnessData.languages).length > 0 && (
+                <RedactableSection
+                  title="Languages"
+                  enabled={!disabledSections["languages"]}
+                  onToggle={() => toggleSection("languages")}
+                >
+                  <CollapsibleSection
+                    icon="💻"
+                    iconBgClass="bg-green-100 dark:bg-green-900/30"
+                    title="Languages"
+                    defaultOpen={false}
+                  >
+                    <MiniBarChart
+                      data={Object.entries(parsed.harnessData.languages)
+                        .sort((a, b) => b[1] - a[1])
+                        .slice(0, 12)
+                        .map(([label, value]) => ({ label, value }))}
+                      title=""
+                      color="bg-green-500"
+                    />
+                  </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* MCP Servers */}
+              {Object.keys(parsed.harnessData.mcpServers).length > 0 && (
+                <RedactableSection
+                  title="MCP Servers"
+                  enabled={!disabledSections["mcpServers"]}
+                  onToggle={() => toggleSection("mcpServers")}
+                >
+                  <CollapsibleSection
+                    icon="🔗"
+                    iconBgClass="bg-cyan-100 dark:bg-cyan-900/30"
+                    title="MCP Servers"
+                    defaultOpen={false}
+                  >
+                    <div className="space-y-1">
+                      {Object.entries(parsed.harnessData.mcpServers)
+                        .sort((a, b) => b[1] - a[1])
+                        .map(([server, calls]) => (
+                          <div
+                            key={server}
+                            className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
+                          >
+                            <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                              {server}
+                            </span>
+                            <span className="text-xs text-slate-400">
+                              {calls.toLocaleString()} calls
+                            </span>
+                          </div>
+                        ))}
+                    </div>
+                  </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* Versions */}
+              {parsed.harnessData.versions.length > 0 && (
+                <RedactableSection
+                  title="Claude Code Versions"
+                  enabled={!disabledSections["versions"]}
+                  onToggle={() => toggleSection("versions")}
+                >
+                  <CollapsibleSection
+                    icon="📦"
+                    iconBgClass="bg-slate-100 dark:bg-slate-900/30"
+                    title="Claude Code Versions"
+                    defaultOpen={false}
+                  >
+                    <div className="flex flex-wrap gap-1.5">
+                      {parsed.harnessData.versions.map((version) => (
+                        <span
+                          key={version}
+                          className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                        >
+                          {version}
+                        </span>
+                      ))}
+                    </div>
+                  </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* Writeup Sections */}
+              {parsed.harnessData.writeupSections.length > 0 && (
+                <RedactableSection
+                  title="Writeup Analysis"
+                  enabled={!disabledSections["writeupSections"]}
+                  onToggle={() => toggleSection("writeupSections")}
+                >
+                  <CollapsibleSection
+                    icon="📝"
+                    iconBgClass="bg-blue-100 dark:bg-blue-900/30"
+                    title="Writeup Analysis"
+                    defaultOpen={false}
+                  >
+                    <div className="space-y-6">
+                      {parsed.harnessData.writeupSections.map((section) => (
+                        <div key={section.title}>
+                          <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+                            {section.title}
+                          </h4>
+                          <div
+                            className="prose prose-sm max-w-none text-slate-600 dark:text-slate-400 [&_p]:mb-2 [&_li]:mb-1"
+                            dangerouslySetInnerHTML={{
+                              __html: section.contentHtml,
+                            }}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* Harness Files */}
+              {parsed.harnessData.harnessFiles.length > 0 && (
+                <RedactableSection
+                  title="Harness File Ecosystem"
+                  enabled={!disabledSections["harnessFiles"]}
+                  onToggle={() => toggleSection("harnessFiles")}
+                >
+                  <CollapsibleSection
+                    icon="📁"
+                    iconBgClass="bg-orange-100 dark:bg-orange-900/30"
+                    title="Harness File Ecosystem"
+                    defaultOpen={false}
+                  >
+                    <div className="space-y-1">
+                      {parsed.harnessData.harnessFiles.map((file) => (
+                        <div
+                          key={file}
+                          className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
+                        >
+                          {file}
+                        </div>
+                      ))}
+                    </div>
+                  </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* Project Links */}
+              {previewProjectLinks.length > 0 && (
+                <div className="mb-6">
+                  <ProjectLinks links={previewProjectLinks} />
+                </div>
+              )}
+
               {/* Narrative Sections (mirrors profile page) */}
               <div className="mt-6 space-y-4">
                 {SECTION_OPTIONS.filter(
@@ -1305,7 +1554,7 @@ export default function UploadPage() {
                 fileCount={parsed.stats.fileCount ?? null}
                 dayCount={parsed.stats.dayCount ?? null}
                 commitCount={parsed.stats.commitCount ?? null}
-                chartData={normalizeChartData(parsed.chartData)}
+                chartData={normalizedChartData}
                 detectedSkills={normalizeSkills(parsed.detectedSkills)}
                 keyPattern={parsed.data.interaction_style?.key_pattern ?? null}
                 projectAreas={
@@ -1314,6 +1563,127 @@ export default function UploadPage() {
                     : parsed.data.project_areas
                 }
               />
+
+              {normalizedChartData && (
+                <div className="mt-6 grid gap-4 sm:grid-cols-2">
+                  {normalizedChartData.toolUsage &&
+                    normalizedChartData.toolUsage.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.toolUsage}
+                          title="Tool Usage"
+                          color="bg-blue-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.languages &&
+                    normalizedChartData.languages.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.languages}
+                          title="Languages"
+                          color="bg-green-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.requestTypes &&
+                    normalizedChartData.requestTypes.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.requestTypes}
+                          title="Request Types"
+                          color="bg-violet-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.sessionTypes &&
+                    normalizedChartData.sessionTypes.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.sessionTypes}
+                          title="Session Types"
+                          color="bg-amber-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.responseTimeDistribution &&
+                    normalizedChartData.responseTimeDistribution.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.responseTimeDistribution}
+                          title="Response Time Distribution"
+                          color="bg-cyan-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.toolErrors &&
+                    normalizedChartData.toolErrors.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.toolErrors}
+                          title="Tool Errors"
+                          color="bg-red-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.whatHelpedMost &&
+                    normalizedChartData.whatHelpedMost.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.whatHelpedMost}
+                          title="What Helped Most"
+                          color="bg-emerald-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.outcomes &&
+                    normalizedChartData.outcomes.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.outcomes}
+                          title="Outcomes"
+                          color="bg-teal-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.frictionTypes &&
+                    normalizedChartData.frictionTypes.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.frictionTypes}
+                          title="Friction Types"
+                          color="bg-orange-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.satisfaction &&
+                    normalizedChartData.satisfaction.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.satisfaction}
+                          title="Satisfaction"
+                          color="bg-pink-500"
+                        />
+                      </div>
+                    )}
+                  {normalizedChartData.timeOfDay &&
+                    normalizedChartData.timeOfDay.length > 0 && (
+                      <div className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+                        <MiniBarChart
+                          data={normalizedChartData.timeOfDay}
+                          title="Time of Day"
+                          color="bg-indigo-500"
+                        />
+                      </div>
+                    )}
+                </div>
+              )}
+
+              {previewProjectLinks.length > 0 && (
+                <div className="mt-6">
+                  <ProjectLinks links={previewProjectLinks} />
+                </div>
+              )}
 
               <div className="mt-6 space-y-4">
                 {SECTION_OPTIONS.filter(
@@ -1358,6 +1728,17 @@ export default function UploadPage() {
               <h3 className="mb-3 text-base font-semibold text-slate-900 dark:text-slate-100">
                 Sensitive Data Review
               </h3>
+              <div className="mb-3 flex flex-wrap gap-2 text-xs">
+                <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-amber-800 dark:border-amber-800/60 dark:bg-amber-950/20 dark:text-amber-300">
+                  Redact: removes the text entirely
+                </span>
+                <span className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-blue-800 dark:border-blue-800/60 dark:bg-blue-950/20 dark:text-blue-300">
+                  Use alias: replaces it with a safe label
+                </span>
+                <span className="rounded-full border border-green-200 bg-green-50 px-3 py-1 text-green-800 dark:border-green-800/60 dark:bg-green-950/20 dark:text-green-300">
+                  Keep: leaves the original text visible
+                </span>
+              </div>
               <div className="space-y-2">
                 {redactions.map((item) => (
                   <div
@@ -1365,10 +1746,10 @@ export default function UploadPage() {
                     className={clsx(
                       "flex flex-wrap items-center gap-2 rounded-lg border px-4 py-3",
                       item.action === "redact"
-                        ? "border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/20"
+                        ? "border-amber-200 bg-amber-50 dark:border-amber-800/60 dark:bg-amber-950/20"
                         : item.action === "alias"
                           ? "border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/20"
-                          : "border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-800",
+                          : "border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20",
                     )}
                   >
                     {/* Type badge */}
@@ -1397,10 +1778,10 @@ export default function UploadPage() {
                       className={clsx(
                         "flex-1 font-mono text-xs",
                         item.action === "redact"
-                          ? "text-red-600 line-through dark:text-red-400"
+                          ? "text-amber-900 dark:text-amber-200"
                           : item.action === "alias"
                             ? "text-blue-600 dark:text-blue-400"
-                            : "text-slate-700 dark:text-slate-300",
+                            : "text-green-700 dark:text-green-300",
                       )}
                     >
                       {item.action === "alias" && item.alias
@@ -1408,20 +1789,37 @@ export default function UploadPage() {
                         : item.text}
                     </span>
 
-                    {/* Action buttons: R | A | K */}
-                    <div className="flex gap-1">
+                    <span
+                      className={clsx(
+                        "rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wide",
+                        item.action === "redact"
+                          ? "bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300"
+                          : item.action === "alias"
+                            ? "bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300"
+                            : "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300",
+                      )}
+                    >
+                      {item.action === "redact"
+                        ? "Will redact"
+                        : item.action === "alias"
+                          ? "Using alias"
+                          : "Keep as-is"}
+                    </span>
+
+                    {/* Action buttons */}
+                    <div className="flex flex-wrap gap-1">
                       <button
                         onClick={() => updateRedaction(item.id, "redact")}
                         className={clsx(
-                          "rounded px-2 py-1 text-[10px] font-bold transition-colors",
+                          "rounded px-3 py-1.5 text-[11px] font-semibold transition-colors",
                           item.action === "redact"
-                            ? "bg-red-600 text-white"
-                            : "bg-slate-100 text-slate-500 hover:bg-red-100 dark:bg-slate-700 dark:text-slate-400 dark:hover:bg-red-900/30",
+                            ? "bg-amber-600 text-white"
+                            : "bg-white text-slate-600 hover:bg-amber-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-amber-900/30",
                         )}
-                        title="Redact"
+                        title="Redact this item"
                         aria-label="Redact this item"
                       >
-                        R
+                        Redact
                       </button>
                       <button
                         onClick={() => {
@@ -1432,28 +1830,28 @@ export default function UploadPage() {
                           if (alias) updateRedaction(item.id, "alias", alias);
                         }}
                         className={clsx(
-                          "rounded px-2 py-1 text-[10px] font-bold transition-colors",
+                          "rounded px-3 py-1.5 text-[11px] font-semibold transition-colors",
                           item.action === "alias"
                             ? "bg-blue-600 text-white"
-                            : "bg-slate-100 text-slate-500 hover:bg-blue-100 dark:bg-slate-700 dark:text-slate-400 dark:hover:bg-blue-900/30",
+                            : "bg-white text-slate-600 hover:bg-blue-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-blue-900/30",
                         )}
-                        title="Alias"
+                        title="Replace with alias"
                         aria-label="Alias this item"
                       >
-                        A
+                        Use alias
                       </button>
                       <button
                         onClick={() => updateRedaction(item.id, "keep")}
                         className={clsx(
-                          "rounded px-2 py-1 text-[10px] font-bold transition-colors",
+                          "rounded px-3 py-1.5 text-[11px] font-semibold transition-colors",
                           item.action === "keep"
                             ? "bg-green-600 text-white"
-                            : "bg-slate-100 text-slate-500 hover:bg-green-100 dark:bg-slate-700 dark:text-slate-400 dark:hover:bg-green-900/30",
+                            : "bg-white text-slate-600 hover:bg-green-100 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-green-900/30",
                         )}
-                        title="Keep"
+                        title="Keep original text"
                         aria-label="Keep this item"
                       >
-                        K
+                        Keep
                       </button>
                     </div>
                   </div>

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -27,6 +27,30 @@ const CELL_COUNT = WEEKS * DAYS_PER_WEEK;
 
 type ColorScale = "blue" | "green" | "amber";
 
+const SCALE_SWATCHS: Record<ColorScale, string[]> = {
+  blue: [
+    "bg-blue-100 dark:bg-blue-900/40",
+    "bg-blue-300 dark:bg-blue-800/60",
+    "bg-blue-400 dark:bg-blue-700",
+    "bg-blue-500 dark:bg-blue-600",
+    "bg-blue-700 dark:bg-blue-500",
+  ],
+  green: [
+    "bg-green-100 dark:bg-green-900/40",
+    "bg-green-300 dark:bg-green-800/60",
+    "bg-green-400 dark:bg-green-700",
+    "bg-green-500 dark:bg-green-600",
+    "bg-green-700 dark:bg-green-500",
+  ],
+  amber: [
+    "bg-amber-100 dark:bg-amber-900/40",
+    "bg-amber-300 dark:bg-amber-800/60",
+    "bg-amber-400 dark:bg-amber-700",
+    "bg-amber-500 dark:bg-amber-600",
+    "bg-amber-700 dark:bg-amber-500",
+  ],
+};
+
 function getLevel(
   scale: ColorScale,
   value: number,
@@ -139,6 +163,8 @@ function formatTokens(n: number): string {
 
 function formatCost(n: number): string {
   if (n === 0) return "0";
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
   if (n >= 100) return `$${Math.round(n)}`;
   if (n >= 10) return `$${n.toFixed(0)}`;
   if (n >= 1) return `$${n.toFixed(1)}`;
@@ -148,16 +174,41 @@ function formatCost(n: number): string {
 // Rough blended USD / 1M tokens, no input/output split available.
 // These are estimates — labeled "Est." in UI.
 const MODEL_BLENDED_RATE_PER_M: Array<{ match: RegExp; rate: number }> = [
-  { match: /opus/i, rate: 30 }, // blended between $15 in / $75 out
-  { match: /haiku/i, rate: 1.6 }, // blended between $0.80 in / $4 out
-  { match: /sonnet/i, rate: 6 }, // blended between $3 in / $15 out
+  { match: /opus(?:\s|[-_.])?4/i, rate: 45 },
+  { match: /opus/i, rate: 30 },
+  { match: /haiku(?:\s|[-_.])?4/i, rate: 3 },
+  { match: /haiku/i, rate: 1.6 },
+  { match: /sonnet(?:\s|[-_.])?4/i, rate: 9 },
+  { match: /sonnet/i, rate: 6 },
 ];
 const DEFAULT_RATE_PER_M = 6; // fall back to Sonnet-blended
 
-function estimateTotalCostUsd(models?: Record<string, number>): number {
-  if (!models) return 0;
+function normalizeModelTokenUsage(
+  models?: Record<string, number>,
+  totalTokens?: number,
+): Array<[string, number]> {
+  if (!models || Object.keys(models).length === 0) return [];
+
+  const entries = Object.entries(models).filter(([, tokens]) => tokens > 0);
+  if (entries.length === 0) return [];
+
+  const sum = entries.reduce((acc, [, value]) => acc + value, 0);
+  if (totalTokens && sum > 0 && sum <= 100.5) {
+    return entries.map(([name, share]) => [name, (share / sum) * totalTokens]);
+  }
+
+  return entries;
+}
+
+function estimateTotalCostUsd(
+  models?: Record<string, number>,
+  totalTokens?: number,
+): number {
+  const modelUsage = normalizeModelTokenUsage(models, totalTokens);
+  if (modelUsage.length === 0) return 0;
+
   let total = 0;
-  for (const [name, tokens] of Object.entries(models)) {
+  for (const [name, tokens] of modelUsage) {
     if (!tokens || tokens <= 0) continue;
     const entry = MODEL_BLENDED_RATE_PER_M.find((m) => m.match.test(name));
     const rate = entry ? entry.rate : DEFAULT_RATE_PER_M;
@@ -168,13 +219,13 @@ function estimateTotalCostUsd(models?: Record<string, number>): number {
 
 function GridHeatmap({
   title,
-  subtitle,
+  summary,
   scale,
   data,
   formatValue,
 }: {
   title: string;
-  subtitle?: string;
+  summary: string;
   scale: ColorScale;
   data: number[]; // length CELL_COUNT
   formatValue: (n: number) => string;
@@ -182,42 +233,62 @@ function GridHeatmap({
   const max = Math.max(...data, 1);
   const nonZero = data.filter((v) => v > 0);
   const min = nonZero.length > 0 ? Math.min(...nonZero) : 0;
+  const longestCellValue = data.reduce((longest, value) => {
+    const label = formatValue(value);
+    return label.length > longest ? label.length : longest;
+  }, 0);
+  const minCellWidth =
+    longestCellValue >= 7 ? 64 : longestCellValue >= 5 ? 56 : 44;
+  const minCellHeight =
+    longestCellValue >= 7 ? 44 : longestCellValue >= 5 ? 40 : 34;
 
   return (
-    <div>
-      <div
-        className={`mb-1 text-xs font-bold uppercase tracking-wider ${TITLE_COLORS[scale]}`}
-      >
-        {title}
-      </div>
-      {subtitle && (
-        <div className="mb-2 text-[10px] text-slate-500 dark:text-slate-400">
-          {subtitle}
+    <div className="rounded-lg border border-slate-100 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-950/20">
+      <div className="mb-3 flex min-h-[2.5rem] items-start justify-between gap-3">
+        <div
+          className={`text-xs font-bold uppercase tracking-wider ${TITLE_COLORS[scale]}`}
+        >
+          {title}
         </div>
-      )}
-      <div
-        className="grid gap-[3px]"
-        style={{
-          gridTemplateColumns: `repeat(${DAYS_PER_WEEK}, minmax(0, 1fr))`,
-        }}
-      >
-        {data.map((value, i) => {
-          const level = getLevel(scale, value, max);
-          return (
-            <div
-              key={i}
-              title={formatValue(value)}
-              className={`flex aspect-square items-center justify-center rounded text-[10px] font-semibold ${level.bg} ${level.text} ${level.border ?? ""}`}
-            >
-              {formatValue(value)}
-            </div>
-          );
-        })}
+        <div className="text-right text-sm font-semibold text-slate-700 dark:text-slate-200">
+          {summary}
+        </div>
       </div>
-      {/* Legend: min / max for this series */}
-      <div className="mt-2 flex items-center justify-between text-[10px] text-slate-500 dark:text-slate-400">
-        <span>{formatValue(min)}</span>
-        <span>{formatValue(max)}</span>
+
+      <div className="overflow-x-auto pb-1">
+        <div
+          className="grid min-w-max gap-[4px]"
+          style={{
+            gridTemplateColumns: `repeat(${DAYS_PER_WEEK}, minmax(${minCellWidth}px, 1fr))`,
+          }}
+        >
+          {data.map((value, i) => {
+            const level = getLevel(scale, value, max);
+            return (
+              <div
+                key={i}
+                title={formatValue(value)}
+                className={`flex items-center justify-center rounded px-1.5 text-center text-[10px] font-semibold leading-tight ${level.bg} ${level.text} ${level.border ?? ""}`}
+                style={{ minHeight: `${minCellHeight}px` }}
+              >
+                {formatValue(value)}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3 text-[10px] text-slate-500 dark:text-slate-400">
+        <span className="shrink-0">Low {formatValue(min)}</span>
+        <div className="flex items-center gap-1">
+          {SCALE_SWATCHS[scale].map((swatch, index) => (
+            <span
+              key={`${scale}-${index}`}
+              className={`h-2.5 w-5 rounded-sm ${swatch}`}
+            />
+          ))}
+        </div>
+        <span className="shrink-0">High {formatValue(max)}</span>
       </div>
     </div>
   );
@@ -293,11 +364,12 @@ export default function ActivityHeatmap({
   // series. If we have no tokens, fall back to zeros.
   const costDaily = useMemo<number[] | null>(() => {
     if (!tokensDaily) return null;
-    const totalCost = estimateTotalCostUsd(models);
+    const totalTokenCount = totalTokens ?? tokensDaily.reduce((a, b) => a + b, 0);
+    const totalCost = estimateTotalCostUsd(models, totalTokenCount);
     if (totalCost <= 0) {
       // Fallback: still derive from totalTokens using default blended rate
       const fallbackTotal =
-        (totalTokens ?? tokensDaily.reduce((a, b) => a + b, 0)) *
+        totalTokenCount *
         (DEFAULT_RATE_PER_M / 1_000_000);
       if (fallbackTotal <= 0) return tokensDaily.map(() => 0);
       const tokenSum = tokensDaily.reduce((a, b) => a + b, 0) || 1;
@@ -316,22 +388,24 @@ export default function ActivityHeatmap({
       <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
         Activity
       </h3>
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-6 lg:grid-cols-2 2xl:grid-cols-3">
         <GridHeatmap
           title="Sessions"
+          summary={`${sessionsDaily.reduce((a, b) => a + b, 0)} total`}
           scale="blue"
           data={sessionsDaily}
           formatValue={(n) => (n > 0 ? n.toString() : "")}
         />
         <GridHeatmap
           title="Tokens"
+          summary={`${formatTokens(tokensDaily.reduce((a, b) => a + b, 0))} total`}
           scale="green"
           data={tokensDaily}
           formatValue={(n) => (n > 0 ? formatTokens(n) : "")}
         />
         <GridHeatmap
           title="Est. API Cost"
-          subtitle={`~${formatCost(totalCostEstimate)} total (estimate)`}
+          summary={`~${formatCost(totalCostEstimate)} total`}
           scale="amber"
           data={costDaily}
           formatValue={(n) => (n > 0 ? formatCost(n) : "")}

--- a/src/components/FileOpStyleBar.tsx
+++ b/src/components/FileOpStyleBar.tsx
@@ -9,33 +9,25 @@ interface FileOpStyleBarProps {
 const SEGMENTS: {
   key: keyof Pick<HarnessFileOpStyle, "readPct" | "editPct" | "writePct">;
   label: string;
-  shortLabel: string;
   bg: string;
-  textColor: string;
   legendBg: string;
 }[] = [
   {
     key: "readPct",
     label: "Read",
-    shortLabel: "Read",
     bg: "bg-blue-500",
-    textColor: "text-white",
     legendBg: "bg-blue-500",
   },
   {
     key: "editPct",
     label: "Edit",
-    shortLabel: "Edit",
     bg: "bg-blue-400",
-    textColor: "text-white",
     legendBg: "bg-blue-400",
   },
   {
     key: "writePct",
     label: "Write",
-    shortLabel: "Wr",
     bg: "bg-blue-300",
-    textColor: "text-blue-900 dark:text-blue-100",
     legendBg: "bg-blue-300",
   },
 ];
@@ -53,54 +45,59 @@ export default function FileOpStyleBar({ fileOpStyle }: FileOpStyleBarProps) {
       <div className="mb-2 text-xs font-semibold text-slate-500 dark:text-slate-400">
         File Operations
       </div>
+
+      <div className="mb-2 grid gap-1.5 text-[11px] sm:grid-cols-2">
+        {SEGMENTS.map((seg) => {
+          const pct = fileOpStyle[seg.key];
+          if (pct <= 0) return null;
+          return (
+            <div
+              key={`stat-${seg.key}`}
+              className="flex items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 dark:border-slate-700 dark:bg-slate-800/50"
+            >
+              <div className="flex items-center gap-1.5">
+                <span className={`h-2.5 w-2.5 rounded-full ${seg.legendBg}`} />
+                <span className="text-slate-600 dark:text-slate-300">
+                  {seg.label}
+                </span>
+              </div>
+              <span className="font-semibold text-slate-900 dark:text-slate-100">
+                {pct}%
+              </span>
+            </div>
+          );
+        })}
+        {searchPct > 0 && (
+          <div className="flex items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 dark:border-slate-700 dark:bg-slate-800/50">
+            <div className="flex items-center gap-1.5">
+              <span className="h-2.5 w-2.5 rounded-full bg-blue-100 dark:bg-blue-900/40" />
+              <span className="text-slate-600 dark:text-slate-300">Search</span>
+            </div>
+            <span className="font-semibold text-slate-900 dark:text-slate-100">
+              {searchPct}%
+            </span>
+          </div>
+        )}
+      </div>
+
       {/* Stacked bar */}
-      <div className="flex h-7 overflow-hidden rounded-md">
+      <div className="flex h-4 overflow-hidden rounded-md">
         {SEGMENTS.map((seg) => {
           const pct = fileOpStyle[seg.key];
           if (pct <= 0) return null;
           return (
             <div
               key={seg.key}
-              className={`flex items-center justify-center text-[10px] font-semibold ${seg.bg} ${seg.textColor}`}
+              className={seg.bg}
               style={{ width: `${pct}%` }}
-            >
-              {pct >= 10
-                ? `${seg.label} ${pct}%`
-                : pct >= 5
-                  ? `${seg.shortLabel}`
-                  : ""}
-            </div>
+            />
           );
         })}
         {searchPct > 0 && (
           <div
-            className="flex items-center justify-center bg-blue-100 text-[10px] font-semibold text-blue-800 dark:bg-blue-900/40 dark:text-blue-300"
+            className="bg-blue-100 dark:bg-blue-900/40"
             style={{ width: `${searchPct}%` }}
-          >
-            {searchPct >= 5 ? `${searchPct}%` : ""}
-          </div>
-        )}
-      </div>
-      {/* Legend */}
-      <div className="mt-1.5 flex flex-wrap gap-3">
-        {SEGMENTS.map((seg) => {
-          if (fileOpStyle[seg.key] <= 0) return null;
-          return (
-            <div key={seg.key} className="flex items-center gap-1">
-              <div className={`h-2 w-2 rounded-sm ${seg.legendBg}`} />
-              <span className="text-[11px] text-slate-500 dark:text-slate-400">
-                {seg.label}
-              </span>
-            </div>
-          );
-        })}
-        {searchPct > 0 && (
-          <div className="flex items-center gap-1">
-            <div className="h-2 w-2 rounded-sm bg-blue-100 dark:bg-blue-900/40" />
-            <span className="text-[11px] text-slate-500 dark:text-slate-400">
-              Search
-            </span>
-          </div>
+          />
         )}
       </div>
       {/* Style insight */}

--- a/src/components/HowIWorkCluster.tsx
+++ b/src/components/HowIWorkCluster.tsx
@@ -22,7 +22,7 @@ export default function HowIWorkCluster({ harnessData }: HowIWorkClusterProps) {
       <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
         How I Work
       </h3>
-      <div className="grid gap-6 sm:grid-cols-3">
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(260px,1.15fr)]">
         {hasAutonomy && (
           <div className="flex items-center justify-center">
             <AutonomyGauge autonomy={autonomy} />

--- a/src/components/MiniBarChart.tsx
+++ b/src/components/MiniBarChart.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+interface MiniBarChartProps {
+  data: Array<{ label: string; value: number }>;
+  color?: string;
+  title: string;
+}
+
+export default function MiniBarChart({
+  data,
+  color = "bg-blue-500",
+  title,
+}: MiniBarChartProps) {
+  if (!data || data.length === 0) return null;
+
+  const max = Math.max(...data.map((d) => d.value), 1);
+
+  return (
+    <div>
+      {title ? (
+        <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          {title}
+        </h4>
+      ) : null}
+      <div className="space-y-1">
+        {data.slice(0, 8).map((item) => (
+          <div key={item.label} className="flex items-center gap-2">
+            <span className="w-20 truncate text-xs text-slate-600 dark:text-slate-400">
+              {item.label}
+            </span>
+            <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800">
+              <div
+                className={`h-full rounded-full ${color}`}
+                style={{ width: `${Math.max(3, (item.value / max) * 100)}%` }}
+              />
+            </div>
+            <span className="w-10 text-right text-xs text-slate-400">
+              {item.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToolUsageTreemap.tsx
+++ b/src/components/ToolUsageTreemap.tsx
@@ -21,6 +21,10 @@ function getToolBg(name: string): string {
   return TOOL_CATEGORIES[name]?.bg ?? "bg-slate-500";
 }
 
+function getToolCategory(name: string): string {
+  return TOOL_CATEGORIES[name]?.label ?? "other";
+}
+
 function formatNumber(n: number): string {
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return n.toString();
@@ -37,27 +41,37 @@ export default function ToolUsageTreemap({ toolUsage }: ToolUsageTreemapProps) {
       <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
         Tool Usage
       </h3>
-      <div className="flex flex-wrap gap-[3px]">
+      <div
+        className="grid gap-3"
+        style={{ gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))" }}
+      >
         {entries.map(([name, value]) => {
           const pct = (value / total) * 100;
-          // Minimum width for readability
-          const width = Math.max(pct, 4);
-          // Scale height based on proportion
-          const minHeight = pct > 8 ? 80 : 60;
+          const minHeight = pct >= 25 ? 118 : pct >= 14 ? 102 : 88;
           return (
             <div
               key={name}
-              className={`flex flex-col items-center justify-center rounded-md ${getToolBg(name)} cursor-default transition-opacity hover:opacity-85`}
+              className={`flex flex-col justify-between rounded-xl ${getToolBg(name)} cursor-default p-3 text-white transition-opacity hover:opacity-90`}
               style={{
-                width: `calc(${width}% - 3px)`,
                 minHeight: `${minHeight}px`,
-                flexGrow: pct > 15 ? 2 : 1,
               }}
             >
-              <span className="text-[13px] font-bold text-white">{name}</span>
-              <span className="text-[10px] font-medium text-white/80">
+              <div className="space-y-2">
+                <div className="flex items-start justify-between gap-2">
+                  <span className="rounded-full bg-white/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white/90">
+                    {getToolCategory(name)}
+                  </span>
+                  <span className="text-[11px] font-semibold text-white/80">
+                    {Math.round(pct)}%
+                  </span>
+                </div>
+                <div className="break-words text-sm font-bold leading-tight">
+                  {name}
+                </div>
+              </div>
+              <div className="mt-3 text-lg font-extrabold tracking-tight text-white">
                 {formatNumber(value)}
-              </span>
+              </div>
             </div>
           );
         })}

--- a/src/components/WorkflowDiagram.tsx
+++ b/src/components/WorkflowDiagram.tsx
@@ -163,7 +163,7 @@ export function buildWorkflowDiagram(
     const id = skill.replace(/[^a-zA-Z0-9]/g, "_");
     const { plugin, shortName } = parseSkillSource(skill);
     const safeName = shortName.replace(/"/g, "'");
-    const label = `${safeName}<br/><span style='font-size:9px;opacity:0.7'>${plugin}</span><br/>${count}×`;
+    const label = `${safeName}<br/><span style='font-size:12px;opacity:0.72'>${plugin}</span><br/><span style='font-size:13px;font-weight:700'>${count}×</span>`;
     lines.push(`    ${id}["${label}"]`);
   }
 
@@ -262,8 +262,8 @@ export default function WorkflowDiagram({
   );
 
   return (
-    <div className="mb-6 grid gap-4 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,1fr)]">
-      <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50 xl:row-span-2">
+    <div className="mb-6 space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
         <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
           <div>
             <h3 className="text-[15px] font-bold text-slate-900 dark:text-slate-100">
@@ -309,7 +309,7 @@ export default function WorkflowDiagram({
 
         <div
           ref={containerRef}
-          className="hidden min-h-[240px] items-center justify-center overflow-x-auto rounded-lg border border-slate-100 bg-slate-50/70 px-2 py-4 sm:flex dark:border-slate-800 dark:bg-slate-950/30 [&_svg]:max-w-full"
+          className="hidden min-h-[420px] items-center justify-center overflow-auto rounded-lg border border-slate-100 bg-slate-50/70 px-4 py-5 sm:flex dark:border-slate-800 dark:bg-slate-950/30 [&_svg]:min-h-[360px] [&_svg]:min-w-[960px] [&_svg]:max-w-none"
         >
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
         </div>
@@ -396,160 +396,156 @@ export default function WorkflowDiagram({
         )}
       </div>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
-        <div className="mb-4">
-          <h3 className="text-[15px] font-bold text-slate-900 dark:text-slate-100">
-            What {name} Delegates to Agents
-          </h3>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            The parallel work this report hands off, or the orchestration
-            footprint when task-level descriptions are intentionally omitted.
-          </p>
-        </div>
-
-        {/* Raw agent-dispatch descriptions can contain customer/repo/path
-            identifiers (see PR #4 which removed them from the extractor).
-            Any legacy reports that still have agentDispatches populated are
-            deliberately NOT rendered here — we only show the curated
-            agentDispatch.types/models summary below. */}
-
-        {hasDispatchSummary ? (
-          <div className="space-y-4">
-            <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-3">
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  Total Agents
-                </div>
-                <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
-                  {formatCount(agentDispatch?.totalAgents ?? 0)}
-                </div>
-              </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  Background
-                </div>
-                <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
-                  {agentDispatch?.backgroundPct ?? 0}%
-                </div>
-              </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  Custom Agents
-                </div>
-                <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
-                  {agentDispatch?.customAgents.length ?? 0}
-                </div>
-              </div>
-            </div>
-
-            {dispatchTypeEntries.length > 0 && (
-              <div>
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  Agent Types
-                </div>
-                <div className="space-y-2">
-                  {dispatchTypeEntries.map(([label, count]) => (
-                    <div
-                      key={label}
-                      className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-300"
-                    >
-                      <span className="font-medium">{label}</span>
-                      <span className="font-mono text-slate-400">{count}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {dispatchModelEntries.length > 0 && (
-              <div>
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  Model Tiering
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {dispatchModelEntries.map(([label, count]) => (
-                    <span
-                      key={label}
-                      className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300"
-                    >
-                      {label} ({count})
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {agentDispatch?.customAgents.length ? (
-              <div>
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-                  Custom Agents
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {agentDispatch.customAgents.slice(0, 6).map((label) => (
-                    <span
-                      key={label}
-                      className="rounded-full border border-violet-200 bg-violet-50 px-2.5 py-1 text-xs text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300"
-                    >
-                      {label}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
+          <div className="mb-4">
+            <h3 className="text-[15px] font-bold text-slate-900 dark:text-slate-100">
+              What {name} Delegates to Agents
+            </h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              The parallel work this report hands off, or the orchestration
+              footprint when task-level descriptions are intentionally omitted.
+            </p>
           </div>
-        ) : (
-          <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-800/40 dark:text-slate-400">
-            No delegation data was captured in this report.
-          </div>
-        )}
-      </div>
 
-      <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
-        <div className="mb-4">
-          <h3 className="text-[15px] font-bold text-slate-900 dark:text-slate-100">
-            Workflow Insight
-          </h3>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            What this workflow reveals about development style, sequencing, and
-            shipping posture.
-          </p>
-        </div>
-
-        <div className="space-y-3">
-          {workflowInsights.map((insight) => (
-            <div
-              key={insight.title}
-              className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60"
-            >
-              <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
-                {insight.title}
+          {hasDispatchSummary ? (
+            <div className="space-y-4">
+              <div className="grid gap-3 sm:grid-cols-3">
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    Total Agents
+                  </div>
+                  <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
+                    {formatCount(agentDispatch?.totalAgents ?? 0)}
+                  </div>
+                </div>
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    Background
+                  </div>
+                  <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
+                    {agentDispatch?.backgroundPct ?? 0}%
+                  </div>
+                </div>
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    Custom Agents
+                  </div>
+                  <div className="mt-1 text-lg font-bold text-slate-900 dark:text-slate-100">
+                    {agentDispatch?.customAgents.length ?? 0}
+                  </div>
+                </div>
               </div>
-              <p className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                {insight.body}
-              </p>
+
+              {dispatchTypeEntries.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Agent Types
+                  </div>
+                  <div className="space-y-2">
+                    {dispatchTypeEntries.map(([label, count]) => (
+                      <div
+                        key={label}
+                        className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-300"
+                      >
+                        <span className="font-medium">{label}</span>
+                        <span className="font-mono text-slate-400">{count}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {dispatchModelEntries.length > 0 && (
+                <div>
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Model Tiering
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {dispatchModelEntries.map(([label, count]) => (
+                      <span
+                        key={label}
+                        className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300"
+                      >
+                        {label} ({count})
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {agentDispatch?.customAgents.length ? (
+                <div>
+                  <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Custom Agents
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {agentDispatch.customAgents.slice(0, 6).map((label) => (
+                      <span
+                        key={label}
+                        className="rounded-full border border-violet-200 bg-violet-50 px-2.5 py-1 text-xs text-violet-700 dark:border-violet-700 dark:bg-violet-950/30 dark:text-violet-300"
+                      >
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
             </div>
-          ))}
-
-          {hasPhaseData && (
-            <div className="grid gap-3 pt-1 sm:grid-cols-2">
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  Explore Before Build
-                </div>
-                <div className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
-                  {phaseStats.exploreBeforeImplPct}%
-                </div>
-              </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
-                  Test Before Ship
-                </div>
-                <div className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
-                  {phaseStats.testBeforeShipPct}%
-                </div>
-              </div>
+          ) : (
+            <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-4 py-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-800/40 dark:text-slate-400">
+              No delegation data was captured in this report.
             </div>
           )}
+        </div>
+
+        <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
+          <div className="mb-4">
+            <h3 className="text-[15px] font-bold text-slate-900 dark:text-slate-100">
+              Workflow Insight
+            </h3>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              What this workflow reveals about development style, sequencing, and
+              shipping posture.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {workflowInsights.map((insight) => (
+              <div
+                key={insight.title}
+                className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60"
+              >
+                <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  {insight.title}
+                </div>
+                <p className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                  {insight.body}
+                </p>
+              </div>
+            ))}
+
+            {hasPhaseData && (
+              <div className="grid gap-3 pt-1 sm:grid-cols-2">
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    Explore Before Build
+                  </div>
+                  <div className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+                    {phaseStats.exploreBeforeImplPct}%
+                  </div>
+                </div>
+                <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 dark:border-slate-700 dark:bg-slate-800/60">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                    Test Before Ship
+                  </div>
+                  <div className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-100">
+                    {phaseStats.testBeforeShipPct}%
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useMermaid.ts
+++ b/src/hooks/useMermaid.ts
@@ -51,7 +51,15 @@ export function useMermaid(options: UseMermaidOptions = {}): UseMermaidReturn {
                 startOnLoad: false,
                 theme: "neutral",
                 securityLevel: "strict",
-                flowchart: { useMaxWidth: true },
+                themeVariables: {
+                  fontSize: "16px",
+                },
+                flowchart: {
+                  useMaxWidth: false,
+                  htmlLabels: true,
+                  nodeSpacing: 40,
+                  rankSpacing: 56,
+                },
               });
             })();
           }

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -652,6 +652,18 @@ function findSectionByTitle(
 function parseNumericValue(s: string): number {
   if (!s) return 0;
   s = s.replace(/,/g, "").trim();
+
+  const tokenMatch = s.match(
+    /(\d+(?:\.\d+)?)\s*([KM])?\s*(?:tokens?|tok)\b/i,
+  );
+  if (tokenMatch) {
+    const value = parseFloat(tokenMatch[1]);
+    const suffix = tokenMatch[2]?.toUpperCase();
+    if (suffix === "M") return Math.round(value * 1_000_000);
+    if (suffix === "K") return Math.round(value * 1_000);
+    return Math.round(value) || 0;
+  }
+
   const upper = s.toUpperCase();
   if (upper.endsWith("M")) return Math.round(parseFloat(s) * 1_000_000);
   if (upper.endsWith("K")) return Math.round(parseFloat(s) * 1_000);

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -1,0 +1,135 @@
+import type { HarnessData } from "@/types/insights";
+
+export const HIDEABLE_HARNESS_SECTION_KEYS = [
+  "heroStats",
+  "activityHeatmap",
+  "howIWork",
+  "toolUsage",
+  "workflowData",
+  "skillInventory",
+  "plugins",
+  "cliTools",
+  "gitPatterns",
+  "permissionModes",
+  "hookDefinitions",
+  "agentDispatch",
+  "languages",
+  "mcpServers",
+  "versions",
+  "writeupSections",
+  "harnessFiles",
+] as const;
+
+export type HideableHarnessSectionKey =
+  (typeof HIDEABLE_HARNESS_SECTION_KEYS)[number];
+
+const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
+  "toolUsage",
+  "workflowData",
+  "skillInventory",
+  "plugins",
+  "cliTools",
+  "gitPatterns",
+  "permissionModes",
+  "hookDefinitions",
+  "agentDispatch",
+  "languages",
+  "mcpServers",
+  "versions",
+  "writeupSections",
+  "harnessFiles",
+]);
+
+export function getHiddenHarnessSections(
+  disabledSections: Record<string, boolean>,
+): HideableHarnessSectionKey[] {
+  return HIDEABLE_HARNESS_SECTION_KEYS.filter((key) => disabledSections[key]);
+}
+
+export function isHarnessSectionHidden(
+  hiddenSections: string[] | null | undefined,
+  key: HideableHarnessSectionKey,
+): boolean {
+  return hiddenSections?.includes(key) ?? false;
+}
+
+export function stripHiddenHarnessData(
+  data: HarnessData,
+  hiddenSections: readonly string[],
+): HarnessData {
+  const copy: HarnessData = {
+    ...data,
+    toolUsage: { ...data.toolUsage },
+    skillInventory: [...data.skillInventory],
+    hookDefinitions: [...data.hookDefinitions],
+    plugins: [...data.plugins],
+    harnessFiles: [...data.harnessFiles],
+    cliTools: { ...data.cliTools },
+    languages: { ...data.languages },
+    models: { ...data.models },
+    permissionModes: { ...data.permissionModes },
+    mcpServers: { ...data.mcpServers },
+    gitPatterns: {
+      ...data.gitPatterns,
+      branchPrefixes: { ...data.gitPatterns.branchPrefixes },
+    },
+    versions: [...data.versions],
+    writeupSections: [...data.writeupSections],
+  };
+
+  for (const key of hiddenSections) {
+    if (!STRIPPABLE_HARNESS_DATA_KEYS.has(key)) continue;
+
+    switch (key) {
+      case "workflowData":
+        copy.workflowData = null;
+        break;
+      case "skillInventory":
+        copy.skillInventory = [];
+        break;
+      case "plugins":
+        copy.plugins = [];
+        break;
+      case "cliTools":
+        copy.cliTools = {};
+        break;
+      case "gitPatterns":
+        copy.gitPatterns = {
+          prCount: 0,
+          commitCount: 0,
+          linesAdded: "0",
+          branchPrefixes: {},
+        };
+        break;
+      case "permissionModes":
+        copy.permissionModes = {};
+        break;
+      case "hookDefinitions":
+        copy.hookDefinitions = [];
+        break;
+      case "agentDispatch":
+        copy.agentDispatch = null;
+        break;
+      case "languages":
+        copy.languages = {};
+        break;
+      case "mcpServers":
+        copy.mcpServers = {};
+        break;
+      case "versions":
+        copy.versions = [];
+        break;
+      case "writeupSections":
+        copy.writeupSections = [];
+        break;
+      case "harnessFiles":
+        copy.harnessFiles = [];
+        break;
+      case "toolUsage":
+        copy.toolUsage = {};
+        break;
+    }
+  }
+
+  return copy;
+}


### PR DESCRIPTION
## Summary
- mirror report-only cards into review/edit visibility controls and honor hidden harness sections after publish
- improve review accessibility and readability for sensitive data controls, activity heatmaps, tool usage, file operations, and workflow diagrams
- fix harness token parsing and API cost estimation for model usage displays

## Validation
- npx prisma generate
- npx eslint 'src/app/upload/page.tsx' 'src/app/insights/[slug]/page.tsx' 'src/app/insights/[slug]/edit/page.tsx' 'src/app/api/insights/route.ts' 'src/lib/harness-section-visibility.ts' 'src/components/MiniBarChart.tsx'
- npx eslint 'src/app/upload/page.tsx' 'src/components/ActivityHeatmap.tsx' 'src/components/FileOpStyleBar.tsx' 'src/components/HowIWorkCluster.tsx' 'src/components/ToolUsageTreemap.tsx' 'src/components/WorkflowDiagram.tsx' 'src/hooks/useMermaid.ts' 'src/lib/harness-parser.ts'
- npx tsc --noEmit