### PR TITLE
fix(lines-of-code): harnessData fallback for null scalar columns (#35)

### DIFF
--- a/src/app/api/og/[slug]/route.tsx
+++ b/src/app/api/og/[slug]/route.tsx
@@ -1,5 +1,9 @@
 import { ImageResponse } from "next/og";
 import { prisma } from "@/lib/db";
+import {
+  resolveLinesAdded,
+  resolveLinesRemoved,
+} from "@/lib/lines-of-code";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
 
 export const runtime = "nodejs";
@@ -45,27 +49,6 @@ function formatLines(n: number): string {
   if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return Math.round(n).toLocaleString();
-}
-
-// Parse the harness gitPatterns.linesAdded string ("44.0K", "1.2M",
-// "1,234") into a number. Harness reports historically only encode total
-// additions in this field as a display string, so we use it as a fallback
-// when the scalar columns are null.
-function parseHarnessLinesString(value: unknown): number {
-  if (typeof value !== "string") return 0;
-  const trimmed = value.trim().replace(/,/g, "");
-  if (!trimmed) return 0;
-  const match = trimmed.match(/^([\d.]+)\s*([KkMm])?$/);
-  if (!match) {
-    const n = parseFloat(trimmed);
-    return Number.isFinite(n) ? n : 0;
-  }
-  const base = parseFloat(match[1]);
-  if (!Number.isFinite(base)) return 0;
-  const suffix = match[2]?.toLowerCase();
-  if (suffix === "k") return base * 1_000;
-  if (suffix === "m") return base * 1_000_000;
-  return base;
 }
 
 function formatDuration(hours: number): string {
@@ -191,14 +174,22 @@ export async function GET(
       // the harness `gitPatterns.linesAdded` display string when scalars
       // are null. Without this fallback the LINES/WK cell rendered `0` for
       // every harness report whose scalar columns weren't populated by
-      // upload — see issue #29.
-      const scalarAdded = report.linesAdded ?? 0;
-      const scalarRemoved = report.linesRemoved ?? 0;
-      const fallbackAdded =
-        scalarAdded === 0 && scalarRemoved === 0
-          ? parseHarnessLinesString(h.gitPatterns?.linesAdded)
-          : 0;
-      const totalLines = scalarAdded + scalarRemoved + fallbackAdded;
+      // upload — see issues #29 / #35. Shared resolver lives in
+      // src/lib/lines-of-code.ts so ProfileCard and HeroStats get the same
+      // fallback.
+      const resolvedAdded = resolveLinesAdded({
+        linesAdded: report.linesAdded,
+        linesRemoved: report.linesRemoved,
+        harnessData: h,
+      });
+      const resolvedRemoved = resolveLinesRemoved({
+        linesAdded: report.linesAdded,
+        linesRemoved: report.linesRemoved,
+        harnessData: h,
+      });
+      const scalarAdded = resolvedAdded ?? 0;
+      const scalarRemoved = resolvedRemoved ?? 0;
+      const totalLines = scalarAdded + scalarRemoved;
       const hasLinesData = totalLines > 0;
       const hasSplit = scalarAdded > 0 && scalarRemoved > 0;
 
@@ -261,9 +252,22 @@ export async function GET(
       });
       // Same null-safe LOC handling as the harness branch: only render the
       // cell when there is real data, prefer split format when both
-      // additions and removals are populated.
-      const insightsAdded = report.linesAdded ?? 0;
-      const insightsRemoved = report.linesRemoved ?? 0;
+      // additions and removals are populated. Shared resolver is still
+      // used here even though `insights` reports have no harnessData
+      // fallback — it keeps the read path symmetrical with the harness
+      // branch and demo reports.
+      const insightsAdded =
+        resolveLinesAdded({
+          linesAdded: report.linesAdded,
+          linesRemoved: report.linesRemoved,
+          harnessData: null,
+        }) ?? 0;
+      const insightsRemoved =
+        resolveLinesRemoved({
+          linesAdded: report.linesAdded,
+          linesRemoved: report.linesRemoved,
+          harnessData: null,
+        }) ?? 0;
       const insightsTotal = insightsAdded + insightsRemoved;
       if (insightsTotal > 0) {
         const hasSplit = insightsAdded > 0 && insightsRemoved > 0;

--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -23,6 +23,7 @@ import SectionRenderer from "@/components/SectionRenderer";
 import Link from "next/link";
 import clsx from "clsx";
 import { getHiddenHarnessSections } from "@/lib/harness-section-visibility";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 interface EditProject {
   id: string;
@@ -478,8 +479,16 @@ export default function EditReportPage() {
               sessionCount={
                 report.sessionCount || harnessData.stats?.sessionCount || 0
               }
-              linesAdded={report.linesAdded ?? null}
-              linesRemoved={report.linesRemoved ?? null}
+              linesAdded={resolveLinesAdded({
+                linesAdded: report.linesAdded,
+                linesRemoved: report.linesRemoved,
+                harnessData,
+              })}
+              linesRemoved={resolveLinesRemoved({
+                linesAdded: report.linesAdded,
+                linesRemoved: report.linesRemoved,
+                harnessData,
+              })}
             />
           </HideableCard>
 

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -20,6 +20,7 @@ import {
   type HarnessData,
 } from "@/types/insights";
 import { normalizeChartData } from "@/lib/chart-parser";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 // New redesigned components for harness reports
 import HeroStats from "@/components/HeroStats";
@@ -347,8 +348,16 @@ export default function InsightDetailPage() {
                 report.harnessData?.stats?.sessionCount ||
                 0
               }
-              linesAdded={report.linesAdded ?? null}
-              linesRemoved={report.linesRemoved ?? null}
+              linesAdded={resolveLinesAdded({
+                linesAdded: report.linesAdded,
+                linesRemoved: report.linesRemoved,
+                harnessData: report.harnessData,
+              })}
+              linesRemoved={resolveLinesRemoved({
+                linesAdded: report.linesAdded,
+                linesRemoved: report.linesRemoved,
+                harnessData: report.harnessData,
+              })}
             />
           )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/types/insights";
 import { homepage as copy } from "@/content/homepage";
 import { estimateApiCostUsd } from "@/lib/api-cost";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 // Parse a skill identifier into its plugin source and short name.
 // Skills are in the form "plugin-name:skill-name" or just "skill-name" (custom).
@@ -64,6 +65,15 @@ interface HarnessSlice {
   workflowData?: HarnessWorkflowSlice | null;
   /** Top-level per-model token counts used for API cost estimation. */
   models?: Record<string, number>;
+  /**
+   * Git patterns slice — used by the lines-of-code resolver when the
+   * scalar `linesAdded` / `linesRemoved` columns on the report are null
+   * (real harness uploads today). See src/lib/lines-of-code.ts and #35.
+   */
+  gitPatterns?: {
+    linesAdded?: string | number | null;
+    linesRemoved?: string | number | null;
+  } | null;
 }
 
 interface InsightSummary {
@@ -664,25 +674,55 @@ function ProfileCard({
               {pluginsCount === 1 ? "plugin" : "plugins"}
             </span>
           </div>
-          {((insight.linesAdded ?? 0) > 0 ||
-            (insight.linesRemoved ?? 0) > 0) && (
-            <div className="flex flex-1 flex-col border-l border-slate-100 px-3 last:pr-0 dark:border-slate-800">
-              <span className="whitespace-nowrap text-[15px] font-bold leading-none">
-                <span className="text-green-600 dark:text-green-400">
-                  +{formatLines(insight.linesAdded ?? 0)}
+          {(() => {
+            // Lines-of-code: prefer the scalar columns, fall back to the
+            // harness JSON string (see src/lib/lines-of-code.ts, #35).
+            // Real harness uploads leave the scalars null, so reading
+            // `insight.linesAdded` directly used to hide this cell for
+            // every user-uploaded report. #29 fixed this in the OG card
+            // only; #35 extends the fix to ProfileCard.
+            const resolvedAdded = resolveLinesAdded({
+              linesAdded: insight.linesAdded,
+              linesRemoved: insight.linesRemoved,
+              harnessData: insight.harnessData,
+            });
+            const resolvedRemoved = resolveLinesRemoved({
+              linesAdded: insight.linesAdded,
+              linesRemoved: insight.linesRemoved,
+              harnessData: insight.harnessData,
+            });
+            const addedDisplay = resolvedAdded ?? 0;
+            const removedDisplay = resolvedRemoved ?? 0;
+            const hasLines = addedDisplay > 0 || removedDisplay > 0;
+            // Harness reports carry only additions in gitPatterns — when
+            // the scalar removed is null and only the additions fallback
+            // resolved, hide the "/ -0" half so we don't claim zero
+            // deletions we can't actually verify.
+            const showRemoved = resolvedRemoved != null;
+            if (!hasLines) return null;
+            return (
+              <div className="flex flex-1 flex-col border-l border-slate-100 px-3 last:pr-0 dark:border-slate-800">
+                <span className="whitespace-nowrap text-[15px] font-bold leading-none">
+                  <span className="text-green-600 dark:text-green-400">
+                    +{formatLines(addedDisplay)}
+                  </span>
+                  {showRemoved && (
+                    <>
+                      <span className="text-slate-300 dark:text-slate-600">
+                        {" / "}
+                      </span>
+                      <span className="text-red-600 dark:text-red-400">
+                        -{formatLines(removedDisplay)}
+                      </span>
+                    </>
+                  )}
                 </span>
-                <span className="text-slate-300 dark:text-slate-600">
-                  {" / "}
+                <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
+                  lines
                 </span>
-                <span className="text-red-600 dark:text-red-400">
-                  -{formatLines(insight.linesRemoved ?? 0)}
-                </span>
-              </span>
-              <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
-                lines
-              </span>
-            </div>
-          )}
+              </div>
+            );
+          })()}
           {featured && commitsWk != null && commitsWk > 0 && (
             <div className="flex flex-1 flex-col border-l border-slate-100 px-3 dark:border-slate-800">
               <span className="text-[15px] font-bold leading-none text-cyan-600 dark:text-cyan-400">

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -50,6 +50,7 @@ import {
   getHiddenHarnessSections,
   stripHiddenHarnessData,
 } from "@/lib/harness-section-visibility";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 type Step = "upload" | "projects" | "review";
 
@@ -1399,8 +1400,16 @@ export default function UploadPage() {
                     parsed.harnessData.stats.sessionCount ??
                     0
                   }
-                  linesAdded={parsed.stats.linesAdded ?? null}
-                  linesRemoved={parsed.stats.linesRemoved ?? null}
+                  linesAdded={resolveLinesAdded({
+                    linesAdded: parsed.stats.linesAdded ?? null,
+                    linesRemoved: parsed.stats.linesRemoved ?? null,
+                    harnessData: parsed.harnessData,
+                  })}
+                  linesRemoved={resolveLinesRemoved({
+                    linesAdded: parsed.stats.linesAdded ?? null,
+                    linesRemoved: parsed.stats.linesRemoved ?? null,
+                    harnessData: parsed.harnessData,
+                  })}
                 />
               </RedactableSection>
 

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -157,8 +157,12 @@ export default function HeroStats({
   // Null-safe: only render the lines pill when we have at least one
   // positive value. Zero / null / undefined all hide the metric cleanly
   // per issue #24 ("reports missing these values hide the metric cleanly").
+  // Real harness reports (#35) only ship additions via the gitPatterns
+  // fallback — removed stays null — so we track "present vs missing"
+  // distinctly from "zero" and hide the `-X` half when removed is null.
   const added = linesAdded ?? 0;
   const removed = linesRemoved ?? 0;
+  const removedPresent = linesRemoved != null;
   const showLines = added > 0 || removed > 0;
 
   return (
@@ -205,10 +209,14 @@ export default function HeroStats({
           <span className="font-bold text-green-600 dark:text-green-400">
             +{formatLines(added)}
           </span>
-          <span className="text-slate-300 dark:text-slate-600">/</span>
-          <span className="font-bold text-red-600 dark:text-red-400">
-            -{formatLines(removed)}
-          </span>
+          {removedPresent && (
+            <>
+              <span className="text-slate-300 dark:text-slate-600">/</span>
+              <span className="font-bold text-red-600 dark:text-red-400">
+                -{formatLines(removed)}
+              </span>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/lib/__tests__/lines-of-code.test.ts
+++ b/src/lib/__tests__/lines-of-code.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseHarnessLinesString,
+  resolveLinesAdded,
+  resolveLinesRemoved,
+} from "../lines-of-code";
+
+describe("parseHarnessLinesString", () => {
+  it("parses K suffix (uppercase)", () => {
+    expect(parseHarnessLinesString("44.0K")).toBe(44000);
+  });
+
+  it("parses K suffix with decimal", () => {
+    expect(parseHarnessLinesString("18.4K")).toBe(18400);
+  });
+
+  it("parses k suffix (lowercase)", () => {
+    expect(parseHarnessLinesString("18.4k")).toBe(18400);
+  });
+
+  it("parses M suffix (uppercase)", () => {
+    expect(parseHarnessLinesString("1.2M")).toBe(1_200_000);
+  });
+
+  it("parses m suffix (lowercase)", () => {
+    expect(parseHarnessLinesString("1.2m")).toBe(1_200_000);
+  });
+
+  it("parses plain integer strings", () => {
+    expect(parseHarnessLinesString("44000")).toBe(44000);
+  });
+
+  it("parses thousands-separator strings", () => {
+    expect(parseHarnessLinesString("18,400")).toBe(18400);
+  });
+
+  it("passes finite numbers through", () => {
+    expect(parseHarnessLinesString(44000)).toBe(44000);
+  });
+
+  it("returns null for non-finite numbers", () => {
+    expect(parseHarnessLinesString(Number.NaN)).toBeNull();
+    expect(parseHarnessLinesString(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("returns null for null input", () => {
+    expect(parseHarnessLinesString(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseHarnessLinesString(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(parseHarnessLinesString("")).toBeNull();
+  });
+
+  it("returns null for a whitespace-only string", () => {
+    expect(parseHarnessLinesString("   ")).toBeNull();
+  });
+
+  it("returns null for garbage strings", () => {
+    expect(parseHarnessLinesString("garbage")).toBeNull();
+  });
+
+  it("returns null for suffix typos (KB, lines, Q)", () => {
+    // Strict full-string match: reject anything with extra letters or
+    // trailing words so malformed harness JSON fails closed instead of
+    // silently parsing just the prefix. Regression guard from the
+    // codex review of #35.
+    expect(parseHarnessLinesString("44.0KB")).toBeNull();
+    expect(parseHarnessLinesString("18.4K lines")).toBeNull();
+    expect(parseHarnessLinesString("1.2Q")).toBeNull();
+  });
+
+  it("returns null for multi-dot inputs", () => {
+    expect(parseHarnessLinesString("1.2.3K")).toBeNull();
+    expect(parseHarnessLinesString("1..2K")).toBeNull();
+  });
+
+  it("rejects a lone decimal with no leading digit", () => {
+    // Our strict regex requires at least one leading digit.
+    expect(parseHarnessLinesString(".5K")).toBeNull();
+  });
+
+  it("handles a sub-unit K-suffix value with a leading zero", () => {
+    expect(parseHarnessLinesString("0.5K")).toBe(500);
+  });
+});
+
+describe("resolveLinesAdded", () => {
+  it("prefers the scalar column when present", () => {
+    const result = resolveLinesAdded({
+      linesAdded: 1234,
+      linesRemoved: null,
+      harnessData: { gitPatterns: { linesAdded: "44.0K" } },
+    });
+    expect(result).toBe(1234);
+  });
+
+  it("uses 0 from the scalar column when explicitly zero", () => {
+    // Zero is a real value, not a fallback trigger.
+    const result = resolveLinesAdded({
+      linesAdded: 0,
+      linesRemoved: null,
+      harnessData: { gitPatterns: { linesAdded: "44.0K" } },
+    });
+    expect(result).toBe(0);
+  });
+
+  it("falls back to the harness string when the scalar is null", () => {
+    const result = resolveLinesAdded({
+      linesAdded: null,
+      linesRemoved: null,
+      harnessData: { gitPatterns: { linesAdded: "44.0K" } },
+    });
+    expect(result).toBe(44000);
+  });
+
+  it("falls back to the harness string when the scalar is undefined", () => {
+    const result = resolveLinesAdded({
+      harnessData: { gitPatterns: { linesAdded: "18.4K" } },
+    });
+    expect(result).toBe(18400);
+  });
+
+  it("returns null when both sources are null", () => {
+    expect(
+      resolveLinesAdded({
+        linesAdded: null,
+        linesRemoved: null,
+        harnessData: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when scalar is null and harnessData has no gitPatterns", () => {
+    expect(
+      resolveLinesAdded({
+        linesAdded: null,
+        harnessData: { gitPatterns: null },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when scalar is null and harness string is unparseable", () => {
+    expect(
+      resolveLinesAdded({
+        linesAdded: null,
+        harnessData: { gitPatterns: { linesAdded: "garbage" } },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("resolveLinesRemoved", () => {
+  it("prefers the scalar column when present", () => {
+    const result = resolveLinesRemoved({
+      linesAdded: null,
+      linesRemoved: 4321,
+    });
+    expect(result).toBe(4321);
+  });
+
+  it("uses 0 from the scalar column when explicitly zero", () => {
+    const result = resolveLinesRemoved({
+      linesRemoved: 0,
+      harnessData: { gitPatterns: { linesRemoved: "5.0K" } },
+    });
+    expect(result).toBe(0);
+  });
+
+  it("falls back to harnessData.gitPatterns.linesRemoved when scalar is null", () => {
+    // Defensive: the harness pipeline does not populate this today,
+    // but the resolver is symmetrical so future schema changes work.
+    const result = resolveLinesRemoved({
+      linesRemoved: null,
+      harnessData: { gitPatterns: { linesRemoved: "9.2K" } },
+    });
+    expect(result).toBe(9200);
+  });
+
+  it("returns null when scalar is null and no fallback exists", () => {
+    // Real harness reports today: scalar NULL, gitPatterns has only
+    // linesAdded, so resolveLinesRemoved should cleanly return null.
+    expect(
+      resolveLinesRemoved({
+        linesRemoved: null,
+        harnessData: { gitPatterns: { linesAdded: "44.0K" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when both sources are null", () => {
+    expect(
+      resolveLinesRemoved({
+        linesAdded: null,
+        linesRemoved: null,
+        harnessData: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/lines-of-code.ts
+++ b/src/lib/lines-of-code.ts
@@ -1,0 +1,102 @@
+/**
+ * Lines-of-code resolution helpers.
+ *
+ * Real harness reports (produced by the `insight-harness` upload pipeline)
+ * leave the `linesAdded` / `linesRemoved` scalar columns on `InsightReport`
+ * NULL, and stash the display value inside the JSON `harnessData` column at
+ * `gitPatterns.linesAdded` as a compact string like `"44.0K"`. Demo/seeded
+ * reports populate the scalar columns directly, so read-site consumers need
+ * a unified resolver that prefers scalars and falls back to parsing the
+ * harness string.
+ *
+ * See issues #24 (scalar read path), #29 (OG card origin of the parser),
+ * and #35 (this shared extraction).
+ */
+
+/**
+ * Parse a harness `gitPatterns.linesAdded` value into a numeric count.
+ *
+ * Accepts:
+ *   - Numbers (returned as-is, if finite)
+ *   - Strings with an optional K/M suffix: "44.0K", "1.2M", "44k", "1.2m"
+ *   - Plain-number strings with thousands separators: "18,400", "44000"
+ *
+ * Returns `null` when the input is missing, empty, or unparseable so
+ * callers can null-check cleanly instead of tripping on a sentinel `0`.
+ */
+export function parseHarnessLinesString(
+  value: string | number | null | undefined,
+): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim().replace(/,/g, "");
+  if (!trimmed) return null;
+
+  // Strict full-string match: one group of digits, optional single
+  // decimal part, and an optional K/M suffix. Anything else (extra
+  // letters, stray text like "44.0KB" or "18.4K lines", or multi-dot
+  // inputs like "1.2.3K") is rejected so malformed harness JSON fails
+  // closed as `null` instead of silently parsing a partial prefix.
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)([KkMm])?$/);
+  if (!match) return null;
+
+  const base = parseFloat(match[1]);
+  if (!Number.isFinite(base)) return null;
+
+  const suffix = match[2]?.toLowerCase();
+  if (suffix === "k") return base * 1_000;
+  if (suffix === "m") return base * 1_000_000;
+  return base;
+}
+
+/**
+ * Minimal shape of an `InsightReport` slice this resolver needs.
+ * Deliberately structural so both Prisma rows and API DTOs match.
+ */
+export interface LinesOfCodeSource {
+  linesAdded?: number | null;
+  linesRemoved?: number | null;
+  harnessData?: {
+    gitPatterns?: {
+      linesAdded?: string | number | null;
+      // Harness reports don't currently ship a `linesRemoved` field in
+      // gitPatterns, but we read it defensively so the resolver stays
+      // symmetrical if the upload pipeline starts populating it.
+      linesRemoved?: string | number | null;
+    } | null;
+  } | null;
+}
+
+/**
+ * Resolve a report's total lines-added count, preferring the scalar
+ * column when populated and falling back to the harness JSON string.
+ *
+ * Returns `null` when neither source has usable data so call sites can
+ * cleanly hide the metric (per the #24 null-safe UX contract).
+ */
+export function resolveLinesAdded(report: LinesOfCodeSource): number | null {
+  if (report.linesAdded != null) return report.linesAdded;
+  const fallback = report.harnessData?.gitPatterns?.linesAdded;
+  return parseHarnessLinesString(fallback);
+}
+
+/**
+ * Resolve a report's total lines-removed count. Mirrors
+ * {@link resolveLinesAdded}: prefers the scalar column, then the harness
+ * JSON fallback, then `null`.
+ *
+ * Note: in practice the harness pipeline only ships `gitPatterns.linesAdded`
+ * (total churn) so this fallback almost always returns `null` today. It's
+ * wired anyway so demo reports with both scalars work identically to real
+ * uploads, and so a future harness schema change that adds `linesRemoved`
+ * flows through without another read-site edit.
+ */
+export function resolveLinesRemoved(report: LinesOfCodeSource): number | null {
+  if (report.linesRemoved != null) return report.linesRemoved;
+  const fallback = report.harnessData?.gitPatterns?.linesRemoved;
+  return parseHarnessLinesString(fallback);
+}


### PR DESCRIPTION
Closes #35.

## Summary

Extracts `parseHarnessLinesString` + the scalar-with-fallback resolver from the OG route (#29) into `src/lib/lines-of-code.ts` and applies it to every read site that renders the lines-of-code metric:

- `src/app/page.tsx` (ProfileCard vanity strip)
- `src/components/HeroStats.tsx` via call sites in `src/app/insights/[slug]/page.tsx`, `src/app/insights/[slug]/edit/page.tsx`, `src/app/upload/page.tsx`
- `src/app/api/og/[slug]/route.tsx` (local helper removed)

Real harness uploads leave the `linesAdded` / `linesRemoved` scalar columns NULL and encode the value inside `harnessData.gitPatterns.linesAdded` as a display string (e.g. `"44.0K"`), so #24's scalar-only read path was silently hiding the metric for every user-uploaded report. #29 fixed the OG card in isolation; this PR DRYs the helper and extends the fix to the remaining surfaces (Option A from the issue).

## Notable choices

- **Parser is strict.** Uses a full-string regex so malformed harness JSON (`"44.0KB"`, `"18.4K lines"`, `"1.2.3K"`) fails closed as `null` instead of silently parsing a partial prefix. Codex flagged this in gate #1 and I tightened + added tests before committing.
- **`resolveLinesRemoved` is symmetrical** even though harness pipelines don't populate `gitPatterns.linesRemoved` today. Defensive so a future schema change flows through without another read-site edit.
- **Homepage feed unchanged.** `/api/insights` uses Prisma `include:` and already returns the full `harnessData` JSON, so no API changes were required.
- **HeroStats hides the `-0` half** when `linesRemoved` is truly `null` (vs `0`). Before this PR, the common harness case (additions only) would've rendered `+44k / -0` once the fallback landed; now it renders `+44k` cleanly.

## Verification

- New unit tests: 30 cases covering K/k/M/m suffix variants, thousands separators, plain integers, malformed input (KB, lines, Q, multi-dot, leading dot), and resolver precedence (scalar present, scalar zero, scalar null with/without fallback).
- Full test suite: 305 tests pass.
- `npx tsc --noEmit` clean.
- `npx eslint` clean on all touched files.
- **Real-report verification:** queried the DB for `kabirdos-20260411-qtzrf1` — confirmed `linesAdded: NULL`, `linesRemoved: NULL`, `gitPatterns.linesAdded: "44.0K"`, `gitPatterns.linesRemoved: undefined`. Resolver returns `44000` / `null`. ProfileCard + HeroStats will now render `+44k` instead of hiding the cell.
- Codex CLI code review passed both gates (pre-commit and pre-push).

## Test plan

- [ ] Load homepage and confirm harness profiles with NULL scalar columns now show a lines-of-code pill on their card.
- [ ] Load `/insights/kabirdos-20260411-qtzrf1` and confirm HeroStats shows `+44k` (no `-0` half).
- [ ] Load a demo report with populated scalars and confirm it still shows `+X / -Y`.
- [ ] Load a report with neither scalars nor harness fallback (if one exists) and confirm the pill stays hidden.