### PR TITLE
fix: restore lines-of-code metric to profile and report pages (#24)

### DIFF
--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -57,6 +57,8 @@ interface ReportData {
   dayCount: number | null;
   totalTokens: number | null;
   durationHours: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
   harnessData: HarnessData | null;
   hiddenHarnessSections: string[];
   atAGlance: unknown;
@@ -476,6 +478,8 @@ export default function EditReportPage() {
               sessionCount={
                 report.sessionCount || harnessData.stats?.sessionCount || 0
               }
+              linesAdded={report.linesAdded ?? null}
+              linesRemoved={report.linesRemoved ?? null}
             />
           </HideableCard>
 

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -347,6 +347,8 @@ export default function InsightDetailPage() {
                 report.harnessData?.stats?.sessionCount ||
                 0
               }
+              linesAdded={report.linesAdded ?? null}
+              linesRemoved={report.linesRemoved ?? null}
             />
           )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,6 +77,8 @@ interface InsightSummary {
   commitCount: number | null;
   totalTokens: number | null;
   durationHours: number | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
   detectedSkills: SkillKey[];
   harnessData: HarnessSlice | null;
   author: {
@@ -105,6 +107,16 @@ function formatHours(n: number): string {
   if (n >= 100) return `${Math.round(n)}h`;
   if (n >= 10) return `${n.toFixed(0)}h`;
   return `${n.toFixed(1)}h`;
+}
+
+// Compact formatter for lines-of-code counts. Keeps one decimal in the
+// k-range so values like 18,400 render as "18.4k" (matching the format
+// called out in issue #24) and stay readable in the narrow vanity strip.
+function formatLines(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return Math.round(n).toLocaleString();
 }
 
 function perWeek(
@@ -674,6 +686,25 @@ function ProfileCard({
               {pluginsCount === 1 ? "plugin" : "plugins"}
             </span>
           </div>
+          {((insight.linesAdded ?? 0) > 0 ||
+            (insight.linesRemoved ?? 0) > 0) && (
+            <div className="flex flex-1 flex-col border-l border-slate-100 px-3 last:pr-0 dark:border-slate-800">
+              <span className="whitespace-nowrap text-[15px] font-bold leading-none">
+                <span className="text-green-600 dark:text-green-400">
+                  +{formatLines(insight.linesAdded ?? 0)}
+                </span>
+                <span className="text-slate-300 dark:text-slate-600">
+                  {" / "}
+                </span>
+                <span className="text-red-600 dark:text-red-400">
+                  -{formatLines(insight.linesRemoved ?? 0)}
+                </span>
+              </span>
+              <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
+                lines
+              </span>
+            </div>
+          )}
           {featured && commitsWk != null && commitsWk > 0 && (
             <div className="flex flex-1 flex-col border-l border-slate-100 px-3 dark:border-slate-800">
               <span className="text-[15px] font-bold leading-none text-cyan-600 dark:text-cyan-400">
@@ -808,6 +839,8 @@ export default function HomePage() {
             commitCount: (r.commitCount as number) ?? null,
             totalTokens: (r.totalTokens as number) ?? null,
             durationHours: (r.durationHours as number) ?? null,
+            linesAdded: (r.linesAdded as number) ?? null,
+            linesRemoved: (r.linesRemoved as number) ?? null,
             detectedSkills: normalizeSkills(r.detectedSkills),
             harnessData: (r.harnessData as HarnessSlice) ?? null,
             author: r.author as InsightSummary["author"],

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1399,6 +1399,8 @@ export default function UploadPage() {
                     parsed.harnessData.stats.sessionCount ??
                     0
                   }
+                  linesAdded={parsed.stats.linesAdded ?? null}
+                  linesRemoved={parsed.stats.linesRemoved ?? null}
                 />
               </RedactableSection>
 

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -6,12 +6,24 @@ interface HeroStatsProps {
   stats: HarnessStats;
   dayCount: number | null;
   sessionCount: number | null;
+  linesAdded?: number | null;
+  linesRemoved?: number | null;
 }
 
 function formatNumber(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return n.toLocaleString();
+}
+
+// Compact lines-of-code formatter: "18.4k" above a thousand, raw number
+// below. Mirrors the helper used on the homepage ProfileCard so the
+// two surfaces show consistent magnitudes.
+function formatLines(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return Math.round(n).toLocaleString();
 }
 
 function perWeek(value: number, dayCount: number | null): string | null {
@@ -138,42 +150,66 @@ export default function HeroStats({
   stats,
   dayCount,
   sessionCount,
+  linesAdded,
+  linesRemoved,
 }: HeroStatsProps) {
   const sessions = sessionCount || stats.sessionCount || 0;
+  // Null-safe: only render the lines pill when we have at least one
+  // positive value. Zero / null / undefined all hide the metric cleanly
+  // per issue #24 ("reports missing these values hide the metric cleanly").
+  const added = linesAdded ?? 0;
+  const removed = linesRemoved ?? 0;
+  const showLines = added > 0 || removed > 0;
 
   return (
-    <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
-      {stats.totalTokens > 0 && (
-        <StatCard
-          value={formatNumber(stats.totalTokens)}
-          label="Tokens"
-          rate={perWeek(stats.totalTokens, dayCount)}
-          numericSeed={stats.totalTokens}
-        />
-      )}
-      {sessions > 0 && (
-        <StatCard
-          value={sessions.toString()}
-          label="Sessions"
-          rate={perWeek(sessions, dayCount)}
-          numericSeed={sessions * 7}
-        />
-      )}
-      {stats.durationHours > 0 && (
-        <StatCard
-          value={`${stats.durationHours}h`}
-          label="Active Time"
-          rate={perWeek(stats.durationHours, dayCount)}
-          numericSeed={stats.durationHours * 13}
-        />
-      )}
-      {stats.skillsUsedCount > 0 && (
-        <StatCard
-          value={stats.skillsUsedCount.toString()}
-          label="Skills"
-          rate={null}
-          numericSeed={stats.skillsUsedCount * 31}
-        />
+    <div className="mb-8">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {stats.totalTokens > 0 && (
+          <StatCard
+            value={formatNumber(stats.totalTokens)}
+            label="Tokens"
+            rate={perWeek(stats.totalTokens, dayCount)}
+            numericSeed={stats.totalTokens}
+          />
+        )}
+        {sessions > 0 && (
+          <StatCard
+            value={sessions.toString()}
+            label="Sessions"
+            rate={perWeek(sessions, dayCount)}
+            numericSeed={sessions * 7}
+          />
+        )}
+        {stats.durationHours > 0 && (
+          <StatCard
+            value={`${stats.durationHours}h`}
+            label="Active Time"
+            rate={perWeek(stats.durationHours, dayCount)}
+            numericSeed={stats.durationHours * 13}
+          />
+        )}
+        {stats.skillsUsedCount > 0 && (
+          <StatCard
+            value={stats.skillsUsedCount.toString()}
+            label="Skills"
+            rate={null}
+            numericSeed={stats.skillsUsedCount * 31}
+          />
+        )}
+      </div>
+      {showLines && (
+        <div className="mt-3 flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 font-mono text-sm dark:border-slate-700 dark:bg-slate-900/50">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400">
+            Lines of code
+          </span>
+          <span className="font-bold text-green-600 dark:text-green-400">
+            +{formatLines(added)}
+          </span>
+          <span className="text-slate-300 dark:text-slate-600">/</span>
+          <span className="font-bold text-red-600 dark:text-red-400">
+            -{formatLines(removed)}
+          </span>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Closes #24.

## Summary
- Brings the +added/-removed lines metric back to the homepage ProfileCard vanity strip.
- Adds it to HeroStats on the harness report detail page (and upload/edit previews for parity).
- Format: "+18.4k / -9.2k" with green/red coloring matching the diff convention.
- Null-safe: if both values are null or zero, the metric is hidden cleanly.

## Verification
- Verified against real records in the local DB: 11 of 13 reports have non-null values (e.g. mika-tanaka-20260331-harness-demo: +28,400 / -9,200).
- `npx tsc --noEmit` clean.
- `npm run lint` has 3 pre-existing errors (unrelated files: page.tsx:820 setState-in-effect, top/page.tsx:206 setState-in-effect, SectionRenderer.tsx:103 unescaped entity) not introduced by this change.
- Codex CLI reviewed twice (pre-commit + pre-push); no blocking findings.

## Test plan
- [ ] Homepage: ProfileCard vanity strip shows "+x / -y lines" cell when values are present; cell is absent otherwise.
- [ ] Harness report detail: HeroStats shows the lines-of-code pill below the 4-card grid.
- [ ] Non-harness report detail: SnapshotCard (unchanged) continues to show lines.
- [ ] Upload + edit previews render the same pill in the hero section.