### PR TITLE
fix(projects): whole-card clickable, smaller, reposition below activity (#27)

### DIFF
--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -371,6 +371,16 @@ export default function InsightDetailPage() {
             />
           )}
 
+          {/* Project Links — rich stacked cards with OG metadata.
+              Rendered directly under the activity card per issue #27. */}
+          {report.reportProjects.length > 0 && (
+            <div className="mb-6">
+              <ProjectLinks
+                links={report.reportProjects.map((rp) => rp.project)}
+              />
+            </div>
+          )}
+
           {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
           {!isHarnessSectionHidden(hiddenHarnessSections, "howIWork") && (
             <HowIWorkCluster harnessData={report.harnessData} />
@@ -659,15 +669,6 @@ export default function InsightDetailPage() {
             </CollapsibleSection>
           )}
 
-          {/* Project Links — rich stacked cards with OG metadata. */}
-          {report.reportProjects.length > 0 && (
-            <div className="mb-6">
-              <ProjectLinks
-                links={report.reportProjects.map((rp) => rp.project)}
-              />
-            </div>
-          )}
-
           {/* Narrative Sections */}
           <div className="space-y-4">
             {SECTIONS.map((section) => {
@@ -720,6 +721,16 @@ export default function InsightDetailPage() {
               projectAreas={report.projectAreas}
             />
           </div>
+
+          {/* Project Links — rich stacked cards with OG metadata.
+              Rendered directly under the activity/snapshot card per issue #27. */}
+          {report.reportProjects.length > 0 && (
+            <div className="mb-6">
+              <ProjectLinks
+                links={report.reportProjects.map((rp) => rp.project)}
+              />
+            </div>
+          )}
 
           {/* Chart Data Visualizations (wire up orphaned chartData) */}
           {report.chartData && (
@@ -834,15 +845,6 @@ export default function InsightDetailPage() {
                     />
                   </div>
                 )}
-            </div>
-          )}
-
-          {/* Project Links — rich stacked cards with OG metadata. */}
-          {report.reportProjects.length > 0 && (
-            <div className="mb-6">
-              <ProjectLinks
-                links={report.reportProjects.map((rp) => rp.project)}
-              />
             </div>
           )}
 

--- a/src/components/ProjectLinks.tsx
+++ b/src/components/ProjectLinks.tsx
@@ -108,10 +108,28 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
   const showImage = Boolean(safeOgImage) && !imageFailed;
   const showSiteRow = Boolean(link.siteName) || Boolean(safeFavicon);
 
+  // Whole card becomes a link. Prefer liveUrl, fall back to githubUrl.
+  // If neither exists the overlay anchor is omitted entirely so the
+  // card stays non-clickable but visually consistent.
+  const cardHref = link.liveUrl || link.githubUrl || null;
+
+  // We use the "stretched link" pattern: the outer card is a plain
+  // <div class="relative">, a full-card <a> overlays it with ::after
+  // via `absolute inset-0`, and the inner icon buttons render as real
+  // <a> siblings with a higher z-index so they remain valid HTML (no
+  // interactive content nested inside an anchor) and stay keyboard-
+  // and screen-reader-navigable.
+  const hoverClass = cardHref ? "hover:shadow-lg" : "";
+
   return (
-    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-800/50">
+    <div
+      className={clsx(
+        "group relative overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow dark:border-slate-700 dark:bg-slate-800/50",
+        hoverClass,
+      )}
+    >
       {showImage && safeOgImage && (
-        <div className="relative aspect-[16/9] w-full overflow-hidden bg-slate-100 dark:bg-slate-900">
+        <div className="relative aspect-[16/7] w-full overflow-hidden bg-slate-100 dark:bg-slate-900">
           {/* Plain <img> on purpose — OG images come from arbitrary
               third-party hosts and next/image would require wildcard
               remotePatterns in next.config.ts. URL has been gated by
@@ -127,15 +145,15 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
           />
         </div>
       )}
-      <div className="p-4">
+      <div className="p-3">
         {showSiteRow && (
-          <div className="mb-1.5 flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+          <div className="mb-1 flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
             {safeFavicon && (
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={safeFavicon}
                 alt=""
-                className="h-4 w-4 rounded-sm"
+                className="h-3.5 w-3.5 rounded-sm"
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).style.display = "none";
                 }}
@@ -146,24 +164,24 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
             {link.siteName && <span className="truncate">{link.siteName}</span>}
           </div>
         )}
-        <h4 className="truncate font-medium text-slate-900 dark:text-slate-100">
+        <h4 className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
           {link.name}
         </h4>
         {link.description && (
-          <p className="mt-1 line-clamp-2 text-sm text-slate-500 dark:text-slate-400">
+          <p className="mt-0.5 line-clamp-2 text-xs text-slate-500 dark:text-slate-400">
             {link.description}
           </p>
         )}
-        <div className="mt-3 flex items-center gap-1.5">
+        <div className="relative z-10 mt-2 flex items-center gap-1">
           {link.githubUrl && (
             <a
               href={link.githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-300"
+              className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-300"
               aria-label={`${link.name} on GitHub`}
             >
-              <GitFork className="h-4 w-4" />
+              <GitFork className="h-3.5 w-3.5" />
             </a>
           )}
           {link.liveUrl && (
@@ -171,19 +189,30 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
               href={link.liveUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-300"
+              className="rounded-lg p-1.5 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700 dark:hover:text-slate-300"
               aria-label={`Visit ${link.name}`}
             >
-              <ExternalLink className="h-4 w-4" />
+              <ExternalLink className="h-3.5 w-3.5" />
             </a>
           )}
           {!link.githubUrl && !link.liveUrl && (
-            <div className="rounded-lg p-2 text-slate-300 dark:text-slate-600">
-              <Globe className="h-4 w-4" />
+            <div className="rounded-lg p-1.5 text-slate-300 dark:text-slate-600">
+              <Globe className="h-3.5 w-3.5" />
             </div>
           )}
         </div>
       </div>
+      {cardHref && (
+        <a
+          href={cardHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={link.name}
+          className="absolute inset-0 z-0 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+        >
+          <span className="sr-only">{`Open ${link.name}`}</span>
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #27.

## Summary
- **Whole card clickable.** `ProjectLinks` now uses a stretched-link overlay: the card body is a non-interactive `<div>`, a full-card absolute `<a>` overlays it (href prefers `liveUrl`, falls back to `githubUrl`, omitted entirely when both are null), and the inner GitHub / live icon buttons remain real anchors on a higher `z-index` so they stay keyboard- and screen-reader-navigable without nesting interactive content inside an anchor.
- **Smaller tiles.** Image aspect `16/9 -> 16/7`, padding `p-4 -> p-3`, tightened title/description fonts, trimmed icon-button padding. Description still `line-clamp-2` per the issue.
- **Repositioned under activity card.** In `src/app/insights/[slug]/page.tsx`, projects now render directly below `ActivityHeatmap` on the harness layout and directly below `SnapshotCard` on the standard insights layout. Previous positions (after HarnessFiles / after chartData) removed.

## Implementation notes
- Used the stretched-link pattern after Codex flagged nested interactive content as an a11y concern. The inner icon buttons are sibling anchors at `z-10` above an overlay at `z-0`, so no `stopPropagation` plumbing and no invalid HTML.
- Hover affordance (`hover:shadow-lg`) only applies when the card has a URL. Cards without any URL stay visually consistent but non-clickable.
- Dark mode classes preserved on the card, button row, overlay focus ring, and the background of the image slot.

## Codex CLI review
- Pre-commit gate: flagged nested-interactive issue in first pass; resolved by switching to stretched-link pattern; second pass clean.
- Pre-push gate: clean. `npx tsc --noEmit` passed, `npx vitest run` passed 275 tests, `npx eslint` on touched files passed. Full `npm run lint` still fails on pre-existing errors in `src/app/page.tsx:798`, `src/app/top/page.tsx:206`, and `src/components/SectionRenderer.tsx:103` — not introduced by this PR.

## Test plan
- [ ] Open a harness report with projects; verify projects render immediately below the activity heatmap.
- [ ] Open a standard insights report with projects; verify projects render immediately below the snapshot card.
- [ ] Click anywhere on a card (image, title, body) → opens liveUrl in new tab.
- [ ] Click the GitHub icon → opens githubUrl in new tab (independent of liveUrl).
- [ ] Card with only a githubUrl (no liveUrl) → whole-card click opens githubUrl.
- [ ] Card with neither URL → card is not clickable, no pointer cursor, visually consistent.
- [ ] Toggle dark mode → styling intact.
- [ ] Tab through cards → overlay anchor focusable, focus-visible ring visible, inner icon links also tabbable.
- [ ] Mobile viewport (`sm:grid-cols-2` off) → cards stack full-width.