### PR TITLE
fix(parser): extract skillVersion from integrity manifest

### DIFF
--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -51,6 +51,7 @@ export function parseHarnessHtml(html: string): HarnessData {
     writeupSections: parseWriteupSections($),
     workflowData: parseWorkflowData($),
     integrityHash: parseIntegrityHash($),
+    skillVersion: parseSkillVersion($),
   };
 }
 
@@ -486,6 +487,18 @@ function parseIntegrityHash($: cheerio.CheerioAPI): string {
   }
 }
 
+function parseSkillVersion($: cheerio.CheerioAPI): string | null {
+  const script = $("#insight-harness-integrity").html();
+  if (!script) return null;
+  try {
+    const data = JSON.parse(script);
+    const payload = JSON.parse(data.payload ?? "{}");
+    return payload.skill_version ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Workflow Data (Phases & Tool Transitions)
 // ---------------------------------------------------------------------------
@@ -653,9 +666,7 @@ function parseNumericValue(s: string): number {
   if (!s) return 0;
   s = s.replace(/,/g, "").trim();
 
-  const tokenMatch = s.match(
-    /(\d+(?:\.\d+)?)\s*([KM])?\s*(?:tokens?|tok)\b/i,
-  );
+  const tokenMatch = s.match(/(\d+(?:\.\d+)?)\s*([KM])?\s*(?:tokens?|tok)\b/i);
   if (tokenMatch) {
     const value = parseFloat(tokenMatch[1]);
     const suffix = tokenMatch[2]?.toUpperCase();

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -228,6 +228,7 @@ export interface HarnessData {
   writeupSections: HarnessWriteupSection[];
   workflowData: HarnessWorkflowData | null;
   integrityHash: string;
+  skillVersion: string | null;
 }
 
 // v2: Chart data parsed from HTML report
@@ -423,5 +424,6 @@ export function normalizeHarnessData(raw: unknown): HarnessData | null {
       (obj.writeupSections as HarnessData["writeupSections"]) ?? [],
     workflowData: (obj.workflowData as HarnessData["workflowData"]) ?? null,
     integrityHash: (obj.integrityHash as string) ?? "",
+    skillVersion: (obj.skillVersion as string) ?? null,
   };
 }


### PR DESCRIPTION
## Summary
- Parses `skill_version` from the integrity manifest payload in harness HTML reports
- Adds `skillVersion: string | null` to `HarnessData` type and `safeParseHarnessData`
- Returns `null` for pre-2.2.0 reports (backward compatible)

Companion change: insight-harness skill v2.2.0 now embeds `skill_version` in the integrity payload.

## Test plan
- [x] 32 parser tests pass
- [x] TypeScript compiles clean
- [ ] Upload a v2.2.0 report → `harnessData.skillVersion` is `"2.2.0"`
- [ ] Existing reports → `skillVersion` is `null`

Generated with [Claude Code](https://claude.com/claude-code)