### PR TITLE
fix(activity): remove scroll, square cells, big vanity numbers (#22, #23)

### DIFF
--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -427,7 +427,7 @@ export default function EditReportPage() {
   const harnessData = report.harnessData;
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className="mx-auto max-w-5xl px-4 py-8">
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-center gap-3">

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -270,7 +270,7 @@ export default function InsightDetailPage() {
   const hiddenHarnessSections = report.hiddenHarnessSections ?? [];
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className="mx-auto max-w-5xl px-4 py-8">
       {/* Author bar */}
       <div className="mb-6 flex items-center gap-4 border-b border-slate-200 pb-6 dark:border-slate-700">
         <Link href={`/u/${report.author.username}`}>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -837,7 +837,7 @@ export default function UploadPage() {
   }
 
   return (
-    <div className="mx-auto max-w-4xl px-4 py-8">
+    <div className="mx-auto max-w-5xl px-4 py-8">
       <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
         Share Your Insights
       </h1>

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -219,11 +219,13 @@ function GridHeatmap({
         </div>
       </div>
 
-      {/* Heat map — flex-wrap so cells reflow onto a second row if the
-          container is narrow. aspect-square keeps every cell a perfect
-          square regardless of the label length inside it. */}
+      {/* Heat map — 7 columns (one per day of the week) with aspect-square
+          cells that shrink to fit the container. Using a 7-col grid
+          preserves the week-over-week visual chronology regardless of
+          container width. Cells stay perfectly square via aspect-square. */}
       <div
-        className="flex flex-wrap gap-1"
+        className="grid gap-1"
+        style={{ gridTemplateColumns: "repeat(7, minmax(0, 1fr))" }}
         role="list"
         aria-label={`${title} daily activity`}
       >
@@ -240,7 +242,7 @@ function GridHeatmap({
               role="listitem"
               title={titleAttr}
               aria-label={titleAttr}
-              className={`flex aspect-square h-9 w-9 shrink-0 items-center justify-center rounded text-center text-[10px] font-semibold leading-tight sm:h-10 sm:w-10 md:h-11 md:w-11 ${level.bg} ${level.text} ${level.border ?? ""}`}
+              className={`flex aspect-square min-w-0 items-center justify-center rounded text-center text-[10px] font-semibold leading-tight ${level.bg} ${level.text} ${level.border ?? ""}`}
             >
               {displayValue}
             </div>

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -178,63 +178,74 @@ function formatCost(n: number): string {
 
 function GridHeatmap({
   title,
-  summary,
+  bigNumber,
+  bigNumberLabel,
   scale,
   data,
   formatValue,
+  ariaValueLabel,
 }: {
   title: string;
-  summary: string;
+  /** Large vanity number rendered above the heat map (e.g. "101"). */
+  bigNumber: string;
+  /** Smaller label under the vanity number (e.g. "total sessions"). */
+  bigNumberLabel: string;
   scale: ColorScale;
   data: number[]; // length CELL_COUNT
   formatValue: (n: number) => string;
+  /** Accessible suffix used in per-cell title attributes (e.g. "sessions"). */
+  ariaValueLabel: string;
 }) {
   const max = Math.max(...data, 1);
   const nonZero = data.filter((v) => v > 0);
   const min = nonZero.length > 0 ? Math.min(...nonZero) : 0;
-  const longestCellValue = data.reduce((longest, value) => {
-    const label = formatValue(value);
-    return label.length > longest ? label.length : longest;
-  }, 0);
-  const minCellWidth =
-    longestCellValue >= 7 ? 64 : longestCellValue >= 5 ? 56 : 44;
-  const minCellHeight =
-    longestCellValue >= 7 ? 44 : longestCellValue >= 5 ? 40 : 34;
 
   return (
     <div className="rounded-lg border border-slate-100 bg-slate-50/70 p-4 dark:border-slate-800 dark:bg-slate-950/20">
-      <div className="mb-3 flex min-h-[2.5rem] items-start justify-between gap-3">
-        <div
-          className={`text-xs font-bold uppercase tracking-wider ${TITLE_COLORS[scale]}`}
-        >
-          {title}
+      {/* Title chip */}
+      <div
+        className={`mb-2 text-[11px] font-bold uppercase tracking-wider ${TITLE_COLORS[scale]}`}
+      >
+        {title}
+      </div>
+
+      {/* Big vanity number */}
+      <div className="mb-4">
+        <div className="text-4xl font-extrabold leading-none tracking-tight text-slate-900 dark:text-slate-50 sm:text-5xl">
+          {bigNumber}
         </div>
-        <div className="text-right text-sm font-semibold text-slate-700 dark:text-slate-200">
-          {summary}
+        <div className="mt-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+          {bigNumberLabel}
         </div>
       </div>
 
-      <div className="overflow-x-auto pb-1">
-        <div
-          className="grid min-w-max gap-[4px]"
-          style={{
-            gridTemplateColumns: `repeat(${DAYS_PER_WEEK}, minmax(${minCellWidth}px, 1fr))`,
-          }}
-        >
-          {data.map((value, i) => {
-            const level = getLevel(scale, value, max);
-            return (
-              <div
-                key={i}
-                title={formatValue(value)}
-                className={`flex items-center justify-center rounded px-1.5 text-center text-[10px] font-semibold leading-tight ${level.bg} ${level.text} ${level.border ?? ""}`}
-                style={{ minHeight: `${minCellHeight}px` }}
-              >
-                {formatValue(value)}
-              </div>
-            );
-          })}
-        </div>
+      {/* Heat map — flex-wrap so cells reflow onto a second row if the
+          container is narrow. aspect-square keeps every cell a perfect
+          square regardless of the label length inside it. */}
+      <div
+        className="flex flex-wrap gap-1"
+        role="list"
+        aria-label={`${title} daily activity`}
+      >
+        {data.map((value, i) => {
+          const level = getLevel(scale, value, max);
+          const displayValue = formatValue(value);
+          const titleAttr =
+            value > 0
+              ? `${displayValue} ${ariaValueLabel}`
+              : `No ${ariaValueLabel}`;
+          return (
+            <div
+              key={i}
+              role="listitem"
+              title={titleAttr}
+              aria-label={titleAttr}
+              className={`flex aspect-square h-9 w-9 shrink-0 items-center justify-center rounded text-center text-[10px] font-semibold leading-tight sm:h-10 sm:w-10 md:h-11 md:w-11 ${level.bg} ${level.text} ${level.border ?? ""}`}
+            >
+              {displayValue}
+            </div>
+          );
+        })}
       </div>
 
       <div className="mt-3 flex items-center justify-between gap-3 text-[10px] text-slate-500 dark:text-slate-400">
@@ -334,6 +345,8 @@ export default function ActivityHeatmap({
 
   if (!sessionsDaily || !tokensDaily || !costDaily) return null;
 
+  const totalSessionsSum = sessionsDaily.reduce((a, b) => a + b, 0);
+  const totalTokensSum = tokensDaily.reduce((a, b) => a + b, 0);
   const totalCostEstimate = costDaily.reduce((a, b) => a + b, 0);
 
   return (
@@ -344,24 +357,30 @@ export default function ActivityHeatmap({
       <div className="grid gap-6 lg:grid-cols-2 2xl:grid-cols-3">
         <GridHeatmap
           title="Sessions"
-          summary={`${sessionsDaily.reduce((a, b) => a + b, 0)} total`}
+          bigNumber={totalSessionsSum.toLocaleString()}
+          bigNumberLabel="total sessions"
           scale="blue"
           data={sessionsDaily}
           formatValue={(n) => (n > 0 ? n.toString() : "")}
+          ariaValueLabel="sessions"
         />
         <GridHeatmap
           title="Tokens"
-          summary={`${formatTokens(tokensDaily.reduce((a, b) => a + b, 0))} total`}
+          bigNumber={formatTokens(totalTokensSum)}
+          bigNumberLabel="total tokens"
           scale="green"
           data={tokensDaily}
           formatValue={(n) => (n > 0 ? formatTokens(n) : "")}
+          ariaValueLabel="tokens"
         />
         <GridHeatmap
           title="Est. API Cost"
-          summary={`~${formatCost(totalCostEstimate)} total`}
+          bigNumber={formatCost(totalCostEstimate)}
+          bigNumberLabel="estimated API cost"
           scale="amber"
           data={costDaily}
           formatValue={(n) => (n > 0 ? formatCost(n) : "")}
+          ariaValueLabel="dollars estimated"
         />
       </div>
     </div>


### PR DESCRIPTION
Closes #22. Closes #23.

## Summary

- Removes horizontal scroll from every activity card subcard (Sessions / Tokens / Est. API Cost).
- Replaces the previous `min-w-max` + `overflow-x-auto` grid with a 7-column CSS grid (`repeat(7, minmax(0, 1fr))`) of `aspect-square min-w-0` cells. Cells shrink squarely to fit the container at every breakpoint while preserving week-over-week visual chronology.
- Promotes each subcard's total to a large vanity number (`text-4xl` on mobile, `sm:text-5xl` above) with a smaller label beneath, rendered directly above the heat map.
- Widens the report detail, edit, and upload page containers from `max-w-4xl` to `max-w-5xl` so the heat maps have more room before cells shrink.
- API cost vanity number and per-cell values reuse the shared `estimateApiCostUsd` helper from `src/lib/api-cost.ts` (no local pricing math).
- Each cell keeps a readable `title` attribute and now also `aria-label` / `role="listitem"` for better a11y.

Codex passed both gates. The first Codex pass caught a real flex-wrap regression (ragged rows scrambling chronology at the 2xl subcard width) that was fixed by switching to the 7-column grid in commit 2.

## Visual verification

Started `npm run dev` and rendered the component via a temporary `/dev/activity-preview` route (deleted before commit) with mock data (101 sessions, 1.7M tokens, two-model cost breakdown). Took headless Chrome screenshots at:

- 375px (mobile): single card column, cells ~34px, full 4x7 grid fits, no horizontal scroll
- 768px (tablet): single card column, cells ~90px, roomy classic heatmap look
- 1280px (desktop): `lg:grid-cols-2` subcards, cells ~58px
- 1600px (wide): `2xl:grid-cols-3` subcards, cells ~35px, all three subcards side-by-side

Big vanity numbers render prominently on every breakpoint and stay readable on mobile.

## Test plan

- [x] `npx eslint` on touched files — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 275 tests passing (per Codex verification)
- [x] Visual check at 375 / 768 / 1280 / 1600 px
- [x] Codex pre-commit review — no findings
- [x] Codex pre-push review — no merge blockers
- [ ] Reviewer: pull branch, open a real harness report, confirm no horizontal scroll and that cells stay square when long cost values render in the Est. API Cost subcard