### PR TITLE
fix: replace sensitive-items bulk buttons with jump button (#21)

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1360,16 +1360,23 @@ export default function UploadPage() {
             {totalSensitive > 0 && (
               <div className="ml-auto flex gap-2">
                 <button
-                  onClick={applyAllRedactions}
+                  type="button"
+                  onClick={() => {
+                    const target = document.getElementById(
+                      "sensitive-data-review",
+                    );
+                    if (!target) return;
+                    target.scrollIntoView({
+                      behavior: "smooth",
+                      block: "start",
+                    });
+                    // Move focus into the target so keyboard/screen-reader
+                    // users land in the section after scrolling.
+                    target.focus({ preventScroll: true });
+                  }}
                   className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
                 >
-                  Redact all sensitive items
-                </button>
-                <button
-                  onClick={resetRedactions}
-                  className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
-                >
-                  Reset to defaults
+                  Review sensitive items
                 </button>
               </div>
             )}
@@ -2004,10 +2011,32 @@ export default function UploadPage() {
 
           {/* ── Inline Sensitive Data Controls ── */}
           {redactions.length > 0 && (
-            <div className="mb-6">
-              <h3 className="mb-3 text-base font-semibold text-slate-900 dark:text-slate-100">
-                Sensitive Data Review
-              </h3>
+            <div
+              id="sensitive-data-review"
+              tabIndex={-1}
+              className="mb-6 scroll-mt-24 focus:outline-none"
+            >
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                  Sensitive Data Review
+                </h3>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={applyAllRedactions}
+                    className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
+                  >
+                    Redact all sensitive items
+                  </button>
+                  <button
+                    type="button"
+                    onClick={resetRedactions}
+                    className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-medium text-amber-900 transition-colors hover:bg-amber-100 dark:border-amber-700 dark:bg-slate-900 dark:text-amber-200 dark:hover:bg-amber-950/40"
+                  >
+                    Reset to defaults
+                  </button>
+                </div>
+              </div>
               <div className="mb-3 flex flex-wrap gap-2 text-xs">
                 <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-amber-800 dark:border-amber-800/60 dark:bg-amber-950/20 dark:text-amber-300">
                   Redact: removes the text entirely


### PR DESCRIPTION
Closes #21.

## Summary
- Removed the top-of-page **Redact all sensitive items** and **Reset to defaults** buttons from the publish review screen's summary bar.
- Added a single **Review sensitive items** button in their place that smooth-scrolls to the existing Sensitive Data Review section.
- Moved the bulk redact-all / reset-to-defaults controls into the header of the Sensitive Data Review section so they remain reachable.
- Added focus management (tabIndex + focus after scroll) so keyboard and screen-reader users land inside the target section.

## Test plan
- [ ] Upload a report containing sensitive items, reach Step 3 (Review & Publish), confirm only one button (\"Review sensitive items\") appears in the amber summary bar.
- [ ] Click it and verify the page smooth-scrolls to the Sensitive Data Review section.
- [ ] Confirm Redact all / Reset to defaults are visible in the Sensitive Data Review section header and still function.
- [ ] Confirm the button does not render when no sensitive items were detected.
- [ ] Tab key after clicking the jump button should move focus into the target section, not continue from the original button.

Codex review passed pre-commit (one low-severity a11y finding fixed by adding focus management) and pre-push.