### PR TITLE
fix(report): reorder harness sections Plugins → Tool Usage → CLI Tools (#46)

### DIFF
--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -395,12 +395,6 @@ export default function InsightDetailPage() {
             <HowIWorkCluster harnessData={report.harnessData} />
           )}
 
-          {/* Tool Usage Treemap */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "toolUsage") &&
-            Object.keys(report.harnessData.toolUsage).length > 0 && (
-            <ToolUsageTreemap toolUsage={report.harnessData.toolUsage} />
-          )}
-
           {/* Workflow Diagrams */}
           {report.harnessData.workflowData &&
             !isHarnessSectionHidden(hiddenHarnessSections, "workflowData") && (
@@ -457,6 +451,12 @@ export default function InsightDetailPage() {
                 ))}
               </div>
             </CollapsibleSection>
+          )}
+
+          {/* Tool Usage Treemap */}
+          {!isHarnessSectionHidden(hiddenHarnessSections, "toolUsage") &&
+            Object.keys(report.harnessData.toolUsage).length > 0 && (
+            <ToolUsageTreemap toolUsage={report.harnessData.toolUsage} />
           )}
 
           {/* CLI Tools Donut */}


### PR DESCRIPTION
Closes #46.

## Summary
- Move the harness Tool Usage Treemap JSX block to sit between Plugins and CLI Tools Donut in `src/app/insights/[slug]/page.tsx`.
- New harness order: Plugins → Tool Usage → CLI Tools.
- All visibility guards (`isHarnessSectionHidden(..., "toolUsage")`) and data guards preserved verbatim.
- Insights (non-harness) branch only renders generic `chartData` MiniBarCharts and has no Plugins/CLI Tools sections, so no reorder applies there.

## Test plan
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm run build` — succeeds
- [x] `tsc --noEmit` — clean (via codex review)
- [x] Codex review pre-commit + pre-push — no findings
- [ ] Visual: open a published harness report and confirm order is Plugins → Tool Usage → CLI Tools at desktop and mobile, light + dark mode
- [ ] Toggle each of the three sections via `hiddenHarnessSections` and confirm each hides independently