### PR TITLE
fix(workflow-diagram): responsive Mermaid with readable typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,3 +64,36 @@ body {
 .dropzone-active {
   animation: pulse-border 1.5s ease-in-out infinite;
 }
+
+/* Workflow diagram — Mermaid SVG overrides.
+   Mermaid renders node labels via <foreignObject> (which inherits HTML
+   fonts) but edge weights and some helper text render as raw SVG <text>
+   nodes. Those don't inherit naturally, so we force the Inter stack with
+   high specificity. Edge-label sizes are bumped here too — Mermaid's
+   theme `fontSize` doesn't reach them. */
+.workflow-diagram-container svg,
+.workflow-diagram-container svg * {
+  font-family:
+    "Inter",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif !important;
+}
+.workflow-diagram-container .nodeLabel,
+.workflow-diagram-container .nodeLabel div,
+.workflow-diagram-container .nodeLabel span {
+  line-height: 1.15 !important;
+}
+.workflow-diagram-container--desktop .edgeLabel,
+.workflow-diagram-container--desktop .edgeLabel * {
+  font-size: 18px !important;
+  font-weight: 600 !important;
+}
+.workflow-diagram-container--mobile .edgeLabel,
+.workflow-diagram-container--mobile .edgeLabel * {
+  font-size: 16px !important;
+  font-weight: 600 !important;
+}

--- a/src/components/WorkflowDiagram.tsx
+++ b/src/components/WorkflowDiagram.tsx
@@ -149,31 +149,68 @@ function buildWorkflowInsights(
   return insights.slice(0, 4);
 }
 
+export interface BuildWorkflowDiagramOptions {
+  /** Flowchart layout direction. `"LR"` for desktop, `"TD"` for narrow. */
+  direction?: "LR" | "TD";
+  /** Font size (px) for the skill short-name line in each node label. */
+  nameSize?: number;
+  /** Font size (px) for the plugin + "N× used" meta lines in each node label. */
+  metaSize?: number;
+}
+
 export function buildWorkflowDiagram(
   workflowData: HarnessWorkflowData,
+  options: BuildWorkflowDiagramOptions = {},
 ): string {
   const { skillInvocations, workflowPatterns } = workflowData;
+  const { direction = "LR", nameSize = 24, metaSize = 18 } = options;
 
-  const skills = Object.keys(skillInvocations);
+  // Only render skills that actually participate in a workflow pattern.
+  // This drops isolated nodes (skills used without transitioning to/from
+  // anything else) which would otherwise clutter the graph without adding
+  // information — the current-use counts for those are still surfaced in
+  // the pill row above the diagram. Falls back to all skills when no
+  // patterns exist at all, so a very sparse report still shows something.
+  const patternSkillSet = new Set<string>();
+  for (const pattern of workflowPatterns) {
+    for (const skill of pattern.sequence) patternSkillSet.add(skill);
+  }
+  const allSkills = Object.keys(skillInvocations);
+  const skills =
+    patternSkillSet.size > 0
+      ? allSkills.filter((s) => patternSkillSet.has(s))
+      : allSkills;
+
   if (skills.length === 0) return "";
 
-  const lines: string[] = ["flowchart TD"];
+  const lines: string[] = [`flowchart ${direction}`];
 
-  for (const [skill, count] of Object.entries(skillInvocations)) {
+  for (const skill of skills) {
+    const count = skillInvocations[skill] ?? 0;
     const id = skill.replace(/[^a-zA-Z0-9]/g, "_");
     const { plugin, shortName } = parseSkillSource(skill);
     const safeName = shortName.replace(/"/g, "'");
-    const label = `${safeName}<br/><span style='font-size:12px;opacity:0.72'>${plugin}</span><br/><span style='font-size:13px;font-weight:700'>${count}×</span>`;
+    // Three stacked lines, each with its own explicit inline font-size so
+    // Mermaid's theme defaults can't shrink them. htmlLabels render these
+    // as raw HTML inside a foreignObject, which means:
+    //   - `<span style=...>` wins against any CSS cascade
+    //   - securityLevel must be "loose" (see useMermaid.ts) or the style
+    //     attribute gets stripped by DOMPurify
+    const label =
+      `<span style='font-size:${nameSize}px;font-weight:700;line-height:1.15;display:block'>${safeName}</span>` +
+      `<span style='font-size:${metaSize}px;font-weight:500;opacity:0.72;line-height:1.1;display:block;margin-top:4px'>${plugin}</span>` +
+      `<span style='font-size:${metaSize + 1}px;font-weight:700;line-height:1.1;display:block;margin-top:3px'>${count}× used</span>`;
     lines.push(`    ${id}["${label}"]`);
   }
 
+  const renderedSkills = new Set(skills);
   const edgeCounts: Record<string, number> = {};
   for (const pattern of workflowPatterns) {
     const seq = pattern.sequence;
     for (let i = 0; i < seq.length - 1; i++) {
       const from = seq[i];
       const to = seq[i + 1];
-      if (from && to) {
+      if (from && to && renderedSkills.has(from) && renderedSkills.has(to)) {
         const key = `${from}|||${to}`;
         edgeCounts[key] = (edgeCounts[key] || 0) + pattern.count;
       }
@@ -198,11 +235,34 @@ export function buildWorkflowDiagram(
     const { plugin } = parseSkillSource(skill);
     const color = getPluginColor(plugin);
     lines.push(
-      `    style ${id} fill:${color.fill},stroke:${color.stroke},color:${color.text}`,
+      `    style ${id} fill:${color.fill},stroke:${color.stroke},color:${color.text},stroke-width:2px`,
     );
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Force the rendered Mermaid SVG to fill 100% of its container width.
+ *
+ * Mermaid's `useMaxWidth: true` only sets `max-width:100%`, leaving the
+ * intrinsic `width` at the natural layout size. For a flowchart with a
+ * handful of nodes that means lots of wasted whitespace on wide screens
+ * and a tendency to center rather than stretch. Stripping the hardcoded
+ * `width`/`height` attributes and forcing `width="100%"` + `height: auto`
+ * makes the graph actually fill the card edge-to-edge at any breakpoint.
+ */
+function stretchSvgToFullWidth(container: HTMLDivElement) {
+  const svg = container.querySelector("svg");
+  if (!svg) return;
+  svg.removeAttribute("width");
+  svg.removeAttribute("height");
+  svg.setAttribute("width", "100%");
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+  svg.style.width = "100%";
+  svg.style.maxWidth = "100%";
+  svg.style.height = "auto";
+  svg.style.display = "block";
 }
 
 export default function WorkflowDiagram({
@@ -211,24 +271,47 @@ export default function WorkflowDiagram({
   authorHandle,
 }: WorkflowDiagramProps) {
   const name = authorHandle ? `@${authorHandle}` : "This developer";
-  const containerRef = useRef<HTMLDivElement>(null);
+  const desktopRef = useRef<HTMLDivElement>(null);
+  const mobileRef = useRef<HTMLDivElement>(null);
   const renderIdRef = useRef(0);
   const hasSkillData = Object.keys(workflowData.skillInvocations).length > 0;
   const { ready, error, render } = useMermaid({ shouldLoad: hasSkillData });
 
   useEffect(() => {
-    if (!ready || !containerRef.current) return;
+    if (!ready) return;
     let cancelled = false;
 
-    const diagram = buildWorkflowDiagram(workflowData);
-    if (!diagram) return;
-
-    const id = `mermaid-workflow-${++renderIdRef.current}`;
-    render(id, diagram).then((svg) => {
-      if (svg && !cancelled && containerRef.current) {
-        containerRef.current.innerHTML = svg;
-      }
+    // Render two separate diagrams so the desktop and mobile variants can
+    // use different flowchart directions and font sizes. We can't reliably
+    // switch direction with CSS alone — Mermaid bakes layout into the SVG
+    // at render time, so the breakpoint lives in the JSX (hidden / block
+    // classes) and each variant renders into its own container ref.
+    const desktopDiagram = buildWorkflowDiagram(workflowData, {
+      direction: "LR",
+      nameSize: 24,
+      metaSize: 18,
     });
+    const mobileDiagram = buildWorkflowDiagram(workflowData, {
+      direction: "TD",
+      nameSize: 20,
+      metaSize: 15,
+    });
+
+    const renderInto = async (
+      container: HTMLDivElement | null,
+      diagram: string,
+      idSuffix: string,
+    ) => {
+      if (!container || !diagram) return;
+      const id = `mermaid-workflow-${++renderIdRef.current}-${idSuffix}`;
+      const svg = await render(id, diagram);
+      if (!svg || cancelled || !container) return;
+      container.innerHTML = svg;
+      stretchSvgToFullWidth(container);
+    };
+
+    renderInto(desktopRef.current, desktopDiagram, "desktop");
+    renderInto(mobileRef.current, mobileDiagram, "mobile");
 
     return () => {
       cancelled = true;
@@ -238,7 +321,6 @@ export default function WorkflowDiagram({
   if (error || !hasSkillData) return null;
 
   const { phaseStats, phaseDistribution } = workflowData;
-  const sortedSkills = topEntries(workflowData.skillInvocations, 10);
   const topSkillPills = topEntries(workflowData.skillInvocations, 6);
   const topSkill = topEntries(workflowData.skillInvocations, 1)[0];
   const strongestPattern = strongestWorkflowPattern(
@@ -307,46 +389,22 @@ export default function WorkflowDiagram({
           </div>
         )}
 
+        {/* Desktop variant: flowchart LR, big fonts. Hidden below sm breakpoint. */}
         <div
-          ref={containerRef}
-          className="hidden min-h-[420px] items-center justify-center overflow-auto rounded-lg border border-slate-100 bg-slate-50/70 px-4 py-5 sm:flex dark:border-slate-800 dark:bg-slate-950/30 [&_svg]:min-h-[360px] [&_svg]:min-w-[960px] [&_svg]:max-w-none"
+          ref={desktopRef}
+          className="workflow-diagram-container workflow-diagram-container--desktop hidden min-h-[320px] items-center justify-center rounded-lg border border-slate-100 bg-slate-50/70 px-4 py-5 sm:flex dark:border-slate-800 dark:bg-slate-950/30"
         >
           <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
         </div>
 
-        <div className="block sm:hidden">
-          <ol className="space-y-2">
-            {sortedSkills.map(([skillName, count]) => {
-              const { plugin } = parseSkillSource(skillName);
-              const color = getPluginColor(plugin);
-              const safeName = safeSkillKeyLabel(skillName);
-              return (
-                <li
-                  key={skillName}
-                  className="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/50"
-                >
-                  <div className="min-w-0">
-                    <div className="truncate font-mono text-xs text-slate-700 dark:text-slate-300">
-                      {safeName}
-                    </div>
-                    <div
-                      className="mt-1 inline-flex rounded-full px-2 py-0.5 text-[10px] font-semibold"
-                      style={{
-                        backgroundColor: color.fill,
-                        color: color.text,
-                        border: `1px solid ${color.stroke}`,
-                      }}
-                    >
-                      {plugin}
-                    </div>
-                  </div>
-                  <span className="ml-3 shrink-0 text-xs text-slate-400">
-                    {count}x
-                  </span>
-                </li>
-              );
-            })}
-          </ol>
+        {/* Mobile variant: flowchart TD (top-down) so nodes stack naturally
+            on narrow viewports. Smaller label sizes because each node gets
+            the full 375px rather than sharing it horizontally. */}
+        <div
+          ref={mobileRef}
+          className="workflow-diagram-container workflow-diagram-container--mobile flex min-h-[320px] items-center justify-center rounded-lg border border-slate-100 bg-slate-50/70 px-3 py-4 sm:hidden dark:border-slate-800 dark:bg-slate-950/30"
+        >
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
         </div>
 
         {(pluginsPresent.length > 1 || topSkill || strongestPattern) && (
@@ -449,7 +507,9 @@ export default function WorkflowDiagram({
                         className="flex items-center justify-between text-xs text-slate-600 dark:text-slate-300"
                       >
                         <span className="font-medium">{label}</span>
-                        <span className="font-mono text-slate-400">{count}</span>
+                        <span className="font-mono text-slate-400">
+                          {count}
+                        </span>
                       </div>
                     ))}
                   </div>
@@ -505,8 +565,8 @@ export default function WorkflowDiagram({
               Workflow Insight
             </h3>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              What this workflow reveals about development style, sequencing, and
-              shipping posture.
+              What this workflow reveals about development style, sequencing,
+              and shipping posture.
             </p>
           </div>
 

--- a/src/components/__tests__/WorkflowDiagram.test.tsx
+++ b/src/components/__tests__/WorkflowDiagram.test.tsx
@@ -25,31 +25,49 @@ describe("buildWorkflowDiagram", () => {
     expect(buildWorkflowDiagram(makeWorkflowData())).toBe("");
   });
 
-  it("produces valid flowchart header for typical input", () => {
+  it("defaults to flowchart LR (desktop layout)", () => {
     const data = makeWorkflowData({
       skillInvocations: { "ce-brainstorm": 8, "ce-work": 12 },
       workflowPatterns: [{ sequence: ["ce-brainstorm", "ce-work"], count: 5 }],
     });
     const result = buildWorkflowDiagram(data);
-    expect(result).toContain("flowchart TD");
+    expect(result).toContain("flowchart LR");
     expect(result).toContain("ce_brainstorm");
     expect(result).toContain("ce_work");
     expect(result).toContain("-->");
   });
 
+  it("supports TD direction for narrow viewports", () => {
+    const data = makeWorkflowData({
+      skillInvocations: { "ce-brainstorm": 8, "ce-work": 12 },
+      workflowPatterns: [{ sequence: ["ce-brainstorm", "ce-work"], count: 5 }],
+    });
+    const result = buildWorkflowDiagram(data, { direction: "TD" });
+    expect(result).toContain("flowchart TD");
+    expect(result).not.toContain("flowchart LR");
+  });
+
   it("includes invocation counts in node labels", () => {
     const data = makeWorkflowData({
       skillInvocations: { "git-commit-push-pr": 4 },
+      workflowPatterns: [
+        {
+          sequence: ["git-commit-push-pr", "git-commit-push-pr"],
+          count: 1,
+        },
+      ],
     });
     const result = buildWorkflowDiagram(data);
-    // Labels now use HTML with plugin source and count on separate lines
     expect(result).toContain("git-commit-push-pr");
-    expect(result).toContain("4\u00d7");
+    expect(result).toContain("4\u00d7 used");
   });
 
   it("includes plugin source in node labels", () => {
     const data = makeWorkflowData({
       skillInvocations: { "superpowers:writing-plans": 5, "ux-mockup": 3 },
+      workflowPatterns: [
+        { sequence: ["superpowers:writing-plans", "ux-mockup"], count: 2 },
+      ],
     });
     const result = buildWorkflowDiagram(data);
     // Plugin skills show the plugin name
@@ -77,6 +95,65 @@ describe("buildWorkflowDiagram", () => {
     const result = buildWorkflowDiagram(data);
     expect(result).not.toContain("|1x|");
     expect(result).toContain("ce_brainstorm --> ce_work");
+  });
+
+  it("filters out skills that do not participate in any pattern", () => {
+    const data = makeWorkflowData({
+      skillInvocations: {
+        "ce-brainstorm": 8,
+        "ce-work": 12,
+        "isolated-skill": 99,
+      },
+      workflowPatterns: [{ sequence: ["ce-brainstorm", "ce-work"], count: 3 }],
+    });
+    const result = buildWorkflowDiagram(data);
+    expect(result).toContain("ce_brainstorm");
+    expect(result).toContain("ce_work");
+    // isolated-skill has a huge count but never appears in a pattern — it
+    // should be excluded from the graph so it doesn't clutter the layout.
+    expect(result).not.toContain("isolated_skill");
+    expect(result).not.toContain("isolated-skill");
+  });
+
+  it("falls back to all skills when no patterns exist at all", () => {
+    const data = makeWorkflowData({
+      skillInvocations: { "solo-skill": 5, "other-solo": 3 },
+      workflowPatterns: [],
+    });
+    const result = buildWorkflowDiagram(data);
+    // Without any patterns to filter against, both skills should still
+    // render — otherwise sparse reports show an empty diagram.
+    expect(result).toContain("solo_skill");
+    expect(result).toContain("other_solo");
+  });
+
+  it("applies explicit inline font sizes to label spans (desktop defaults)", () => {
+    const data = makeWorkflowData({
+      skillInvocations: { "ce-work": 7 },
+      workflowPatterns: [{ sequence: ["ce-work", "ce-work"], count: 1 }],
+    });
+    const result = buildWorkflowDiagram(data);
+    // Default desktop sizes: nameSize=24, metaSize=18.
+    expect(result).toContain("font-size:24px");
+    expect(result).toContain("font-size:18px");
+    // "N× used" line is metaSize + 1.
+    expect(result).toContain("font-size:19px");
+  });
+
+  it("applies smaller inline font sizes when mobile sizes are passed", () => {
+    const data = makeWorkflowData({
+      skillInvocations: { "ce-work": 7 },
+      workflowPatterns: [{ sequence: ["ce-work", "ce-work"], count: 1 }],
+    });
+    const result = buildWorkflowDiagram(data, {
+      direction: "TD",
+      nameSize: 20,
+      metaSize: 15,
+    });
+    expect(result).toContain("font-size:20px");
+    expect(result).toContain("font-size:15px");
+    expect(result).toContain("font-size:16px");
+    expect(result).not.toContain("font-size:24px");
   });
 });
 

--- a/src/hooks/useMermaid.ts
+++ b/src/hooks/useMermaid.ts
@@ -50,15 +50,25 @@ export function useMermaid(options: UseMermaidOptions = {}): UseMermaidReturn {
               mermaidInstance.initialize({
                 startOnLoad: false,
                 theme: "neutral",
-                securityLevel: "strict",
+                // "loose" allows inline style attributes in htmlLabels, which
+                // we rely on for per-line font sizing inside node labels.
+                // The label content is derived from privacy-sanitized data —
+                // see src/lib/privacy-safe-workflow.ts.
+                securityLevel: "loose",
                 themeVariables: {
-                  fontSize: "16px",
+                  fontSize: "24px",
+                  fontFamily:
+                    'Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+                  primaryColor: "#ffffff",
+                  primaryBorderColor: "#cbd5e1",
+                  lineColor: "#94a3b8",
                 },
                 flowchart: {
-                  useMaxWidth: false,
+                  useMaxWidth: true,
                   htmlLabels: true,
-                  nodeSpacing: 40,
-                  rankSpacing: 56,
+                  nodeSpacing: 60,
+                  rankSpacing: 80,
+                  padding: 18,
                 },
               });
             })();


### PR DESCRIPTION
Closes #25.

## Summary

Keeps the Mermaid-based workflow diagram but fixes the three problems that made it unusable:

1. **No more horizontal scroll**. Drops the 960 px min-width on the SVG and switches `useMaxWidth` to `true`. The diagram fills its card edge-to-edge at every breakpoint — a post-render pass also strips Mermaid's hardcoded `width`/`height` so wide graphs actually stretch instead of centering.
2. **Readable node text**. Each node label is three stacked `<span>`s with explicit inline font sizes (24 / 18 / 19 px on desktop, 20 / 15 / 16 px on mobile). Inline styles beat Mermaid's CSS cascade, so the plugin name and "N× used" sub-lines can't be silently shrunk. `securityLevel` switched from `"strict"` to `"loose"` so DOMPurify stops stripping those inline styles.
3. **Proper mobile layout**. `buildWorkflowDiagram` now takes a `direction` option (`"LR"` for desktop, `"TD"` for mobile). The component renders two SVGs into two refs and toggles between them at the Tailwind `sm:` breakpoint. Drops the old flat `<ol>` fallback — narrow viewports get a real top-down flowchart variant instead.

## Other changes

- **Graph filtering**: skills that don't participate in any workflow pattern are excluded from the graph. Isolated nodes added visual noise without information (their counts are still shown in the pill row above). Sparse reports with zero patterns still fall back to the full set so the diagram is never empty.
- **Inter font throughout**: `useMermaid` sets `themeVariables.fontFamily` to the Inter stack and a scoped `globals.css` rule forces every SVG descendant (including the raw SVG `<text>` nodes used for edge weights) to inherit it. Edge labels are bumped to 18 px desktop / 16 px mobile.
- **Node/rank spacing** bumped (60 / 80 / 18) so the larger text has breathing room.

## Why this approach

The prior version of this PR replaced the Mermaid diagram with a hand-rolled "strongest chain" view, which collapsed to a 2-card row on hub-and-spoke data (like the real `@kabirdos` report: 10 patterns, mostly 2-step sequences with `writing-plans` as a hub). A visualization research pass also confirmed that alternative viz types (chord, matrix, arc, stacked primitives) were worse than Mermaid once sized and typed correctly — see the discussion in the PR conversation for the full comparison.

## Test plan

- [x] `WorkflowDiagram` unit tests rewritten for new signature — 12 tests, all passing
- [x] Full Vitest suite: 280 / 280 passing
- [x] `tsc --noEmit` clean on all source files
- [x] `eslint` clean on all changed files
- [x] Visual validation against the real `@kabirdos` report data in a standalone preview (`/tmp/workflow-chain-preview.html`) — both desktop `LR` and mobile 375 px `TD` variants
- [ ] Final browser QA in the running app against a live harness report before merging

## Files

- `src/components/WorkflowDiagram.tsx` — `buildWorkflowDiagram` takes `direction`/`nameSize`/`metaSize` options, filters skills to those in patterns, restructures labels with explicit inline sizes. Component uses two refs and renders two diagrams. New `stretchSvgToFullWidth` helper.
- `src/hooks/useMermaid.ts` — Inter font family, 24 px base size, `useMaxWidth: true`, bumped spacing, `securityLevel: "loose"`.
- `src/app/globals.css` — scoped overrides for Inter inheritance on SVG text nodes and edge-label sizing.
- `src/components/__tests__/WorkflowDiagram.test.tsx` — direction parameter, filter behavior, inline-font-size assertions.

---

_History note: an earlier version of this PR replaced Mermaid with a hand-rolled chain layout. The branch was reset to `main` and force-pushed after the chain approach was rejected in visual review. The old commit `e996927` is still reachable via the GitHub PR timeline if you want to diff against it._