### PR TITLE
feat(ui): token stats redesign — lifetime tokens, skills, heatmap colors

### DIFF
--- a/src/app/api/og/[slug]/route.tsx
+++ b/src/app/api/og/[slug]/route.tsx
@@ -1,9 +1,6 @@
 import { ImageResponse } from "next/og";
 import { prisma } from "@/lib/db";
-import {
-  resolveLinesAdded,
-  resolveLinesRemoved,
-} from "@/lib/lines-of-code";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
 
 export const runtime = "nodejs";
@@ -64,14 +61,14 @@ function perWeek(total: number, days: number): string {
   return formatNumber(Math.round(total / weeks));
 }
 
-// Heatmap color scale
+// Heatmap color scale — amber for tokens, green for cost
 const HEATMAP_COLORS = [
   "#f1f5f9",
-  "#dbeafe",
-  "#93c5fd",
-  "#60a5fa",
-  "#3b82f6",
-  "#1d4ed8",
+  "#fef3c7",
+  "#fcd34d",
+  "#f59e0b",
+  "#d97706",
+  "#b45309",
 ];
 
 function getHeatmapColor(value: number, max: number): string {
@@ -563,7 +560,6 @@ export async function GET(
                 </div>
               </div>
             )}
-
           </div>
         </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -294,21 +294,21 @@ function extractPluginNames(
 function tokenLevelClass(value: number, max: number): string {
   if (value === 0) return "bg-slate-100 dark:bg-slate-800";
   const pct = value / Math.max(max, 1);
-  if (pct <= 0.2) return "bg-green-100 dark:bg-green-950/50";
-  if (pct <= 0.4) return "bg-green-300 dark:bg-green-800";
-  if (pct <= 0.6) return "bg-green-400 dark:bg-green-700";
-  if (pct <= 0.8) return "bg-green-500 dark:bg-green-600";
-  return "bg-green-700 dark:bg-green-500";
-}
-
-function costLevelClass(value: number, max: number): string {
-  if (value === 0) return "bg-slate-100 dark:bg-slate-800";
-  const pct = value / Math.max(max, 1);
   if (pct <= 0.2) return "bg-amber-100 dark:bg-amber-950/50";
   if (pct <= 0.4) return "bg-amber-300 dark:bg-amber-800";
   if (pct <= 0.6) return "bg-amber-400 dark:bg-amber-700";
   if (pct <= 0.8) return "bg-amber-500 dark:bg-amber-600";
   return "bg-amber-700 dark:bg-amber-500";
+}
+
+function costLevelClass(value: number, max: number): string {
+  if (value === 0) return "bg-slate-100 dark:bg-slate-800";
+  const pct = value / Math.max(max, 1);
+  if (pct <= 0.2) return "bg-green-100 dark:bg-green-950/50";
+  if (pct <= 0.4) return "bg-green-300 dark:bg-green-800";
+  if (pct <= 0.6) return "bg-green-400 dark:bg-green-700";
+  if (pct <= 0.8) return "bg-green-500 dark:bg-green-600";
+  return "bg-green-700 dark:bg-green-500";
 }
 
 // ── Sub-components ──────────────────────────────────────────
@@ -650,7 +650,7 @@ function ProfileCard({
           )}
           {hoursWk != null && hoursWk > 0 && (
             <div className="flex flex-1 flex-col border-r border-slate-100 px-3 dark:border-slate-800">
-              <span className="text-[15px] font-bold leading-none text-purple-600 dark:text-purple-400">
+              <span className="text-[15px] font-bold leading-none text-cyan-600 dark:text-cyan-400">
                 {formatHours(hoursWk)}
               </span>
               <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
@@ -664,14 +664,6 @@ function ProfileCard({
             </span>
             <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
               skills
-            </span>
-          </div>
-          <div className="flex flex-1 flex-col px-3 last:pr-0">
-            <span className="text-[15px] font-bold leading-none text-slate-800 dark:text-slate-200">
-              {pluginsCount}
-            </span>
-            <span className="mt-1 text-[9px] font-semibold uppercase tracking-wider text-slate-400">
-              {pluginsCount === 1 ? "plugin" : "plugins"}
             </span>
           </div>
           {(() => {

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -336,7 +336,8 @@ export default function ActivityHeatmap({
   // series. If we have no tokens, fall back to zeros.
   const costDaily = useMemo<number[] | null>(() => {
     if (!tokensDaily) return null;
-    const totalTokenCount = totalTokens ?? tokensDaily.reduce((a, b) => a + b, 0);
+    const totalTokenCount =
+      totalTokens ?? tokensDaily.reduce((a, b) => a + b, 0);
     // Shared helper handles per-model rate lookup AND the missing-
     // breakdown fallback (Sonnet 4.6 blended rate over total tokens).
     const totalCost = estimateApiCostUsd(models, totalTokenCount);
@@ -370,7 +371,7 @@ export default function ActivityHeatmap({
           title="Tokens"
           bigNumber={formatTokens(totalTokensSum)}
           bigNumberLabel="total tokens"
-          scale="green"
+          scale="amber"
           data={tokensDaily}
           formatValue={(n) => (n > 0 ? formatTokens(n) : "")}
           ariaValueLabel="tokens"
@@ -379,7 +380,7 @@ export default function ActivityHeatmap({
           title="Est. API Cost"
           bigNumber={formatCost(totalCostEstimate)}
           bigNumberLabel="estimated API cost"
-          scale="amber"
+          scale="green"
           data={costDaily}
           formatValue={(n) => (n > 0 ? formatCost(n) : "")}
           ariaValueLabel="dollars estimated"

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -191,9 +191,7 @@ function LinesStatCard({
         <span className="text-green-600 dark:text-green-400">{addedStr}</span>
         {removedStr && (
           <>
-            <span className="mx-0 hidden text-slate-300 dark:text-slate-600 lg:mx-1 lg:inline">
-              /
-            </span>
+            <span className="hidden lg:inline"> </span>
             <br className="lg:hidden" />
             <span className="text-red-600 dark:text-red-400">{removedStr}</span>
           </>
@@ -229,8 +227,28 @@ export default function HeroStats({
   const removedRaw = linesRemoved ?? 0;
   const showLinesCard = addedRaw > 0 || removedRaw > 0;
 
+  // Lifetime tokens: use the explicit lifetimeTokens field if present,
+  // otherwise fall back to totalTokens as a reasonable proxy.
+  const lifetimeTokens = stats.lifetimeTokens || stats.totalTokens || 0;
+
   return (
     <div className="mb-8">
+      {/* Lifetime tokens banner */}
+      {lifetimeTokens > 0 && (
+        <div className="mb-6 rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50/80 to-cyan-50/60 px-6 py-5 text-center dark:border-blue-900/40 dark:from-blue-950/30 dark:to-cyan-950/20">
+          <div className="bg-gradient-to-r from-blue-600 to-cyan-600 bg-clip-text font-mono text-5xl font-extrabold leading-none tracking-tight text-transparent sm:text-7xl dark:from-blue-400 dark:to-cyan-400">
+            {formatNumber(lifetimeTokens)}
+          </div>
+          <div className="mt-2 text-[13px] font-bold uppercase tracking-[0.1em] text-slate-500 dark:text-slate-400">
+            Lifetime Tokens
+          </div>
+          {stats.totalTokens > 0 && stats.totalTokens !== lifetimeTokens && (
+            <div className="mt-1.5 text-[13px] font-medium text-slate-400 dark:text-slate-500">
+              {formatNumber(stats.totalTokens)} in last 30 days
+            </div>
+          )}
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {stats.totalTokens > 0 && (
           <StatCard

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -69,6 +69,7 @@ function parseHarnessStats($: cheerio.CheerioAPI): HarnessStats {
 
   return {
     totalTokens: parseNumericValue(statValues["tokens"] ?? "0"),
+    lifetimeTokens: parseNumericValue(statValues["lifetime tokens"] ?? "0"),
     durationHours:
       parseInt(statValues["duration"]?.replace(/h$/i, "") ?? "0", 10) || 0,
     avgSessionMinutes:

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -118,6 +118,7 @@ export interface ParsedInsightsReport {
 
 export interface HarnessStats {
   totalTokens: number;
+  lifetimeTokens?: number;
   durationHours: number;
   avgSessionMinutes: number;
   skillsUsedCount: number;
@@ -389,7 +390,11 @@ export function normalizeHarnessData(raw: unknown): HarnessData | null {
 
   // Fill in defaults for optional/array fields that may be missing
   return {
-    stats: obj.stats as HarnessData["stats"],
+    stats: {
+      ...(obj.stats as HarnessData["stats"]),
+      lifetimeTokens:
+        ((obj.stats as Record<string, unknown>).lifetimeTokens as number) ?? 0,
+    },
     autonomy: obj.autonomy as HarnessData["autonomy"],
     featurePills: obj.featurePills as HarnessData["featurePills"],
     toolUsage: (obj.toolUsage as Record<string, number>) ?? {},


### PR DESCRIPTION
## Summary
- Lifetime tokens displayed prominently in HeroStats banner (blue-to-cyan gradient)
- Skills count replaces plugins count in profile card stats strip  
- Lines of code shown as `+X` green / `-Y` red (no slash separator)
- Heatmap colors standardized across all surfaces: tokens=amber, cost=green
- Active time color changed from purple to cyan for palette consistency
- Parser extracts `lifetimeTokens` from harness HTML

## Affected surfaces
- Report detail page (HeroStats + ActivityHeatmap)
- Homepage profile cards (ProfileCard)
- OG share card

## Test plan
- [ ] Report page: lifetime tokens banner above cards, green/red lines
- [ ] Homepage cards: skills stat, amber token heatmap, green cost heatmap
- [ ] OG card: amber token heatmap
- [ ] ActivityHeatmap: tokens=amber, cost=green

Generated with [Claude Code](https://claude.com/claude-code)