### PR TITLE
feat(visibility): per-item eye toggle with server-side privacy fix (#28)

### DIFF
--- a/src/app/api/insights/[slug]/route.ts
+++ b/src/app/api/insights/[slug]/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import type { InsightReportDetailContract } from "@/types/api-contracts";
 import { ALLOWED_PUT_FIELDS } from "@/app/api/insights/allowed-fields";
+import { filterReportForResponse } from "@/lib/filter-report-response";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -121,9 +122,18 @@ export async function GET(
 
     const { votes: _votes, highlights: _highlights, ...rest } = report;
 
+    // Apply server-side filtering of hidden harness/narrative data.
+    // Owner with ?includeHidden=true gets unfiltered data (edit page).
+    // Non-owners always get filtered, regardless of query param.
+    const viewerIsOwner = !!(userId && userId === report.authorId);
+    const filtered = filterReportForResponse(rest, {
+      viewerIsOwner,
+      includeHidden: includeHiddenRequested,
+    });
+
     return NextResponse.json({
       data: {
-        ...rest,
+        ...filtered,
         voteCounts,
         userVotes,
         userHighlights,

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -5,6 +5,7 @@ import type { InsightReportListItemContract } from "@/types/api-contracts";
 import { normalizeHarnessData } from "@/types/insights";
 import type { Prisma } from "@prisma/client";
 import { fetchLinkPreview } from "@/lib/link-preview";
+import { filterReportForResponse } from "@/lib/filter-report-response";
 const SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
@@ -105,8 +106,16 @@ export async function GET(request: Request) {
 
       const { votes: ignoredVotes, ...rest } = report;
       void ignoredVotes;
+
+      // Apply server-side filtering of hidden data for list feeds.
+      // List feeds never pass includeHidden — always filter.
+      const filtered = filterReportForResponse(rest, {
+        viewerIsOwner: false,
+        includeHidden: false,
+      });
+
       return {
-        ...rest,
+        ...filtered,
         voteCounts,
         _trendingVotes: report.votes,
       };

--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -5,8 +5,10 @@ import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { ArrowLeft, AlertTriangle } from "lucide-react";
 import EyeToggle from "@/components/EyeToggle";
+import HideableItem from "@/components/HideableItem";
 import type { HarnessData } from "@/types/insights";
 import { normalizeHarnessData } from "@/types/insights";
+import { buildItemKey } from "@/lib/item-visibility";
 import HeroStats from "@/components/HeroStats";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
@@ -22,7 +24,7 @@ import CollapsibleSection from "@/components/CollapsibleSection";
 import SectionRenderer from "@/components/SectionRenderer";
 import Link from "next/link";
 import clsx from "clsx";
-import { getHiddenHarnessSections } from "@/lib/harness-section-visibility";
+import { getHiddenKeypaths } from "@/lib/harness-section-visibility";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 interface EditProject {
@@ -311,7 +313,7 @@ export default function EditReportPage() {
       }
     }
 
-    body.hiddenHarnessSections = getHiddenHarnessSections(hiddenSections);
+    body.hiddenHarnessSections = getHiddenKeypaths(hiddenSections);
 
     return body;
   };
@@ -547,7 +549,21 @@ export default function EditReportPage() {
               hidden={!!hiddenSections["skillInventory"]}
               onToggle={() => toggleSection("skillInventory")}
             >
-              <SkillCardGrid skillInventory={harnessData.skillInventory} />
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {harnessData.skillInventory.map((skill, i) => {
+                  const itemKey = buildItemKey(harnessData.skillInventory, i, (s) => s.name);
+                  const keypath = `skillInventory.${itemKey}`;
+                  return (
+                    <HideableItem
+                      key={itemKey}
+                      hidden={!!hiddenSections[keypath]}
+                      onToggle={() => toggleSection(keypath)}
+                    >
+                      <SkillCardGrid skillInventory={[skill]} />
+                    </HideableItem>
+                  );
+                })}
+              </div>
             </HideableCard>
           )}
 
@@ -564,34 +580,41 @@ export default function EditReportPage() {
                 defaultOpen={true}
               >
                 <div className="grid gap-2 sm:grid-cols-2">
-                  {harnessData.plugins.map((plugin) => (
-                    <div
-                      key={plugin.name}
-                      className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
-                    >
-                      <div className="flex items-center justify-between">
-                        <span className="font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
-                          {plugin.name}
-                        </span>
-                        <span
-                          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
-                            plugin.active
-                              ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                              : "bg-slate-100 text-slate-400 dark:bg-slate-800"
-                          }`}
-                        >
-                          {plugin.active ? "on" : "off"}
-                        </span>
-                      </div>
-                      {(plugin.version || plugin.marketplace) && (
-                        <div className="mt-0.5 text-[11px] text-slate-400">
-                          {plugin.version && `v${plugin.version}`}
-                          {plugin.version && plugin.marketplace && " · "}
-                          {plugin.marketplace}
+                  {harnessData.plugins.map((plugin, i) => {
+                    const itemKey = buildItemKey(harnessData.plugins, i, (p) => p.name);
+                    const keypath = `plugins.${itemKey}`;
+                    return (
+                      <HideableItem
+                        key={itemKey}
+                        hidden={!!hiddenSections[keypath]}
+                        onToggle={() => toggleSection(keypath)}
+                      >
+                        <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50">
+                          <div className="flex items-center justify-between">
+                            <span className="font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+                              {plugin.name}
+                            </span>
+                            <span
+                              className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
+                                plugin.active
+                                  ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                                  : "bg-slate-100 text-slate-400 dark:bg-slate-800"
+                              }`}
+                            >
+                              {plugin.active ? "on" : "off"}
+                            </span>
+                          </div>
+                          {(plugin.version || plugin.marketplace) && (
+                            <div className="mt-0.5 text-[11px] text-slate-400">
+                              {plugin.version && `v${plugin.version}`}
+                              {plugin.version && plugin.marketplace && " · "}
+                              {plugin.marketplace}
+                            </div>
+                          )}
                         </div>
-                      )}
-                    </div>
-                  ))}
+                      </HideableItem>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             </HideableCard>
@@ -656,13 +679,28 @@ export default function EditReportPage() {
                         <h4 className="mb-2 text-xs font-semibold text-slate-500">
                           Agent Types
                         </h4>
-                        <MiniBarChart
-                          data={Object.entries(
-                            harnessData.agentDispatch.types,
-                          ).map(([label, value]) => ({ label, value }))}
-                          title=""
-                          color="bg-indigo-500"
-                        />
+                        {Object.entries(harnessData.agentDispatch.types).map(
+                          ([typeName, value]) => {
+                            const keypath = `agentDispatch.${buildItemKey(
+                              Object.keys(harnessData.agentDispatch!.types),
+                              Object.keys(harnessData.agentDispatch!.types).indexOf(typeName),
+                              (k) => k,
+                            )}`;
+                            return (
+                              <HideableItem
+                                key={typeName}
+                                hidden={!!hiddenSections[keypath]}
+                                onToggle={() => toggleSection(keypath)}
+                              >
+                                <MiniBarChart
+                                  data={[{ label: typeName, value }]}
+                                  title=""
+                                  color="bg-indigo-500"
+                                />
+                              </HideableItem>
+                            );
+                          },
+                        )}
                       </div>
                     )}
                     {Object.keys(harnessData.agentDispatch.models).length >
@@ -671,13 +709,28 @@ export default function EditReportPage() {
                         <h4 className="mb-2 text-xs font-semibold text-slate-500">
                           Model Tiering
                         </h4>
-                        <MiniBarChart
-                          data={Object.entries(
-                            harnessData.agentDispatch.models,
-                          ).map(([label, value]) => ({ label, value }))}
-                          title=""
-                          color="bg-purple-500"
-                        />
+                        {Object.entries(harnessData.agentDispatch.models).map(
+                          ([modelName, value]) => {
+                            const keypath = `agentDispatch.${buildItemKey(
+                              Object.keys(harnessData.agentDispatch!.models),
+                              Object.keys(harnessData.agentDispatch!.models).indexOf(modelName),
+                              (k) => k,
+                            )}`;
+                            return (
+                              <HideableItem
+                                key={modelName}
+                                hidden={!!hiddenSections[keypath]}
+                                onToggle={() => toggleSection(keypath)}
+                              >
+                                <MiniBarChart
+                                  data={[{ label: modelName, value }]}
+                                  title=""
+                                  color="bg-purple-500"
+                                />
+                              </HideableItem>
+                            );
+                          },
+                        )}
                         {harnessData.agentDispatch.backgroundPct > 0 && (
                           <p className="mt-1 text-xs text-slate-400">
                             {harnessData.agentDispatch.backgroundPct}% run in
@@ -703,14 +756,29 @@ export default function EditReportPage() {
                 title="Languages"
                 defaultOpen={false}
               >
-                <MiniBarChart
-                  data={Object.entries(harnessData.languages)
-                    .sort((a, b) => b[1] - a[1])
-                    .slice(0, 12)
-                    .map(([label, value]) => ({ label, value }))}
-                  title=""
-                  color="bg-green-500"
-                />
+                {Object.entries(harnessData.languages)
+                  .sort((a, b) => b[1] - a[1])
+                  .slice(0, 12)
+                  .map(([lang, value]) => {
+                    const keypath = `languages.${buildItemKey(
+                      Object.keys(harnessData.languages),
+                      Object.keys(harnessData.languages).indexOf(lang),
+                      (k) => k,
+                    )}`;
+                    return (
+                      <HideableItem
+                        key={lang}
+                        hidden={!!hiddenSections[keypath]}
+                        onToggle={() => toggleSection(keypath)}
+                      >
+                        <MiniBarChart
+                          data={[{ label: lang, value }]}
+                          title=""
+                          color="bg-green-500"
+                        />
+                      </HideableItem>
+                    );
+                  })}
               </CollapsibleSection>
             </HideableCard>
           )}
@@ -730,19 +798,29 @@ export default function EditReportPage() {
                 <div className="space-y-1">
                   {Object.entries(harnessData.mcpServers)
                     .sort((a, b) => b[1] - a[1])
-                    .map(([server, calls]) => (
-                      <div
-                        key={server}
-                        className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
-                      >
-                        <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
-                          {server}
-                        </span>
-                        <span className="text-xs text-slate-400">
-                          {calls.toLocaleString()} calls
-                        </span>
-                      </div>
-                    ))}
+                    .map(([server, calls]) => {
+                      const keypath = `mcpServers.${buildItemKey(
+                        Object.keys(harnessData.mcpServers),
+                        Object.keys(harnessData.mcpServers).indexOf(server),
+                        (k) => k,
+                      )}`;
+                      return (
+                        <HideableItem
+                          key={server}
+                          hidden={!!hiddenSections[keypath]}
+                          onToggle={() => toggleSection(keypath)}
+                        >
+                          <div className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800">
+                            <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                              {server}
+                            </span>
+                            <span className="text-xs text-slate-400">
+                              {calls.toLocaleString()} calls
+                            </span>
+                          </div>
+                        </HideableItem>
+                      );
+                    })}
                 </div>
               </CollapsibleSection>
             </HideableCard>
@@ -761,14 +839,21 @@ export default function EditReportPage() {
                 defaultOpen={false}
               >
                 <div className="flex flex-wrap gap-1.5">
-                  {harnessData.versions.map((version) => (
-                    <span
-                      key={version}
-                      className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
-                    >
-                      {version}
-                    </span>
-                  ))}
+                  {harnessData.versions.map((version, i) => {
+                    const itemKey = buildItemKey(harnessData.versions, i, (v) => v);
+                    const keypath = `versions.${itemKey}`;
+                    return (
+                      <HideableItem
+                        key={itemKey}
+                        hidden={!!hiddenSections[keypath]}
+                        onToggle={() => toggleSection(keypath)}
+                      >
+                        <span className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400">
+                          {version}
+                        </span>
+                      </HideableItem>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             </HideableCard>
@@ -787,19 +872,29 @@ export default function EditReportPage() {
                 defaultOpen={false}
               >
                 <div className="space-y-6">
-                  {harnessData.writeupSections.map((section) => (
-                    <div key={section.title}>
-                      <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
-                        {section.title}
-                      </h4>
-                      <div
-                        className="prose prose-sm max-w-none text-slate-600 dark:text-slate-400 [&_p]:mb-2 [&_li]:mb-1"
-                        dangerouslySetInnerHTML={{
-                          __html: section.contentHtml,
-                        }}
-                      />
-                    </div>
-                  ))}
+                  {harnessData.writeupSections.map((section, i) => {
+                    const itemKey = buildItemKey(harnessData.writeupSections, i, (w) => w.title);
+                    const keypath = `writeupSections.${itemKey}`;
+                    return (
+                      <HideableItem
+                        key={itemKey}
+                        hidden={!!hiddenSections[keypath]}
+                        onToggle={() => toggleSection(keypath)}
+                      >
+                        <div>
+                          <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+                            {section.title}
+                          </h4>
+                          <div
+                            className="prose prose-sm max-w-none text-slate-600 dark:text-slate-400 [&_p]:mb-2 [&_li]:mb-1"
+                            dangerouslySetInnerHTML={{
+                              __html: section.contentHtml,
+                            }}
+                          />
+                        </div>
+                      </HideableItem>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             </HideableCard>
@@ -818,14 +913,21 @@ export default function EditReportPage() {
                 defaultOpen={false}
               >
                 <div className="space-y-1">
-                  {harnessData.harnessFiles.map((file) => (
-                    <div
-                      key={file}
-                      className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
-                    >
-                      {file}
-                    </div>
-                  ))}
+                  {harnessData.harnessFiles.map((file, i) => {
+                    const itemKey = buildItemKey(harnessData.harnessFiles, i, (f) => f);
+                    const keypath = `harnessFiles.${itemKey}`;
+                    return (
+                      <HideableItem
+                        key={itemKey}
+                        hidden={!!hiddenSections[keypath]}
+                        onToggle={() => toggleSection(keypath)}
+                      >
+                        <div className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400">
+                          {file}
+                        </div>
+                      </HideableItem>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             </HideableCard>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -34,7 +34,12 @@ import HooksSafetyTable from "@/components/HooksSafetyTable";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
 import MiniBarChart from "@/components/MiniBarChart";
-import { isHarnessSectionHidden } from "@/lib/harness-section-visibility";
+import {
+  hideSetFromArray,
+  isSectionHidden,
+  filterList,
+  filterRecord,
+} from "@/lib/item-visibility";
 
 interface ReportData {
   id: string;
@@ -269,6 +274,7 @@ export default function InsightDetailPage() {
 
   const isHarness = report.reportType === "insight-harness";
   const hiddenHarnessSections = report.hiddenHarnessSections ?? [];
+  const hiddenSet = hideSetFromArray(hiddenHarnessSections);
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
@@ -339,7 +345,7 @@ export default function InsightDetailPage() {
       {isHarness && report.harnessData ? (
         <>
           {/* Hero Stats */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "heroStats") && (
+          {!isSectionHidden(hiddenSet, "heroStats") && (
             <HeroStats
               stats={report.harnessData.stats}
               dayCount={report.dayCount}
@@ -362,10 +368,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* Activity Heatmap — generated from aggregate stats */}
-          {!isHarnessSectionHidden(
-            hiddenHarnessSections,
-            "activityHeatmap",
-          ) && (
+          {!isSectionHidden(hiddenSet, "activityHeatmap") && (
             <ActivityHeatmap
               totalSessions={
                 report.sessionCount ??
@@ -391,19 +394,19 @@ export default function InsightDetailPage() {
           )}
 
           {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "howIWork") && (
+          {!isSectionHidden(hiddenSet, "howIWork") && (
             <HowIWorkCluster harnessData={report.harnessData} />
           )}
 
           {/* Tool Usage Treemap */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "toolUsage") &&
+          {!isSectionHidden(hiddenSet, "toolUsage") &&
             Object.keys(report.harnessData.toolUsage).length > 0 && (
             <ToolUsageTreemap toolUsage={report.harnessData.toolUsage} />
           )}
 
           {/* Workflow Diagrams */}
           {report.harnessData.workflowData &&
-            !isHarnessSectionHidden(hiddenHarnessSections, "workflowData") && (
+            !isSectionHidden(hiddenSet, "workflowData") && (
               <WorkflowDiagram
                 workflowData={report.harnessData.workflowData}
                 agentDispatch={report.harnessData.agentDispatch}
@@ -412,13 +415,20 @@ export default function InsightDetailPage() {
             )}
 
           {/* Skills Card Grid */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "skillInventory") &&
+          {!isSectionHidden(hiddenSet, "skillInventory") &&
             report.harnessData.skillInventory.length > 0 && (
-            <SkillCardGrid skillInventory={report.harnessData.skillInventory} />
+            <SkillCardGrid
+              skillInventory={filterList(
+                report.harnessData.skillInventory,
+                hiddenSet,
+                "skillInventory",
+                (s) => s.name,
+              )}
+            />
           )}
 
           {/* Plugins */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "plugins") &&
+          {!isSectionHidden(hiddenSet, "plugins") &&
             report.harnessData.plugins.length > 0 && (
             <CollapsibleSection
               icon="🔌"
@@ -427,7 +437,7 @@ export default function InsightDetailPage() {
               defaultOpen={true}
             >
               <div className="grid gap-2 sm:grid-cols-2">
-                {report.harnessData.plugins.map((p) => (
+                {filterList(report.harnessData.plugins, hiddenSet, "plugins", (p) => p.name).map((p) => (
                   <div
                     key={p.name}
                     className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
@@ -460,21 +470,18 @@ export default function InsightDetailPage() {
           )}
 
           {/* CLI Tools Donut */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "cliTools") &&
+          {!isSectionHidden(hiddenSet, "cliTools") &&
             Object.keys(report.harnessData.cliTools).length > 0 && (
             <CliToolsDonut cliTools={report.harnessData.cliTools} />
           )}
 
           {/* Git Patterns */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "gitPatterns") && (
+          {!isSectionHidden(hiddenSet, "gitPatterns") && (
             <GitPatternsDisplay gitPatterns={report.harnessData.gitPatterns} />
           )}
 
           {/* Permission Mode & Safety */}
-          {!isHarnessSectionHidden(
-            hiddenHarnessSections,
-            "permissionModes",
-          ) && (
+          {!isSectionHidden(hiddenSet, "permissionModes") && (
             <PermissionModeDisplay
               permissionModes={report.harnessData.permissionModes}
               featurePills={report.harnessData.featurePills}
@@ -482,14 +489,14 @@ export default function InsightDetailPage() {
           )}
 
           {/* Hooks & Safety */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "hookDefinitions") && (
+          {!isSectionHidden(hiddenSet, "hookDefinitions") && (
             <HooksSafetyTable
               hookDefinitions={report.harnessData.hookDefinitions}
             />
           )}
 
           {/* Agent Dispatch */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "agentDispatch") &&
+          {!isSectionHidden(hiddenSet, "agentDispatch") &&
             report.harnessData.agentDispatch &&
             report.harnessData.agentDispatch.totalAgents > 0 && (
               <CollapsibleSection
@@ -559,7 +566,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* Languages */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "languages") &&
+          {!isSectionHidden(hiddenSet, "languages") &&
             Object.keys(report.harnessData.languages).length > 0 && (
             <CollapsibleSection
               icon="💻"
@@ -568,7 +575,9 @@ export default function InsightDetailPage() {
               defaultOpen={false}
             >
               <MiniBarChart
-                data={Object.entries(report.harnessData.languages)
+                data={Object.entries(
+                  filterRecord(report.harnessData.languages, hiddenSet, "languages"),
+                )
                   .sort((a, b) => b[1] - a[1])
                   .slice(0, 12)
                   .map(([label, value]) => ({ label, value }))}
@@ -579,7 +588,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* MCP Servers */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "mcpServers") &&
+          {!isSectionHidden(hiddenSet, "mcpServers") &&
             Object.keys(report.harnessData.mcpServers).length > 0 && (
             <CollapsibleSection
               icon="🔗"
@@ -588,7 +597,9 @@ export default function InsightDetailPage() {
               defaultOpen={false}
             >
               <div className="space-y-1">
-                {Object.entries(report.harnessData.mcpServers)
+                {Object.entries(
+                  filterRecord(report.harnessData.mcpServers, hiddenSet, "mcpServers"),
+                )
                   .sort((a, b) => b[1] - a[1])
                   .map(([server, calls]) => (
                     <div
@@ -608,7 +619,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* Versions */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "versions") &&
+          {!isSectionHidden(hiddenSet, "versions") &&
             report.harnessData.versions.length > 0 && (
             <CollapsibleSection
               icon="📦"
@@ -617,7 +628,7 @@ export default function InsightDetailPage() {
               defaultOpen={false}
             >
               <div className="flex flex-wrap gap-1.5">
-                {report.harnessData.versions.map((v) => (
+                {filterList(report.harnessData.versions, hiddenSet, "versions", (v) => v).map((v) => (
                   <span
                     key={v}
                     className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
@@ -630,7 +641,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* Writeup Sections */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "writeupSections") &&
+          {!isSectionHidden(hiddenSet, "writeupSections") &&
             report.harnessData.writeupSections.length > 0 && (
             <CollapsibleSection
               icon="📝"
@@ -639,7 +650,7 @@ export default function InsightDetailPage() {
               defaultOpen={false}
             >
               <div className="space-y-6">
-                {report.harnessData.writeupSections.map((section) => (
+                {filterList(report.harnessData.writeupSections, hiddenSet, "writeupSections", (w) => w.title).map((section) => (
                   <div key={section.title}>
                     <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
                       {section.title}
@@ -657,7 +668,7 @@ export default function InsightDetailPage() {
           )}
 
           {/* Harness Files */}
-          {!isHarnessSectionHidden(hiddenHarnessSections, "harnessFiles") &&
+          {!isSectionHidden(hiddenSet, "harnessFiles") &&
             report.harnessData.harnessFiles.length > 0 && (
             <CollapsibleSection
               icon="📁"
@@ -666,7 +677,7 @@ export default function InsightDetailPage() {
               defaultOpen={false}
             >
               <div className="space-y-1">
-                {report.harnessData.harnessFiles.map((f) => (
+                {filterList(report.harnessData.harnessFiles, hiddenSet, "harnessFiles", (f) => f).map((f) => (
                   <div
                     key={f}
                     className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
@@ -705,6 +716,7 @@ export default function InsightDetailPage() {
                     voteCount={report.voteCounts[section.key] ?? 0}
                     voted={report.userVotes[section.key] ?? false}
                     annotation={annotations[section.key]}
+                    hiddenItems={hiddenHarnessSections}
                   />
                 </CollapsibleSection>
               );

--- a/src/components/HideableItem.tsx
+++ b/src/components/HideableItem.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import EyeToggle from "./EyeToggle";
+
+/**
+ * Per-item visibility wrapper for use inside report edit page sections.
+ * Renders an inline EyeToggle and dims the child when hidden.
+ * Unlike HideableCard (which wraps whole sections and hides children
+ * entirely), HideableItem keeps children visible but dimmed so the
+ * owner can see what they're hiding.
+ */
+export default function HideableItem({
+  hidden,
+  onToggle,
+  children,
+}: {
+  hidden: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`group relative ${hidden ? "opacity-50" : ""}`}>
+      <div className="absolute -left-1 -top-1 z-10 opacity-0 transition-opacity group-hover:opacity-100">
+        <EyeToggle
+          enabled={!hidden}
+          onToggle={onToggle}
+          showLabel="Show this item"
+          hideLabel="Hide this item"
+        />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/SectionRenderer.tsx
+++ b/src/components/SectionRenderer.tsx
@@ -26,6 +26,7 @@ import type {
   UsagePattern,
   HorizonOpportunity,
 } from "@/types/insights";
+import { hideSetFromArray, filterList } from "@/lib/item-visibility";
 
 interface SectionRendererProps {
   slug: string;
@@ -37,6 +38,14 @@ interface SectionRendererProps {
   voted?: boolean;
   annotation?: string | null;
   readOnly?: boolean;
+  /** Hidden keypaths for defense-in-depth client-side filtering */
+  hiddenItems?: string[];
+  /** Optional wrapper for each item — used on edit page to mount eye toggles */
+  renderItemWrapper?: (
+    sectionKey: string,
+    itemKey: string,
+    children: React.ReactNode,
+  ) => React.ReactNode;
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -205,58 +214,84 @@ function InteractionStyleSection({
   );
 }
 
-function ProjectAreasSection({ data }: { data: { areas: ProjectArea[] } }) {
+function ProjectAreasSection({
+  data,
+  hidden,
+  renderItemWrapper,
+}: {
+  data: { areas: ProjectArea[] };
+  hidden?: Set<string>;
+  renderItemWrapper?: (key: string, itemKey: string, children: React.ReactNode) => React.ReactNode;
+}) {
+  const areas = hidden
+    ? filterList(data.areas, hidden, "projectAreas", (a) => a.name)
+    : data.areas;
   return (
     <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-      {data.areas.map((area, i) => (
-        <div
-          key={i}
-          className="rounded-xl border border-slate-200 bg-white p-4 transition-shadow hover:shadow-sm dark:border-slate-700 dark:bg-slate-800/50"
-        >
-          <div className="flex items-center justify-between mb-2">
-            <h4 className="font-semibold text-slate-900 dark:text-white truncate">
-              {area.name}
-            </h4>
-            <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-400">
-              {area.session_count} sessions
-            </span>
+      {areas.map((area, i) => {
+        const itemKey = `area-${i}`;
+        const card = (
+          <div
+            key={i}
+            className="rounded-xl border border-slate-200 bg-white p-4 transition-shadow hover:shadow-sm dark:border-slate-700 dark:bg-slate-800/50"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="font-semibold text-slate-900 dark:text-white truncate">
+                {area.name}
+              </h4>
+              <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-400">
+                {area.session_count} sessions
+              </span>
+            </div>
+            <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
+              {area.description}
+            </p>
           </div>
-          <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-            {area.description}
-          </p>
-        </div>
-      ))}
+        );
+        return renderItemWrapper ? renderItemWrapper("projectAreas", itemKey, card) : card;
+      })}
     </div>
   );
 }
 
 function ImpressiveWorkflowsSection({
   data,
+  hidden,
+  renderItemWrapper,
 }: {
   data: { intro: string; impressive_workflows: ImpressiveWorkflow[] };
+  hidden?: Set<string>;
+  renderItemWrapper?: (key: string, itemKey: string, children: React.ReactNode) => React.ReactNode;
 }) {
+  const workflows = hidden
+    ? filterList(data.impressive_workflows, hidden, "impressiveWorkflows", (w) => w.title)
+    : data.impressive_workflows;
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
         {data.intro}
       </p>
       <div className="grid gap-3 sm:grid-cols-2">
-        {data.impressive_workflows.map((wf, i) => (
-          <div
-            key={i}
-            className="rounded-xl border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-4 dark:border-green-900 dark:from-green-950/30 dark:to-emerald-950/20"
-          >
-            <div className="flex items-center gap-2 mb-2">
-              <Sparkles className="h-4 w-4 text-green-600 dark:text-green-400" />
-              <h4 className="font-semibold text-green-800 dark:text-green-300">
-                {wf.title}
-              </h4>
+        {workflows.map((wf, i) => {
+          const itemKey = `wf-${i}`;
+          const card = (
+            <div
+              key={i}
+              className="rounded-xl border border-green-200 bg-gradient-to-br from-green-50 to-emerald-50 p-4 dark:border-green-900 dark:from-green-950/30 dark:to-emerald-950/20"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Sparkles className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <h4 className="font-semibold text-green-800 dark:text-green-300">
+                  {wf.title}
+                </h4>
+              </div>
+              <p className="text-sm leading-relaxed text-green-700 dark:text-green-400">
+                {wf.description}
+              </p>
             </div>
-            <p className="text-sm leading-relaxed text-green-700 dark:text-green-400">
-              {wf.description}
-            </p>
-          </div>
-        ))}
+          );
+          return renderItemWrapper ? renderItemWrapper("impressiveWorkflows", itemKey, card) : card;
+        })}
       </div>
     </div>
   );
@@ -264,41 +299,52 @@ function ImpressiveWorkflowsSection({
 
 function FrictionAnalysisSection({
   data,
+  hidden,
+  renderItemWrapper,
 }: {
   data: { intro: string; categories: FrictionCategory[] };
+  hidden?: Set<string>;
+  renderItemWrapper?: (key: string, itemKey: string, children: React.ReactNode) => React.ReactNode;
 }) {
+  const categories = hidden
+    ? filterList(data.categories, hidden, "frictionAnalysis", (c) => c.category)
+    : data.categories;
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
         {data.intro}
       </p>
       <div className="grid gap-3 sm:grid-cols-2">
-        {data.categories.map((cat, i) => (
-          <div
-            key={i}
-            className="rounded-xl border border-red-200 bg-gradient-to-br from-red-50 to-amber-50 p-4 dark:border-red-900/50 dark:from-red-950/20 dark:to-amber-950/10"
-          >
-            <h4 className="font-semibold text-red-800 dark:text-red-300 mb-1.5">
-              {cat.category}
-            </h4>
-            <p className="text-sm leading-relaxed text-red-700 dark:text-red-400 mb-2">
-              {cat.description}
-            </p>
-            {cat.examples.length > 0 && (
-              <ul className="space-y-1">
-                {cat.examples.map((ex, j) => (
-                  <li
-                    key={j}
-                    className="flex items-start gap-1.5 text-xs text-red-600 dark:text-red-400"
-                  >
-                    <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-red-400 dark:bg-red-600" />
-                    {ex}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ))}
+        {categories.map((cat, i) => {
+          const itemKey = `cat-${i}`;
+          const card = (
+            <div
+              key={i}
+              className="rounded-xl border border-red-200 bg-gradient-to-br from-red-50 to-amber-50 p-4 dark:border-red-900/50 dark:from-red-950/20 dark:to-amber-950/10"
+            >
+              <h4 className="font-semibold text-red-800 dark:text-red-300 mb-1.5">
+                {cat.category}
+              </h4>
+              <p className="text-sm leading-relaxed text-red-700 dark:text-red-400 mb-2">
+                {cat.description}
+              </p>
+              {cat.examples.length > 0 && (
+                <ul className="space-y-1">
+                  {cat.examples.map((ex, j) => (
+                    <li
+                      key={j}
+                      className="flex items-start gap-1.5 text-xs text-red-600 dark:text-red-400"
+                    >
+                      <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-red-400 dark:bg-red-600" />
+                      {ex}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          );
+          return renderItemWrapper ? renderItemWrapper("frictionAnalysis", itemKey, card) : card;
+        })}
       </div>
     </div>
   );
@@ -312,6 +358,8 @@ function SuggestionsSection({
     features_to_try: FeatureToTry[];
     usage_patterns: UsagePattern[];
   };
+  hidden?: Set<string>;
+  renderItemWrapper?: (key: string, itemKey: string, children: React.ReactNode) => React.ReactNode;
 }) {
   return (
     <div className="space-y-8">
@@ -442,47 +490,58 @@ function SuggestionsSection({
 
 function OnTheHorizonSection({
   data,
+  hidden,
+  renderItemWrapper,
 }: {
   data: { intro: string; opportunities: HorizonOpportunity[] };
+  hidden?: Set<string>;
+  renderItemWrapper?: (key: string, itemKey: string, children: React.ReactNode) => React.ReactNode;
 }) {
+  const opportunities = hidden
+    ? filterList(data.opportunities, hidden, "onTheHorizon", (o) => o.title)
+    : data.opportunities;
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed text-slate-700 dark:text-slate-300">
         {data.intro}
       </p>
       <div className="grid gap-3 sm:grid-cols-2">
-        {data.opportunities.map((opp, i) => (
-          <div
-            key={i}
-            className="rounded-xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-4 dark:border-purple-900/50 dark:from-purple-950/30 dark:to-violet-950/20"
-          >
-            <div className="flex items-center gap-2 mb-2">
-              <Rocket className="h-4 w-4 text-purple-600 dark:text-purple-400" />
-              <h4 className="font-semibold text-purple-800 dark:text-purple-300 text-sm">
-                {opp.title}
-              </h4>
-            </div>
-            <p className="text-xs text-purple-700 dark:text-purple-400 leading-relaxed">
-              {opp.whats_possible}
-            </p>
-            <p className="mt-2 text-xs text-purple-600 dark:text-purple-400/80">
-              {opp.how_to_try}
-            </p>
-            {opp.copyable_prompt && (
-              <div className="mt-2 rounded-md bg-purple-100/50 p-2 dark:bg-purple-950/30">
-                <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] uppercase tracking-wider text-purple-500 font-medium">
-                    Try it
-                  </span>
-                  <CopyButton text={opp.copyable_prompt} />
-                </div>
-                <pre className="text-xs text-purple-800 dark:text-purple-300 whitespace-pre-wrap font-mono">
-                  {opp.copyable_prompt}
-                </pre>
+        {opportunities.map((opp, i) => {
+          const itemKey = `opp-${i}`;
+          const card = (
+            <div
+              key={i}
+              className="rounded-xl border border-purple-200 bg-gradient-to-br from-purple-50 to-violet-50 p-4 dark:border-purple-900/50 dark:from-purple-950/30 dark:to-violet-950/20"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Rocket className="h-4 w-4 text-purple-600 dark:text-purple-400" />
+                <h4 className="font-semibold text-purple-800 dark:text-purple-300 text-sm">
+                  {opp.title}
+                </h4>
               </div>
-            )}
-          </div>
-        ))}
+              <p className="text-xs text-purple-700 dark:text-purple-400 leading-relaxed">
+                {opp.whats_possible}
+              </p>
+              <p className="mt-2 text-xs text-purple-600 dark:text-purple-400/80">
+                {opp.how_to_try}
+              </p>
+              {opp.copyable_prompt && (
+                <div className="mt-2 rounded-md bg-purple-100/50 p-2 dark:bg-purple-950/30">
+                  <div className="flex items-center justify-between mb-1">
+                    <span className="text-[10px] uppercase tracking-wider text-purple-500 font-medium">
+                      Try it
+                    </span>
+                    <CopyButton text={opp.copyable_prompt} />
+                  </div>
+                  <pre className="text-xs text-purple-800 dark:text-purple-300 whitespace-pre-wrap font-mono">
+                    {opp.copyable_prompt}
+                  </pre>
+                </div>
+              )}
+            </div>
+          );
+          return renderItemWrapper ? renderItemWrapper("onTheHorizon", itemKey, card) : card;
+        })}
       </div>
     </div>
   );
@@ -573,8 +632,11 @@ export default function SectionRenderer({
   voted = false,
   annotation,
   readOnly = false,
+  hiddenItems,
+  renderItemWrapper,
 }: SectionRendererProps) {
   const meta = sectionMeta[sectionType] || sectionMeta.at_a_glance;
+  const hiddenSet = hiddenItems?.length ? hideSetFromArray(hiddenItems) : undefined;
 
   function renderContent() {
     switch (sectionType) {
@@ -598,7 +660,13 @@ export default function SectionRenderer({
           />
         );
       case "project_areas":
-        return <ProjectAreasSection data={data as { areas: ProjectArea[] }} />;
+        return (
+          <ProjectAreasSection
+            data={data as { areas: ProjectArea[] }}
+            hidden={hiddenSet}
+            renderItemWrapper={renderItemWrapper}
+          />
+        );
       case "impressive_workflows":
         return (
           <ImpressiveWorkflowsSection
@@ -608,12 +676,16 @@ export default function SectionRenderer({
                 impressive_workflows: ImpressiveWorkflow[];
               }
             }
+            hidden={hiddenSet}
+            renderItemWrapper={renderItemWrapper}
           />
         );
       case "friction_analysis":
         return (
           <FrictionAnalysisSection
             data={data as { intro: string; categories: FrictionCategory[] }}
+            hidden={hiddenSet}
+            renderItemWrapper={renderItemWrapper}
           />
         );
       case "suggestions":
@@ -626,6 +698,8 @@ export default function SectionRenderer({
                 usage_patterns: UsagePattern[];
               }
             }
+            hidden={hiddenSet}
+            renderItemWrapper={renderItemWrapper}
           />
         );
       case "on_the_horizon":
@@ -634,6 +708,8 @@ export default function SectionRenderer({
             data={
               data as { intro: string; opportunities: HorizonOpportunity[] }
             }
+            hidden={hiddenSet}
+            renderItemWrapper={renderItemWrapper}
           />
         );
       case "fun_ending":

--- a/src/lib/__tests__/filter-report-response.test.ts
+++ b/src/lib/__tests__/filter-report-response.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from "vitest";
+import { filterReportForResponse } from "../filter-report-response";
+
+function makeReport(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "report-1",
+    authorId: "user-1",
+    harnessData: {
+      stats: { totalTokens: 1000, durationHours: 10, avgSessionMinutes: 30, skillsUsedCount: 5, hooksCount: 2, prCount: 3 },
+      autonomy: { label: "high", description: "desc", userMessages: 10, assistantMessages: 50, turnCount: 60, errorRate: "2%" },
+      featurePills: [],
+      toolUsage: { Read: 100, Write: 50, Bash: 30 },
+      skillInventory: [
+        { name: "Superpowers Brainstorming", calls: 10, source: "plugin", description: "brainstorm" },
+        { name: "Code Review", calls: 5, source: "builtin", description: "review" },
+      ],
+      hookDefinitions: [{ event: "preCommit", matcher: "*.ts", script: "lint" }],
+      hookFrequency: {},
+      plugins: [{ name: "my-plugin", version: "1.0", marketplace: "npm", active: true }],
+      harnessFiles: ["CLAUDE.md", ".claude/settings.json"],
+      fileOpStyle: { readPct: 40, editPct: 30, writePct: 20, grepCount: 5, globCount: 3, style: "read-heavy" },
+      agentDispatch: { totalAgents: 5, types: { "general-purpose": 3, "code-review": 2 }, models: { "opus-4": 4, "sonnet-4": 1 }, backgroundPct: 20, customAgents: [] },
+      cliTools: { git: 50, npm: 20 },
+      languages: { TypeScript: 100, Python: 50 },
+      models: { "opus-4": 80, "sonnet-4": 20 },
+      permissionModes: { "auto-accept": 90, "manual": 10 },
+      mcpServers: { filesystem: 30, github: 20 },
+      gitPatterns: { prCount: 3, commitCount: 15, linesAdded: "500", branchPrefixes: { "feat/": 5, "fix/": 3 } },
+      versions: ["1.0.0", "1.1.0"],
+      writeupSections: [{ title: "Overview", contentHtml: "<p>test</p>" }],
+      workflowData: null,
+      integrityHash: "abc123",
+    },
+    hiddenHarnessSections: [] as string[],
+    impressiveWorkflows: {
+      impressive_workflows: [
+        { title: "Parallel Refactor", description: "Did a big refactor in parallel" },
+        { title: "Auto Deploy", description: "Set up auto deploy pipeline" },
+      ],
+    },
+    frictionAnalysis: {
+      categories: [
+        { category: "Test Flakiness", description: "Tests are flaky", examples: ["ex1"] },
+      ],
+    },
+    projectAreas: {
+      areas: [
+        { name: "Frontend", session_count: 10, description: "UI work" },
+        { name: "Backend", session_count: 8, description: "API work" },
+      ],
+    },
+    suggestions: {
+      claude_md_additions: [{ addition: "Add testing instructions", why: "reason", prompt_scaffold: "test" }],
+      features_to_try: [{ feature: "Worktrees", one_liner: "try it", why_for_you: "speed", example_code: "git worktree" }],
+      usage_patterns: [{ title: "Morning Coding", suggestion: "do it", detail: "details", copyable_prompt: "prompt" }],
+    },
+    onTheHorizon: {
+      opportunities: [
+        { title: "MCP Integration", whats_possible: "lots", how_to_try: "try", copyable_prompt: "prompt" },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("filterReportForResponse", () => {
+  it("returns full payload when no hides", () => {
+    const report = makeReport();
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    expect(result.harnessData).toEqual(report.harnessData);
+    expect(result.impressiveWorkflows).toEqual(report.impressiveWorkflows);
+  });
+
+  it("returns full payload for owner with includeHidden=true", () => {
+    const report = makeReport({ hiddenHarnessSections: ["skillInventory", "impressiveWorkflows.parallel-refactor"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: true, includeHidden: true });
+    // Should be untouched
+    expect((result.harnessData as { skillInventory: unknown[] }).skillInventory).toHaveLength(2);
+    expect((result.impressiveWorkflows as { impressive_workflows: unknown[] }).impressive_workflows).toHaveLength(2);
+  });
+
+  it("non-owner with includeHidden=true still gets filtered (security)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["skillInventory"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: true });
+    expect((result.harnessData as { skillInventory: unknown[] }).skillInventory).toHaveLength(0);
+  });
+
+  it("strips section from harnessData on top-level hide", () => {
+    const report = makeReport({ hiddenHarnessSections: ["skillInventory"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    expect((result.harnessData as { skillInventory: unknown[] }).skillInventory).toHaveLength(0);
+  });
+
+  it("strips item from harnessData on item-level hide", () => {
+    const report = makeReport({ hiddenHarnessSections: ["skillInventory.superpowers-brainstorming"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const skills = (result.harnessData as { skillInventory: Array<{ name: string }> }).skillInventory;
+    expect(skills).toHaveLength(1);
+    expect(skills[0].name).toBe("Code Review");
+  });
+
+  it("strips items from narrative JSON (impressiveWorkflows)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["impressiveWorkflows.parallel-refactor"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const iw = result.impressiveWorkflows as { impressive_workflows: Array<{ title: string }> };
+    expect(iw.impressive_workflows).toHaveLength(1);
+    expect(iw.impressive_workflows[0].title).toBe("Auto Deploy");
+  });
+
+  it("strips items from narrative JSON (frictionAnalysis)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["frictionAnalysis.test-flakiness"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const fa = result.frictionAnalysis as { categories: unknown[] };
+    expect(fa.categories).toHaveLength(0);
+  });
+
+  it("strips items from narrative JSON (projectAreas)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["projectAreas.frontend"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const pa = result.projectAreas as { areas: Array<{ name: string }> };
+    expect(pa.areas).toHaveLength(1);
+    expect(pa.areas[0].name).toBe("Backend");
+  });
+
+  it("strips items from narrative JSON (onTheHorizon)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["onTheHorizon.mcp-integration"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const oh = result.onTheHorizon as { opportunities: unknown[] };
+    expect(oh.opportunities).toHaveLength(0);
+  });
+
+  it("filters record-based harness sections (languages)", () => {
+    const report = makeReport({ hiddenHarnessSections: ["languages.python"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const hd = result.harnessData as { languages: Record<string, number> };
+    expect(hd.languages).toEqual({ TypeScript: 100 });
+  });
+
+  it("privacy regression: hidden item natural key must not appear in JSON response", () => {
+    const report = makeReport({ hiddenHarnessSections: ["skillInventory.superpowers-brainstorming"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("Superpowers Brainstorming");
+  });
+
+  it("privacy regression: hidden workflow must not appear in JSON response", () => {
+    const report = makeReport({ hiddenHarnessSections: ["impressiveWorkflows.parallel-refactor"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const json = JSON.stringify(result);
+    expect(json).not.toContain("Parallel Refactor");
+  });
+
+  it("backward compat: existing top-level keys continue to work", () => {
+    const report = makeReport({ hiddenHarnessSections: ["plugins", "languages"] });
+    const result = filterReportForResponse(report, { viewerIsOwner: false, includeHidden: false });
+    const hd = result.harnessData as { plugins: unknown[]; languages: Record<string, number> };
+    expect(hd.plugins).toHaveLength(0);
+    expect(Object.keys(hd.languages)).toHaveLength(0);
+  });
+});

--- a/src/lib/__tests__/item-visibility.test.ts
+++ b/src/lib/__tests__/item-visibility.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from "vitest";
+import {
+  slugItemKey,
+  buildItemKey,
+  isItemHidden,
+  isSectionHidden,
+  hideSetFromArray,
+  filterList,
+  filterRecord,
+  parseKeypath,
+} from "../item-visibility";
+
+describe("slugItemKey", () => {
+  it("kebab-cases and lowercases", () => {
+    expect(slugItemKey("Parallel Refactor")).toBe("parallel-refactor");
+  });
+
+  it("is idempotent", () => {
+    const slug = slugItemKey("Hello World");
+    expect(slugItemKey(slug)).toBe(slug);
+  });
+
+  it("handles emoji and unicode by stripping", () => {
+    expect(slugItemKey("🚀 Deploy Pipeline")).toBe("deploy-pipeline");
+  });
+
+  it("collapses multiple hyphens", () => {
+    expect(slugItemKey("foo---bar")).toBe("foo-bar");
+  });
+
+  it("trims leading/trailing hyphens", () => {
+    expect(slugItemKey("--hello--")).toBe("hello");
+  });
+
+  it("enforces 60 char max", () => {
+    const long = "a".repeat(100);
+    expect(slugItemKey(long).length).toBeLessThanOrEqual(60);
+  });
+
+  it("returns empty string for purely non-alphanumeric input", () => {
+    expect(slugItemKey("🎉🎊")).toBe("");
+  });
+});
+
+describe("buildItemKey", () => {
+  it("returns bare slug when no collision", () => {
+    const list = [{ name: "Alpha" }, { name: "Beta" }];
+    expect(buildItemKey(list, 0, (x) => x.name)).toBe("alpha");
+    expect(buildItemKey(list, 1, (x) => x.name)).toBe("beta");
+  });
+
+  it("appends @index when collision exists", () => {
+    const list = [{ name: "Refactor" }, { name: "Refactor" }, { name: "Other" }];
+    expect(buildItemKey(list, 0, (x) => x.name)).toBe("refactor@0");
+    expect(buildItemKey(list, 1, (x) => x.name)).toBe("refactor@1");
+    expect(buildItemKey(list, 2, (x) => x.name)).toBe("other");
+  });
+
+  it("falls back to @index for empty slugs", () => {
+    const list = [{ name: "🎉" }];
+    expect(buildItemKey(list, 0, (x) => x.name)).toBe("@0");
+  });
+});
+
+describe("parseKeypath", () => {
+  it("parses top-level key", () => {
+    expect(parseKeypath("skillInventory")).toEqual({
+      topKey: "skillInventory",
+      itemKey: null,
+    });
+  });
+
+  it("parses item-level keypath", () => {
+    expect(parseKeypath("skillInventory.parallel-refactor")).toEqual({
+      topKey: "skillInventory",
+      itemKey: "parallel-refactor",
+    });
+  });
+
+  it("parses keypath with collision index", () => {
+    expect(parseKeypath("impressiveWorkflows.refactor@2")).toEqual({
+      topKey: "impressiveWorkflows",
+      itemKey: "refactor@2",
+    });
+  });
+
+  it("rejects empty string", () => {
+    expect(parseKeypath("")).toBeNull();
+  });
+
+  it("rejects malformed topKey (starts with number)", () => {
+    expect(parseKeypath("123abc")).toBeNull();
+  });
+
+  it("rejects keypath with empty itemKey", () => {
+    expect(parseKeypath("skillInventory.")).toBeNull();
+  });
+
+  it("rejects itemKey with uppercase", () => {
+    expect(parseKeypath("skillInventory.Refactor")).toBeNull();
+  });
+});
+
+describe("isSectionHidden / isItemHidden", () => {
+  it("isSectionHidden returns true when top-level key present", () => {
+    const hidden = hideSetFromArray(["skillInventory"]);
+    expect(isSectionHidden(hidden, "skillInventory")).toBe(true);
+    expect(isSectionHidden(hidden, "plugins")).toBe(false);
+  });
+
+  it("isItemHidden returns true for item keypath", () => {
+    const hidden = hideSetFromArray(["skillInventory.parallel-refactor"]);
+    expect(isItemHidden(hidden, "skillInventory", "parallel-refactor")).toBe(true);
+    expect(isItemHidden(hidden, "skillInventory", "other")).toBe(false);
+  });
+
+  it("section-level hide trumps item-level", () => {
+    const hidden = hideSetFromArray(["skillInventory"]);
+    expect(isItemHidden(hidden, "skillInventory", "anything")).toBe(true);
+  });
+});
+
+describe("filterList", () => {
+  const items = [
+    { name: "Alpha" },
+    { name: "Beta" },
+    { name: "Gamma" },
+  ];
+
+  it("returns all items when nothing hidden", () => {
+    const hidden = hideSetFromArray([]);
+    const result = filterList(items, hidden, "skillInventory", (x) => x.name);
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns empty when section-level hidden", () => {
+    const hidden = hideSetFromArray(["skillInventory"]);
+    const result = filterList(items, hidden, "skillInventory", (x) => x.name);
+    expect(result).toHaveLength(0);
+  });
+
+  it("filters specific items by keypath", () => {
+    const hidden = hideSetFromArray(["skillInventory.beta"]);
+    const result = filterList(items, hidden, "skillInventory", (x) => x.name);
+    expect(result).toHaveLength(2);
+    expect(result.map((x) => x.name)).toEqual(["Alpha", "Gamma"]);
+  });
+
+  it("handles multiple hides", () => {
+    const hidden = hideSetFromArray([
+      "skillInventory.alpha",
+      "skillInventory.gamma",
+    ]);
+    const result = filterList(items, hidden, "skillInventory", (x) => x.name);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Beta");
+  });
+});
+
+describe("filterRecord", () => {
+  const rec = { TypeScript: 100, Python: 50, Rust: 30 };
+
+  it("returns all entries when nothing hidden", () => {
+    const hidden = hideSetFromArray([]);
+    const result = filterRecord(rec, hidden, "languages");
+    expect(Object.keys(result)).toHaveLength(3);
+  });
+
+  it("returns empty when section-level hidden", () => {
+    const hidden = hideSetFromArray(["languages"]);
+    const result = filterRecord(rec, hidden, "languages");
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+
+  it("filters specific entries by keypath", () => {
+    const hidden = hideSetFromArray(["languages.python"]);
+    const result = filterRecord(rec, hidden, "languages");
+    expect(Object.keys(result)).toEqual(["TypeScript", "Rust"]);
+  });
+});

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -1,0 +1,149 @@
+/**
+ * Server-side report filtering: strips hidden harness data and narrative
+ * section items before sending to non-owner viewers.
+ *
+ * Fixes the pre-existing privacy leak where GET /api/insights/[slug]
+ * returned harnessData unfiltered for section-level hides added via edit.
+ */
+
+import type { HarnessData } from "@/types/insights";
+import { stripHiddenHarnessData } from "./harness-section-visibility";
+import { hideSetFromArray, filterList } from "./item-visibility";
+
+/**
+ * The shape of a narrative section that contains filterable sub-lists.
+ * We only filter sections that have arrays as sub-properties.
+ */
+
+interface FilterOptions {
+  viewerIsOwner: boolean;
+  includeHidden: boolean;
+}
+
+/**
+ * Filter a report's data for the response. Returns a new object with hidden
+ * data stripped. When viewerIsOwner && includeHidden, returns data untouched.
+ */
+export function filterReportForResponse<
+  T extends {
+    harnessData?: unknown;
+    hiddenHarnessSections?: string[] | null;
+    impressiveWorkflows?: unknown;
+    frictionAnalysis?: unknown;
+    projectAreas?: unknown;
+    suggestions?: unknown;
+    onTheHorizon?: unknown;
+  },
+>(report: T, options: FilterOptions): T {
+  const { viewerIsOwner, includeHidden } = options;
+  const hiddenSections = report.hiddenHarnessSections ?? [];
+
+  // Owner with includeHidden=true gets unfiltered data (for edit page)
+  if (viewerIsOwner && includeHidden) return report;
+
+  // Nothing to filter
+  if (hiddenSections.length === 0) return report;
+
+  const hidden = hideSetFromArray(hiddenSections);
+  const result = { ...report };
+
+  // Filter harnessData (the main privacy fix)
+  if (result.harnessData && typeof result.harnessData === "object") {
+    result.harnessData = stripHiddenHarnessData(
+      result.harnessData as HarnessData,
+      hiddenSections,
+    ) as unknown as T["harnessData"];
+  }
+
+  // Filter narrative JSON sections that contain sub-lists
+  if (result.impressiveWorkflows && typeof result.impressiveWorkflows === "object") {
+    const iw = result.impressiveWorkflows as { impressive_workflows?: Array<{ title: string }> };
+    if (iw.impressive_workflows && Array.isArray(iw.impressive_workflows)) {
+      result.impressiveWorkflows = {
+        ...iw,
+        impressive_workflows: filterList(
+          iw.impressive_workflows,
+          hidden,
+          "impressiveWorkflows",
+          (w) => w.title,
+        ),
+      } as T["impressiveWorkflows"];
+    }
+  }
+
+  if (result.frictionAnalysis && typeof result.frictionAnalysis === "object") {
+    const fa = result.frictionAnalysis as { categories?: Array<{ category: string }> };
+    if (fa.categories && Array.isArray(fa.categories)) {
+      result.frictionAnalysis = {
+        ...fa,
+        categories: filterList(
+          fa.categories,
+          hidden,
+          "frictionAnalysis",
+          (c) => c.category,
+        ),
+      } as T["frictionAnalysis"];
+    }
+  }
+
+  if (result.projectAreas && typeof result.projectAreas === "object") {
+    const pa = result.projectAreas as { areas?: Array<{ name: string }> };
+    if (pa.areas && Array.isArray(pa.areas)) {
+      result.projectAreas = {
+        ...pa,
+        areas: filterList(pa.areas, hidden, "projectAreas", (a) => a.name),
+      } as T["projectAreas"];
+    }
+  }
+
+  if (result.suggestions && typeof result.suggestions === "object") {
+    const sg = result.suggestions as {
+      claude_md_additions?: Array<{ addition: string }>;
+      features_to_try?: Array<{ feature: string }>;
+      usage_patterns?: Array<{ title: string }>;
+    };
+    const filtered: Record<string, unknown> = { ...sg };
+    if (sg.claude_md_additions && Array.isArray(sg.claude_md_additions)) {
+      filtered.claude_md_additions = filterList(
+        sg.claude_md_additions,
+        hidden,
+        "suggestions",
+        (a) => a.addition.slice(0, 48),
+      );
+    }
+    if (sg.features_to_try && Array.isArray(sg.features_to_try)) {
+      filtered.features_to_try = filterList(
+        sg.features_to_try,
+        hidden,
+        "suggestions",
+        (f) => f.feature,
+      );
+    }
+    if (sg.usage_patterns && Array.isArray(sg.usage_patterns)) {
+      filtered.usage_patterns = filterList(
+        sg.usage_patterns,
+        hidden,
+        "suggestions",
+        (p) => p.title,
+      );
+    }
+    result.suggestions = filtered as T["suggestions"];
+  }
+
+  if (result.onTheHorizon && typeof result.onTheHorizon === "object") {
+    const oh = result.onTheHorizon as { opportunities?: Array<{ title: string }> };
+    if (oh.opportunities && Array.isArray(oh.opportunities)) {
+      result.onTheHorizon = {
+        ...oh,
+        opportunities: filterList(
+          oh.opportunities,
+          hidden,
+          "onTheHorizon",
+          (o) => o.title,
+        ),
+      } as T["onTheHorizon"];
+    }
+  }
+
+  return result;
+}

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -1,4 +1,11 @@
 import type { HarnessData } from "@/types/insights";
+import {
+  hideSetFromArray,
+  isSectionHidden,
+  filterList,
+  filterRecord,
+  parseKeypath,
+} from "./item-visibility";
 
 export const HIDEABLE_HARNESS_SECTION_KEYS = [
   "heroStats",
@@ -40,10 +47,31 @@ const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
   "harnessFiles",
 ]);
 
+/**
+ * Extract hidden section keys from a disabled-sections record.
+ * Returns top-level keys for backward compat.
+ */
 export function getHiddenHarnessSections(
   disabledSections: Record<string, boolean>,
 ): HideableHarnessSectionKey[] {
   return HIDEABLE_HARNESS_SECTION_KEYS.filter((key) => disabledSections[key]);
+}
+
+/**
+ * Extract ALL hidden keypaths (both section-level and item-level) from a
+ * disabled-sections record. A keypath is valid if its topKey is in the
+ * HIDEABLE_HARNESS_SECTION_KEYS allowlist.
+ */
+export function getHiddenKeypaths(
+  disabledSections: Record<string, boolean>,
+): string[] {
+  const allowedTopKeys = new Set<string>(HIDEABLE_HARNESS_SECTION_KEYS);
+  return Object.keys(disabledSections).filter((key) => {
+    if (!disabledSections[key]) return false;
+    const parsed = parseKeypath(key);
+    if (!parsed) return false;
+    return allowedTopKeys.has(parsed.topKey);
+  });
 }
 
 export function isHarnessSectionHidden(
@@ -53,10 +81,19 @@ export function isHarnessSectionHidden(
   return hiddenSections?.includes(key) ?? false;
 }
 
+/**
+ * Strip hidden harness data from a HarnessData object.
+ * Handles both section-level keys (e.g. "skillInventory") and item-level
+ * keypaths (e.g. "skillInventory.superpowers-brainstorming").
+ */
 export function stripHiddenHarnessData(
   data: HarnessData,
   hiddenSections: readonly string[],
 ): HarnessData {
+  if (!hiddenSections || hiddenSections.length === 0) return data;
+
+  const hidden = hideSetFromArray(hiddenSections);
+
   const copy: HarnessData = {
     ...data,
     toolUsage: { ...data.toolUsage },
@@ -77,6 +114,7 @@ export function stripHiddenHarnessData(
     writeupSections: [...data.writeupSections],
   };
 
+  // First pass: handle section-level (top-key) hides
   for (const key of hiddenSections) {
     if (!STRIPPABLE_HARNESS_DATA_KEYS.has(key)) continue;
 
@@ -129,6 +167,85 @@ export function stripHiddenHarnessData(
         copy.toolUsage = {};
         break;
     }
+  }
+
+  // Second pass: handle item-level keypaths (only for sections not already fully hidden)
+  if (!isSectionHidden(hidden, "skillInventory")) {
+    copy.skillInventory = filterList(
+      copy.skillInventory,
+      hidden,
+      "skillInventory",
+      (s) => s.name,
+    );
+  }
+  if (!isSectionHidden(hidden, "plugins")) {
+    copy.plugins = filterList(copy.plugins, hidden, "plugins", (p) => p.name);
+  }
+  if (!isSectionHidden(hidden, "hookDefinitions")) {
+    copy.hookDefinitions = filterList(
+      copy.hookDefinitions,
+      hidden,
+      "hookDefinitions",
+      (h) => `${h.event}-${h.matcher}`,
+    );
+  }
+  if (!isSectionHidden(hidden, "harnessFiles")) {
+    copy.harnessFiles = filterList(
+      copy.harnessFiles,
+      hidden,
+      "harnessFiles",
+      (f) => f,
+    );
+  }
+  if (!isSectionHidden(hidden, "writeupSections")) {
+    copy.writeupSections = filterList(
+      copy.writeupSections,
+      hidden,
+      "writeupSections",
+      (w) => w.title,
+    );
+  }
+  if (!isSectionHidden(hidden, "versions")) {
+    copy.versions = filterList(
+      copy.versions,
+      hidden,
+      "versions",
+      (v) => v,
+    );
+  }
+  if (!isSectionHidden(hidden, "toolUsage")) {
+    copy.toolUsage = filterRecord(copy.toolUsage, hidden, "toolUsage");
+  }
+  if (!isSectionHidden(hidden, "cliTools")) {
+    copy.cliTools = filterRecord(copy.cliTools, hidden, "cliTools");
+  }
+  if (!isSectionHidden(hidden, "languages")) {
+    copy.languages = filterRecord(copy.languages, hidden, "languages");
+  }
+  if (!isSectionHidden(hidden, "mcpServers")) {
+    copy.mcpServers = filterRecord(copy.mcpServers, hidden, "mcpServers");
+  }
+  if (!isSectionHidden(hidden, "permissionModes")) {
+    copy.permissionModes = filterRecord(
+      copy.permissionModes,
+      hidden,
+      "permissionModes",
+    );
+  }
+  if (copy.agentDispatch && !isSectionHidden(hidden, "agentDispatch")) {
+    copy.agentDispatch = {
+      ...copy.agentDispatch,
+      types: filterRecord(
+        copy.agentDispatch.types,
+        hidden,
+        "agentDispatch",
+      ),
+      models: filterRecord(
+        copy.agentDispatch.models,
+        hidden,
+        "agentDispatch",
+      ),
+    };
   }
 
   return copy;

--- a/src/lib/item-visibility.ts
+++ b/src/lib/item-visibility.ts
@@ -1,0 +1,164 @@
+/**
+ * Item-level visibility resolver for the per-item eye toggle feature (#28).
+ *
+ * Keypath grammar:
+ *   keypath := topKey | topKey "." itemKey
+ *   topKey  := [a-zA-Z][a-zA-Z0-9]*
+ *   itemKey := slugFragment ("@" indexFallback)?
+ *   slugFragment := url-safe slug (lowercased, kebab-cased, 60 char max)
+ *   indexFallback := integer (item's index at save time)
+ *
+ * Examples:
+ *   "impressiveWorkflows"                  → hide whole section
+ *   "impressiveWorkflows.parallel-refactor" → hide one workflow
+ *   "impressiveWorkflows.refactor@2"       → collision-disambiguated
+ */
+
+const SLUG_MAX_LENGTH = 60;
+
+/**
+ * Convert a natural key (e.g. workflow title) into a stable slug fragment.
+ * Lowercased, kebab-cased, stripped of non-url-safe chars, max 60 chars.
+ */
+export function slugItemKey(natural: string): string {
+  return (
+    natural
+      .toLowerCase()
+      // Replace non-alphanumeric (including emoji/unicode) with hyphens
+      .replace(/[^a-z0-9]+/g, "-")
+      // Collapse multiple hyphens
+      .replace(/-{2,}/g, "-")
+      // Trim leading/trailing hyphens
+      .replace(/^-|-$/g, "")
+      // Enforce max length
+      .slice(0, SLUG_MAX_LENGTH)
+      // Trim trailing hyphen after slice
+      .replace(/-$/, "")
+  );
+}
+
+/**
+ * Build the itemKey for an item in a list, appending @index only on collision.
+ */
+export function buildItemKey<T>(
+  list: readonly T[],
+  index: number,
+  natural: (t: T) => string,
+): string {
+  const base = slugItemKey(natural(list[index]));
+  if (!base) return `@${index}`;
+
+  const duplicates = list.filter((item) => slugItemKey(natural(item)) === base);
+  if (duplicates.length <= 1) return base;
+  return `${base}@${index}`;
+}
+
+/**
+ * Parse a keypath into its topKey and optional itemKey.
+ * Returns null if malformed.
+ */
+export function parseKeypath(keypath: string): {
+  topKey: string;
+  itemKey: string | null;
+} | null {
+  if (!keypath || typeof keypath !== "string") return null;
+
+  const dotIndex = keypath.indexOf(".");
+  if (dotIndex === -1) {
+    // Top-level key only
+    if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(keypath)) return null;
+    return { topKey: keypath, itemKey: null };
+  }
+
+  const topKey = keypath.slice(0, dotIndex);
+  const itemKey = keypath.slice(dotIndex + 1);
+
+  if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(topKey)) return null;
+  if (!itemKey) return null;
+  // itemKey must be a valid slug fragment optionally followed by @number
+  if (!/^[a-z0-9][a-z0-9-]*(@\d+)?$/.test(itemKey)) return null;
+
+  return { topKey, itemKey };
+}
+
+/**
+ * Build a Set from the hiddenHarnessSections string array.
+ */
+export function hideSetFromArray(arr: readonly string[]): Set<string> {
+  return new Set(arr);
+}
+
+/**
+ * Check if a whole section is hidden (top-level key present in set).
+ */
+export function isSectionHidden(
+  hidden: Set<string>,
+  sectionKey: string,
+): boolean {
+  return hidden.has(sectionKey);
+}
+
+/**
+ * Check if a specific item is hidden.
+ * Returns true if either the section-level key OR the item-level keypath is in the set.
+ */
+export function isItemHidden(
+  hidden: Set<string>,
+  sectionKey: string,
+  itemKey: string,
+): boolean {
+  // Section-level hide trumps — if the whole section is hidden, every item is hidden
+  if (hidden.has(sectionKey)) return true;
+  return hidden.has(`${sectionKey}.${itemKey}`);
+}
+
+/**
+ * Filter a list, removing items whose keypath is in the hidden set.
+ * If the whole section is hidden, returns an empty array.
+ */
+export function filterList<T>(
+  list: readonly T[],
+  hidden: Set<string>,
+  sectionKey: string,
+  natural: (t: T) => string,
+): T[] {
+  if (isSectionHidden(hidden, sectionKey)) return [];
+
+  // Check if there are any item-level hides for this section
+  const hasItemHides = Array.from(hidden).some(
+    (k) => k.startsWith(`${sectionKey}.`),
+  );
+  if (!hasItemHides) return [...list];
+
+  return list.filter((_, index) => {
+    const itemKey = buildItemKey(list, index, natural);
+    return !hidden.has(`${sectionKey}.${itemKey}`);
+  });
+}
+
+/**
+ * Filter a record (object), removing entries whose key-slug is in the hidden set.
+ * If the whole section is hidden, returns an empty object.
+ */
+export function filterRecord<T>(
+  rec: Record<string, T>,
+  hidden: Set<string>,
+  sectionKey: string,
+): Record<string, T> {
+  if (isSectionHidden(hidden, sectionKey)) return {} as Record<string, T>;
+
+  // Check if there are any item-level hides for this section
+  const hasItemHides = Array.from(hidden).some(
+    (k) => k.startsWith(`${sectionKey}.`),
+  );
+  if (!hasItemHides) return { ...rec };
+
+  const result: Record<string, T> = {};
+  for (const [key, value] of Object.entries(rec)) {
+    const itemKey = slugItemKey(key);
+    if (!hidden.has(`${sectionKey}.${itemKey}`)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Adds item-level hide/show toggles on the report edit page -- every skill, plugin, agent type, language, version, writeup section, MCP server, and harness file can be individually hidden
- Server-side filter strips hidden items before JSON response (privacy fix for pre-existing leak)
- Public detail page defense-in-depth: switches to `isSectionHidden`/`filterList`/`filterRecord` from `item-visibility.ts`
- Closes #28

## Changes
- **PR 1 commit:** Foundation + server-side filter (`item-visibility.ts`, `filter-report-response.ts`, route handler changes, 40 tests)
- **PR 2 commit:** `HideableItem` component, edit page per-item toggles, `SectionRenderer` `renderItemWrapper` prop, public page defense-in-depth

## Test plan
- [ ] Load existing report with section-level hides -> renders identically (backward compat)
- [ ] Hide one skill on edit page -> save -> reload -> still hidden
- [ ] Public URL in incognito -> hidden item NOT in network response JSON
- [ ] Toggle item back on -> item reappears
- [ ] Section-level "hide all" -> destructive confirmation fires -> hides section
- [ ] 350 existing tests pass + 40 new from PR 1

Generated with [Claude Code](https://claude.com/claude-code)