### PR TITLE
refactor(parser): replace HTML scraping with embedded JSON data layer

### DIFF
--- a/docs/plans/2026-04-12-001-refactor-json-data-layer-plan.md
+++ b/docs/plans/2026-04-12-001-refactor-json-data-layer-plan.md
@@ -1,0 +1,308 @@
+---
+title: "refactor: Replace HTML scraping with embedded JSON data layer"
+type: refactor
+status: active
+date: 2026-04-12
+---
+
+# Replace HTML Scraping with Embedded JSON Data Layer
+
+## Overview
+
+Restructure the insight-harness data pipeline to embed all structured data as a JSON blob inside the HTML report, and have the website read that JSON directly instead of scraping HTML with cheerio. The HTML continues to serve as a local preview for users; the site never looks at the HTML rendering.
+
+## Problem Frame
+
+The current pipeline is:
+
+```
+extract.py → format data as HTML → upload to site → cheerio scrapes HTML back into data → store
+```
+
+Every field goes through two lossy transformations: Python dict → HTML string → regex/cheerio parse. This caused:
+
+- "4.1B" parsed as "4" (missing B suffix in `parseNumericValue`)
+- Cache-key typos silently producing 0 values in HTML that the parser faithfully reproduced
+- Format suffix disagreements between the Python `fmt()` function and the TS `parseNumericValue` parser
+- 680 lines of fragile parsing code (`harness-parser.ts`) that must exactly mirror the HTML structure
+
+The fix: embed the raw structured data as JSON, read it directly, skip the HTML entirely.
+
+## Requirements Trace
+
+- R1. The harness HTML report must embed a complete JSON blob containing all data currently in `HarnessData`
+- R2. The site must read the JSON blob directly. No fallback to HTML parsing — harness reports without valid embedded JSON are rejected with a clear 400 error
+- R3. Numbers must survive the round-trip without formatting/parsing — stored as numbers, read as numbers
+- R4. Adding a new field to the harness report must require only: (a) add to Python dict, (b) add to TS type — no parser function needed
+- R5. The HTML report must continue to render a human-readable local preview
+- R6. Plain `/insights` reports (non-harness) must continue to parse via the existing HTML parser — JSON embedding is harness-only
+- R7. `writeupSections[].contentHtml` must be sanitized at the JSON ingestion boundary (strip scripts, iframes, event handlers) since it is rendered with `dangerouslySetInnerHTML`
+- R8. The upload route must source ALL harness data from the JSON blob — no cheerio scraping of the top-level harness HTML (`extractEnhancedStats` must be skipped for harness reports)
+
+## Scope Boundaries
+
+- **In scope:** extract.py JSON embedding, parser simplification, upload detection, type enrichment
+- **Out of scope:** Removing the HTML rendering from extract.py (users still view it locally), changing the Prisma schema beyond adding optional fields
+- **No backward compat needed:** The product hasn't launched yet. All harness reports will be generated with v2.3.0+ (JSON-embedded). No need to support pre-JSON harness reports. The cheerio harness parsing code can be deleted entirely.
+- **Not changing:** The `/insights` (non-harness) report parsing — that uses a separate `parseInsightsHtml()` parser and must continue working. The upload UX flow, the edit page, and the public detail page rendering also stay the same (they consume `HarnessData` from the DB).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `~/.claude/skills/insight-harness/scripts/extract.py` — generator, 2500 lines. Already embeds a small JSON integrity manifest in `<script id="insight-harness-integrity">`. The pattern exists; we're expanding it to include ALL data.
+- `src/lib/harness-parser.ts` — 689 lines, 21 parse functions. Almost entirely replaceable.
+- `src/types/insights.ts` — `HarnessData` interface (25 fields), `normalizeHarnessData()` validation function, `safeParseHarnessData()` deserializer.
+- `src/app/api/upload/route.ts` — detects report type via `isHarnessReport()`, calls `parseHarnessHtml()`, returns parsed data to the upload page.
+- `src/app/upload/page.tsx` — receives parsed data, maps fields, POSTs to `/api/insights`.
+
+### Existing JSON Embedding Pattern
+
+The integrity manifest already uses the exact pattern we want to expand:
+
+```html
+<script type="application/json" id="insight-harness-integrity">
+  { "payload": "{\"v\":2,\"skill_version\":\"2.2.0\",...}", "hash": "abc123" }
+</script>
+```
+
+The parser already reads this (`parseIntegrityHash`, `parseSkillVersion`). We just need a second, larger blob for the full data.
+
+## Key Technical Decisions
+
+- **Separate script tag, not expanding integrity manifest:** The integrity manifest serves a specific purpose (hash verification). The full data blob gets its own `<script id="harness-data">` tag. This keeps concerns separate and avoids breaking the hash when data changes.
+- **JSON shape matches HarnessData directly:** The embedded JSON should map 1:1 to the TypeScript `HarnessData` interface. No intermediate format, no translation layer. extract.py builds the same dict shape, serializes it, and the TS parser deserializes it directly into `HarnessData`.
+- **No cheerio fallback for harness reports:** Since the product hasn't launched, all harness reports will have embedded JSON. The 21 cheerio parse functions for harness data can be deleted. `isHarnessReport()` stays (detects harness vs `/insights`). The `/insights` HTML parser (`parseInsightsHtml`) is a separate codepath and stays unchanged. Missing or malformed JSON in a harness report returns a 400 error — no silent degradation.
+- **Numbers stay as numbers:** Token counts, session counts, durations — all stored as raw numbers in JSON. No K/M/B formatting on the Python side for data fields. The HTML rendering can still format for display, but the JSON blob carries raw values.
+- **Writeup HTML sanitization preserved:** The current cheerio parser sanitizes `writeupSections[].contentHtml` by stripping `<script>`, `<iframe>`, `<object>`, `<embed>`, and event handler attributes. This sanitization must be preserved at the JSON ingestion boundary since these strings are rendered with `dangerouslySetInnerHTML` in 4 places. Apply the same cheerio-based strip after JSON.parse, before returning `HarnessData`.
+- **Enhanced stats from JSON, not HTML:** The upload route currently scrapes `linesAdded`, `linesRemoved`, `fileCount`, `dayCount`, `msgsPerDay` from harness HTML via `extractEnhancedStats()`. These must be included in the JSON blob and sourced from there for harness reports, so the claim "site never looks at the HTML rendering" is actually true.
+- **Richer data deferred:** Per-model 4-way token breakdowns (`perModelTokens`), daily activity arrays (`dailyActivity`), and per-session metadata are deferred to a follow-up PR when UI is wired to consume them. This PR focuses on transport correctness only.
+
+## High-Level Technical Design
+
+> _This illustrates the intended approach and is directional guidance for review, not implementation specification._
+
+```
+┌─────────────────────────────────────────────────────┐
+│                  extract.py                          │
+│                                                      │
+│  data = {stats, autonomy, tools, skills, ...}       │
+│                                                      │
+│  ┌──────────────────────┐  ┌──────────────────────┐ │
+│  │  HTML Rendering       │  │  JSON Serialization  │ │
+│  │  (local preview)      │  │  (data transport)    │ │
+│  │                       │  │                      │ │
+│  │  Bar charts, grids,   │  │  json.dumps(data)    │ │
+│  │  formatted numbers    │  │  raw numbers, arrays │ │
+│  └──────────┬───────────┘  └──────────┬───────────┘ │
+│             │                          │              │
+│             ▼                          ▼              │
+│  <div class="stats-grid">   <script id="harness-data"│
+│    <div>1.5M</div>            type="application/json"│
+│    ...                        >{...all raw data}</    │
+│  </div>                      script>                  │
+└─────────────────────────────────────────────────────┘
+                         │
+                    HTML file
+                         │
+                    ┌────▼────┐
+                    │ Upload  │
+                    └────┬────┘
+                         │
+              ┌──────────▼──────────┐
+              │  /api/upload         │
+              │                      │
+              │  hasEmbeddedData()?  │
+              │    YES → JSON.parse  │  ← new path (5 lines)
+              │    NO  → cheerio     │  ← legacy fallback
+              └──────────┬──────────┘
+                         │
+                    HarnessData
+                    (identical shape
+                     either path)
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Build the JSON data dict in extract.py**
+
+  **Goal:** Construct the complete data dict that will be embedded as JSON, matching the `HarnessData` TypeScript interface shape.
+
+  **Requirements:** R1, R3, R4
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `~/.claude/skills/insight-harness/scripts/extract.py`
+
+  **Target repo:** `~/.claude/skills/insight-harness` (local skill, not the insightful repo)
+
+  **Approach:**
+  - In `generate_html()`, after all data is assembled but before HTML string construction, build a `harness_json` dict with keys matching `HarnessData` field names exactly: `stats`, `autonomy`, `featurePills`, `toolUsage`, `skillInventory`, `hookDefinitions`, `hookFrequency`, `plugins`, `harnessFiles`, `fileOpStyle`, `agentDispatch`, `cliTools`, `languages`, `models`, `permissionModes`, `mcpServers`, `gitPatterns`, `versions`, `writeupSections`, `workflowData`, `integrityHash`, `skillVersion`
+  - All numeric values stored as raw numbers (no K/M/B formatting)
+  - The `writeupSections` field should carry the same HTML content strings (sanitization happens on the TS side at ingestion)
+  - Include `lifetimeTokens` (number) in the stats dict
+  - Include enhanced stats fields that the upload route currently scrapes from HTML: `linesAdded` (number), `linesRemoved` (number), `fileCount` (number), `dayCount` (number), `msgsPerDay` (number) — these go in a top-level `enhancedStats` dict
+  - Serialize with `json.dumps(harness_json)` and embed in the HTML as `<script type="application/json" id="harness-data">{json}</script>`
+  - **Mandatory:** escape `</script>` in the JSON string: `json_str.replace("</script>", "<\\/script>")` — this is not optional, writeup content can contain arbitrary HTML
+  - Keep the existing `<script id="insight-harness-integrity">` tag unchanged (it serves hash verification)
+
+  **Patterns to follow:**
+  - The existing integrity manifest embedding pattern at the bottom of `generate_html()`
+
+  **Test scenarios:**
+  - Happy path: Run extract.py, verify the output HTML contains `id="harness-data"` with valid JSON
+  - Happy path: Parse the embedded JSON, verify every key exists and has the expected type (number, string, array, dict)
+  - Edge case: Verify raw token numbers are integers (not formatted strings like "1.5M")
+  - Edge case: Verify `writeupSections[].contentHtml` containing `</script>` is properly escaped and doesn't break the script tag
+  - Edge case: Verify `enhancedStats` fields (linesAdded, linesRemoved, fileCount, dayCount, msgsPerDay) are present as raw numbers
+  - Integration: Parse the JSON and compare key values (totalTokens, sessionCount, models) against the HTML-rendered values to confirm they agree
+
+  **Verification:**
+  - Generated HTML opens in browser (local preview still works)
+  - `python3 -c "import json; ..."` can parse the embedded blob and read all fields
+
+- [ ] **Unit 2: Add JSON extraction path to harness-parser.ts**
+
+  **Goal:** Replace the 21 cheerio parse functions with a single JSON extraction. Delete the cheerio harness parsing code entirely.
+
+  **Requirements:** R2, R3, R6, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Modify: `src/lib/harness-parser.ts`
+  - Modify: `src/lib/__tests__/harness-parser.test.ts`
+  - Modify: `src/lib/__tests__/harness-parser-workflow.test.ts` (rewrite — currently depends on HTML scraping)
+
+  **Approach:**
+  - Replace `parseHarnessHtml()` body: extract JSON from `<script id="harness-data">` via regex, `JSON.parse`, sanitize writeup HTML, validate with `normalizeHarnessData()`. ~30 lines replacing ~600.
+  - **Sanitize `writeupSections[].contentHtml`** after JSON.parse: strip `<script>`, `<iframe>`, `<object>`, `<embed>` tags and `onclick`/`onerror`/`onload`/`onmouseover` attributes. Use cheerio for this (same approach as current parser, just applied to the JSON-extracted strings instead of the full HTML DOM).
+  - `isHarnessReport()` stays (detects harness vs `/insights`)
+  - Delete ALL 21 cheerio parse functions: `parseHarnessStats`, `parseAutonomy`, `parseFeaturePills`, `parseBarChart`, `parseSkillInventory`, `parseHookDefinitions`, `parsePlugins`, `parseHarnessFiles`, `parseFileOpStyle`, `parseAgentDispatch`, `parseKvSection`, `parseGitPatterns`, `parseVersionTags`, `parseWriteupSections`, `parseWorkflowData`, `parseIntegrityHash`, `parseSkillVersion`, `findSectionByTitle`, `parseNumericValue`
+  - Keep cheerio import for writeup sanitization only (lightweight usage — sanitize individual HTML strings, not full document parsing)
+  - Throw a descriptive error if the `harness-data` script tag is missing or JSON is malformed — the upload route catches this and returns 400
+  - Regex for extraction must be robust to attribute order (test both `id="harness-data" type="application/json"` and reversed)
+  - Rewrite tests to use JSON-embedded HTML fixtures instead of cheerio-parsed HTML fixtures
+
+  **Patterns to follow:**
+  - `normalizeHarnessData()` in `types/insights.ts` — already validates and fills defaults
+
+  **Test scenarios:**
+  - Happy path: HTML with `id="harness-data"` JSON → returns HarnessData with correct values
+  - Happy path: All expected fields present and type-correct
+  - Edge case: Malformed JSON in script tag → throws descriptive error (no silent fallback)
+  - Edge case: Missing `harness-data` script tag → throws descriptive error
+  - Edge case: Valid JSON but missing optional fields → `normalizeHarnessData` fills defaults
+  - Edge case: Script tag attributes in reversed order → still extracts correctly
+  - **XSS regression:** `writeupSections[].contentHtml` containing `<script>alert(1)</script>` → script tag stripped after ingestion
+  - **XSS regression:** `contentHtml` with `<img onerror="alert(1)">` → event handler stripped
+  - Integration: Parse a real generated HTML (from Unit 1) → all values match ground truth
+
+  **Verification:**
+  - Tests pass with new JSON-based fixtures
+  - cheerio kept only for writeup sanitization (confirm no full-document parsing usage)
+  - File shrinks from ~689 lines to ~50-80
+
+- [ ] **Unit 3: Add enhancedStats to HarnessData type and update normalizeHarnessData**
+
+  **Goal:** Add `enhancedStats` to the TypeScript type so the upload route can source these from JSON instead of HTML scraping. Confirm `lifetimeTokens` works via JSON path.
+
+  **Requirements:** R4, R8
+
+  **Dependencies:** Unit 1, Unit 2
+
+  **Files:**
+  - Modify: `src/types/insights.ts`
+  - Test: `src/lib/__tests__/harness-parser.test.ts` (extend existing)
+
+  **Approach:**
+  - Add `HarnessEnhancedStats` interface: `{ linesAdded: number | null, linesRemoved: number | null, fileCount: number | null, dayCount: number | null, msgsPerDay: number | null }`
+  - Add `enhancedStats?: HarnessEnhancedStats | null` to `HarnessData`
+  - Confirm `lifetimeTokens?: number` on `HarnessStats` (already added in PR #54) works via JSON path
+  - Update `normalizeHarnessData()` to handle `enhancedStats` with `?? null` default
+  - Note: `safeParseHarnessData()` does not exist in the codebase — no update needed
+
+  **Patterns to follow:**
+  - Existing nullable fields on `HarnessData` like `workflowData: HarnessWorkflowData | null` and `skillVersion: string | null`
+
+  **Test scenarios:**
+  - Happy path: JSON with `enhancedStats` present → correctly parsed and accessible
+  - Edge case: JSON without `enhancedStats` (future-proofing) → field is null, no crash
+  - Edge case: `normalizeHarnessData` with partial `enhancedStats` → fills defaults without throwing
+  - Confirm `lifetimeTokens` round-trips correctly as a number
+
+  **Verification:**
+  - TypeScript compiles clean
+  - Existing tests pass
+  - `enhancedStats` accessible when present, gracefully absent when not
+
+  **Deferred to follow-up:** `perModelTokens`, `dailyActivity`, per-session metadata — add when UI is wired to consume them
+
+- [ ] **Unit 4: Update upload route to source harness data from JSON**
+
+  **Goal:** Stop scraping harness HTML for enhanced stats. Source all harness data from the JSON blob. Return 400 for invalid harness reports.
+
+  **Requirements:** R2, R6, R8
+
+  **Dependencies:** Unit 2, Unit 3
+
+  **Files:**
+  - Modify: `src/app/api/upload/route.ts`
+  - Test: manual verification via upload flow + route-level error tests
+
+  **Approach:**
+  - For harness reports, skip `extractEnhancedStats(html)` — source `linesAdded`, `linesRemoved`, `fileCount`, `dayCount`, `msgsPerDay` from `harnessData.enhancedStats` instead
+  - `extractEnhancedStats()` stays for plain `/insights` reports (it parses the insights stats row)
+  - Catch the descriptive error thrown by `parseHarnessHtml()` when JSON is missing/malformed and return a 400 with a clear message (not a generic 500)
+  - Verify that `totalTokens` and other scalar fields now carry raw JSON numbers
+  - The harness stat override block (`...(harnessData ? { sessionCount: ..., commitCount: ..., dayCount: ... } : {})`) should pull `dayCount` from `enhancedStats` instead of falling back to 30
+
+  **Patterns to follow:**
+  - Existing upload flow at `src/app/api/upload/route.ts` lines 88-145
+
+  **Test scenarios:**
+  - Happy path: Upload a v2.3.0 HTML report with embedded JSON → `totalTokens` matches the raw number from JSON (e.g., 9500000 not 1500000)
+  - Happy path: Enhanced stats (linesAdded, fileCount, etc.) sourced from JSON, not HTML scraping
+  - Error: Upload a harness report without `harness-data` script tag → returns 400 with descriptive message
+  - Error: Upload a harness report with malformed JSON → returns 400, not 500
+  - Unchanged: Upload a plain `/insights` report → `extractEnhancedStats` still used, works as before
+  - Integration: Full upload → publish flow → verify stored `harnessData` in DB has correct token values
+
+  **Verification:**
+  - Upload a fresh report generated by Unit 1's extract.py
+  - Confirm the published report shows correct numbers
+  - Confirm `extractEnhancedStats` is NOT called for harness reports
+
+## System-Wide Impact
+
+- **Interaction graph:** The change is isolated to the parse layer. Everything downstream (DB storage, API responses, React rendering) consumes `HarnessData` — the shape doesn't change, only how it's populated. No callbacks, middleware, or observers affected.
+- **Error propagation:** JSON parse failure throws a descriptive error caught by the upload route, which returns 400. No silent degradation — harness reports must have valid JSON.
+- **State lifecycle risks:** None — the JSON blob is read-only, parsed once during upload, never mutated.
+- **API surface parity:** No API changes. The `HarnessData` JSON column in the DB stores the same shape regardless of source.
+- **Integration coverage:** The upload → parse → store → render pipeline should be tested end-to-end with JSON-embedded reports. Old HTML-only harness reports are not supported (product hasn't launched).
+- **Unchanged invariants:** The Prisma schema, the `InsightReport` model, the GET/PUT API routes, the edit page, the public detail page, the OG card — all unchanged. They read from `harnessData` in the DB, which has the same shape either way.
+
+## Risks & Dependencies
+
+| Risk                                                   | Mitigation                                                                                                                                                                              |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSON blob too large (writeup sections contain HTML)    | Measure size. Current integrity manifest is ~500 bytes; full data with writeups will be ~50-100KB. Well within HTML limits.                                                             |
+| Script tag content breaks if JSON contains `</script>` | **Mandatory** escape in extract.py: `json_str.replace("</script>", "<\\/script>")`. `json.dumps` won't produce this, but writeup content can contain arbitrary HTML. Tested explicitly. |
+| XSS via writeup contentHtml in JSON                    | Sanitize `writeupSections[].contentHtml` at the JSON ingestion boundary (strip scripts, iframes, event handlers). Same cheerio-based approach as current parser.                        |
+| Auto-update overwrites extract.py fixes again          | Already disabled in this session. Also: once extract.py is published to the remote repo (craigdossantos/claude-toolkit), the auto-update will pull the fixed version.                   |
+| `/insights` reports still need HTML parsing            | Separate parser (`parseInsightsHtml`) is untouched — only harness cheerio code is deleted.                                                                                              |
+| Upload route still scrapes harness HTML                | `extractEnhancedStats()` skipped for harness reports — enhanced stats sourced from JSON blob's `enhancedStats` field instead.                                                           |
+
+## Documentation / Operational Notes
+
+- After implementing, update `~/.claude/skills/insight-harness/SKILL.md` description to mention the embedded JSON data layer
+- Bump skill version to 2.3.0
+- The remote repo (craigdossantos/claude-toolkit) should be updated with the new extract.py so auto-update pulls the correct version for all users
+
+## Sources & References
+
+- Related issues: #42, #43 (token counting bugs caused by HTML round-trip)
+- Audit doc: `docs/research/2026-04-11-insight-harness-audit.md`
+- Current parser: `src/lib/harness-parser.ts` (689 lines, 21 functions — most become dead code after this)
+- Current types: `src/types/insights.ts` (HarnessData interface)

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "prisma": "^6.19.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "sanitize-html": "^2.17.2",
         "slugify": "^1.6.9",
         "unfurl.js": "^6.4.0"
       },
@@ -31,6 +32,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/sanitize-html": "^2.16.1",
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
         "tailwindcss": "^4",
@@ -2974,6 +2976,16 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -5071,6 +5083,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -5564,7 +5585,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6901,6 +6921,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -8251,6 +8280,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -8415,7 +8450,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8856,6 +8890,20 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.2.tgz",
+      "integrity": "sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prisma": "^6.19.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "sanitize-html": "^2.17.2",
     "slugify": "^1.6.9",
     "unfurl.js": "^6.4.0"
   },
@@ -35,6 +36,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/sanitize-html": "^2.16.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "tailwindcss": "^4",

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -110,12 +110,35 @@ export async function POST(request: Request) {
     // Detect sensitive data using the redaction engine
     const detectedRedactions = detectRedactions(parsed.data);
 
-    // Extract enhanced stats — for harness reports, use harness stats grid;
-    // for plain insights, use the insights stats row
-    const enhancedStats = extractEnhancedStats(isHarness ? html : insightsHtml);
-
     // Parse harness-specific data if applicable
-    const harnessData = isHarness ? parseHarnessHtml(html) : undefined;
+    let harnessData: ReturnType<typeof parseHarnessHtml> | undefined;
+    if (isHarness) {
+      try {
+        harnessData = parseHarnessHtml(html);
+      } catch (e) {
+        return NextResponse.json(
+          {
+            error:
+              e instanceof Error
+                ? e.message
+                : "Failed to parse harness report data",
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    // Extract enhanced stats — for harness reports, source from JSON blob;
+    // for plain insights, scrape from the insights stats row
+    const enhancedStats = harnessData?.enhancedStats
+      ? {
+          linesAdded: harnessData.enhancedStats.linesAdded,
+          linesRemoved: harnessData.enhancedStats.linesRemoved,
+          fileCount: harnessData.enhancedStats.fileCount,
+          dayCount: harnessData.enhancedStats.dayCount,
+          msgsPerDay: harnessData.enhancedStats.msgsPerDay,
+        }
+      : extractEnhancedStats(insightsHtml);
 
     // For harness reports, override stats with harness-level data
     // since the embedded insights tab may have stale/different stats
@@ -125,9 +148,9 @@ export async function POST(request: Request) {
       ...(harnessData
         ? {
             sessionCount:
-              parsed.stats.sessionCount || harnessData.stats.sessionCount || 0,
+              harnessData.stats.sessionCount ?? parsed.stats.sessionCount ?? 0,
             commitCount:
-              parsed.stats.commitCount || harnessData.stats.commitCount || 0,
+              harnessData.stats.commitCount ?? parsed.stats.commitCount ?? 0,
             dayCount: enhancedStats.dayCount ?? 30,
           }
         : {}),

--- a/src/app/insights/[slug]/edit/page.tsx
+++ b/src/app/insights/[slug]/edit/page.tsx
@@ -509,6 +509,7 @@ export default function EditReportPage() {
               dayCount={report.dayCount ?? undefined}
               slug={report.slug}
               models={harnessData.models}
+              perModelTokens={harnessData.perModelTokens}
             />
           </HideableCard>
 
@@ -551,7 +552,11 @@ export default function EditReportPage() {
             >
               <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
                 {harnessData.skillInventory.map((skill, i) => {
-                  const itemKey = buildItemKey(harnessData.skillInventory, i, (s) => s.name);
+                  const itemKey = buildItemKey(
+                    harnessData.skillInventory,
+                    i,
+                    (s) => s.name,
+                  );
                   const keypath = `skillInventory.${itemKey}`;
                   return (
                     <HideableItem
@@ -581,7 +586,11 @@ export default function EditReportPage() {
               >
                 <div className="grid gap-2 sm:grid-cols-2">
                   {harnessData.plugins.map((plugin, i) => {
-                    const itemKey = buildItemKey(harnessData.plugins, i, (p) => p.name);
+                    const itemKey = buildItemKey(
+                      harnessData.plugins,
+                      i,
+                      (p) => p.name,
+                    );
                     const keypath = `plugins.${itemKey}`;
                     return (
                       <HideableItem
@@ -683,7 +692,9 @@ export default function EditReportPage() {
                           ([typeName, value]) => {
                             const keypath = `agentDispatch.${buildItemKey(
                               Object.keys(harnessData.agentDispatch!.types),
-                              Object.keys(harnessData.agentDispatch!.types).indexOf(typeName),
+                              Object.keys(
+                                harnessData.agentDispatch!.types,
+                              ).indexOf(typeName),
                               (k) => k,
                             )}`;
                             return (
@@ -713,7 +724,9 @@ export default function EditReportPage() {
                           ([modelName, value]) => {
                             const keypath = `agentDispatch.${buildItemKey(
                               Object.keys(harnessData.agentDispatch!.models),
-                              Object.keys(harnessData.agentDispatch!.models).indexOf(modelName),
+                              Object.keys(
+                                harnessData.agentDispatch!.models,
+                              ).indexOf(modelName),
                               (k) => k,
                             )}`;
                             return (
@@ -840,7 +853,11 @@ export default function EditReportPage() {
               >
                 <div className="flex flex-wrap gap-1.5">
                   {harnessData.versions.map((version, i) => {
-                    const itemKey = buildItemKey(harnessData.versions, i, (v) => v);
+                    const itemKey = buildItemKey(
+                      harnessData.versions,
+                      i,
+                      (v) => v,
+                    );
                     const keypath = `versions.${itemKey}`;
                     return (
                       <HideableItem
@@ -873,7 +890,11 @@ export default function EditReportPage() {
               >
                 <div className="space-y-6">
                   {harnessData.writeupSections.map((section, i) => {
-                    const itemKey = buildItemKey(harnessData.writeupSections, i, (w) => w.title);
+                    const itemKey = buildItemKey(
+                      harnessData.writeupSections,
+                      i,
+                      (w) => w.title,
+                    );
                     const keypath = `writeupSections.${itemKey}`;
                     return (
                       <HideableItem
@@ -914,7 +935,11 @@ export default function EditReportPage() {
               >
                 <div className="space-y-1">
                   {harnessData.harnessFiles.map((file, i) => {
-                    const itemKey = buildItemKey(harnessData.harnessFiles, i, (f) => f);
+                    const itemKey = buildItemKey(
+                      harnessData.harnessFiles,
+                      i,
+                      (f) => f,
+                    );
                     const keypath = `harnessFiles.${itemKey}`;
                     return (
                       <HideableItem

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -380,6 +380,7 @@ export default function InsightDetailPage() {
               dateRangeStart={report.dateRangeStart ?? undefined}
               slug={slug}
               models={report.harnessData?.models ?? undefined}
+              perModelTokens={report.harnessData?.perModelTokens ?? undefined}
             />
           )}
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,6 +65,11 @@ interface HarnessSlice {
   workflowData?: HarnessWorkflowSlice | null;
   /** Top-level per-model token counts used for API cost estimation. */
   models?: Record<string, number>;
+  /** 4-way per-model breakdown (input/output/cache_read/cache_create) for accurate cost. */
+  perModelTokens?: Record<
+    string,
+    { input: number; output: number; cache_read: number; cache_create: number }
+  > | null;
   /**
    * Git patterns slice — used by the lines-of-code resolver when the
    * scalar `linesAdded` / `linesRemoved` columns on the report are null
@@ -508,6 +513,7 @@ function ProfileCard({
   const totalCost = estimateApiCostUsd(
     insight.harnessData?.models,
     effectiveTokens ?? 0,
+    insight.harnessData?.perModelTokens,
   );
   const costWk = perWeek(totalCost, insight.dayCount);
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1432,6 +1432,7 @@ export default function UploadPage() {
                   dateRangeStart={parsed.stats.dateRangeStart ?? undefined}
                   slug="preview"
                   models={parsed.harnessData.models}
+                  perModelTokens={parsed.harnessData.perModelTokens}
                 />
               </RedactableSection>
 

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -19,6 +19,11 @@ interface ActivityHeatmapProps {
   slug?: string;
   /** Optional model → token count map, used to estimate API cost */
   models?: Record<string, number>;
+  /** Optional 4-way per-model breakdown for accurate cost estimation */
+  perModelTokens?: Record<
+    string,
+    { input: number; output: number; cache_read: number; cache_create: number }
+  > | null;
 }
 
 // 4 weeks × 7 days = 28 cells per heatmap (no day-of-week labels)
@@ -274,6 +279,7 @@ export default function ActivityHeatmap({
   dateRangeStart,
   slug,
   models,
+  perModelTokens,
 }: ActivityHeatmapProps) {
   const { sessionsDaily, tokensDaily } = useMemo<{
     sessionsDaily: number[] | null;
@@ -340,11 +346,15 @@ export default function ActivityHeatmap({
       totalTokens ?? tokensDaily.reduce((a, b) => a + b, 0);
     // Shared helper handles per-model rate lookup AND the missing-
     // breakdown fallback (Sonnet 4.6 blended rate over total tokens).
-    const totalCost = estimateApiCostUsd(models, totalTokenCount);
+    const totalCost = estimateApiCostUsd(
+      models,
+      totalTokenCount,
+      perModelTokens,
+    );
     if (totalCost <= 0) return tokensDaily.map(() => 0);
     const tokenSum = tokensDaily.reduce((a, b) => a + b, 0) || 1;
     return tokensDaily.map((t) => (t / tokenSum) * totalCost);
-  }, [tokensDaily, models, totalTokens]);
+  }, [tokensDaily, models, totalTokens, perModelTokens]);
 
   if (!sessionsDaily || !tokensDaily || !costDaily) return null;
 

--- a/src/lib/__tests__/harness-parser-workflow.test.ts
+++ b/src/lib/__tests__/harness-parser-workflow.test.ts
@@ -1,78 +1,112 @@
 import { describe, it, expect } from "vitest";
 import { parseHarnessHtml } from "@/lib/harness-parser";
 
-const MOCK_HTML = `
-<!DOCTYPE html>
-<html lang="en">
-<head><title>Test</title></head>
-<body>
-<div class="stats-grid">
-  <div class="stat"><div class="stat-value">10</div><div class="stat-label">Sessions</div></div>
-  <div class="stat"><div class="stat-value">1.2M</div><div class="stat-label">Tokens</div></div>
-  <div class="stat"><div class="stat-value">24h</div><div class="stat-label">Duration</div></div>
-  <div class="stat"><div class="stat-value">45m</div><div class="stat-label">Avg Session</div></div>
-  <div class="stat"><div class="stat-value">3</div><div class="stat-label">Skills Used</div></div>
-  <div class="stat"><div class="stat-value">2</div><div class="stat-label">Hooks</div></div>
-  <div class="stat"><div class="stat-value">0</div><div class="stat-label">PRs</div></div>
-  <div class="stat"><div class="stat-value">5</div><div class="stat-label">Commits</div></div>
-</div>
-<div class="autonomy-box">
-  <div class="autonomy-label">Directive</div>
-  <div class="autonomy-desc">test</div>
-  <div class="autonomy-stats">
-    <div class="autonomy-stat"><strong>50</strong> user msgs</div>
-    <div class="autonomy-stat"><strong>200</strong> assistant msgs</div>
-    <div class="autonomy-stat"><strong>100</strong> turns measured</div>
-    <div class="autonomy-stat"><strong>2%</strong> error rate</div>
-  </div>
-</div>
-<div class="pills"></div>
+// ---------------------------------------------------------------------------
+// Base HarnessData with workflow data embedded as JSON
+// ---------------------------------------------------------------------------
 
-<section>
-  <div class="section-header"><h2>Workflow Phases</h2><span class="count">8 sessions analyzed</span></div>
-  <div class="two-col">
-    <div>
-      <h3>Phase Distribution</h3>
-      <div class="kv-row"><span class="mono">exploration</span><span class="meta">40%</span></div>
-      <div class="kv-row"><span class="mono">implementation</span><span class="meta">35%</span></div>
-      <div class="kv-row"><span class="mono">testing</span><span class="meta">15%</span></div>
-      <div class="kv-row"><span class="mono">shipping</span><span class="meta">10%</span></div>
-    </div>
-    <div>
-      <h3>Phase Transitions</h3>
-      <div class="bar-row"><div class="bar-label">exploration->implementation</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">23</div></div>
-      <div class="bar-row"><div class="bar-label">implementation->testing</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">15</div></div>
-      <div class="bar-row"><div class="bar-label">testing->shipping</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">8</div></div>
-    </div>
-  </div>
-  <div style="display:flex;gap:1.5rem">
-    <div class="meta"><strong>75%</strong> explore before implementing</div>
-    <div class="meta"><strong>60%</strong> test before shipping</div>
-  </div>
-</section>
+const BASE_DATA = {
+  stats: {
+    totalTokens: 1200000,
+    lifetimeTokens: 0,
+    durationHours: 24,
+    avgSessionMinutes: 45,
+    skillsUsedCount: 3,
+    hooksCount: 2,
+    prCount: 0,
+    sessionCount: 10,
+    commitCount: 5,
+  },
+  autonomy: {
+    label: "Directive",
+    description: "test",
+    userMessages: 50,
+    assistantMessages: 200,
+    turnCount: 100,
+    errorRate: "2%",
+  },
+  featurePills: [],
+  toolUsage: {},
+  skillInventory: [],
+  hookDefinitions: [],
+  hookFrequency: {},
+  plugins: [],
+  harnessFiles: [],
+  fileOpStyle: {
+    readPct: 0,
+    editPct: 0,
+    writePct: 0,
+    grepCount: 0,
+    globCount: 0,
+    style: "",
+  },
+  agentDispatch: null,
+  cliTools: {},
+  languages: {},
+  models: {},
+  permissionModes: {},
+  mcpServers: {},
+  gitPatterns: {
+    prCount: 0,
+    commitCount: 0,
+    linesAdded: "0",
+    branchPrefixes: {},
+  },
+  versions: [],
+  writeupSections: [],
+  workflowData: null as null,
+  integrityHash: "test123",
+  skillVersion: null,
+};
 
-<section>
-  <div class="section-header"><h2>Skill Workflow</h2></div>
-  <div class="footnote">Skill invocations</div>
-  <div class="bar-row"><div class="bar-label">ce-brainstorm</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">8</div></div>
-  <div class="bar-row"><div class="bar-label">ce-work</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">12</div></div>
-  <div class="bar-row"><div class="bar-label">git-commit-push-pr</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">4</div></div>
-  <div class="footnote">Agent dispatches</div>
-  <div class="bar-row"><div class="bar-label">Run tests for auth module</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">3</div></div>
-  <div class="bar-row"><div class="bar-label">Lint and format changed files</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">2</div></div>
-  <div class="footnote">Common workflow patterns</div>
-  <div class="bar-row"><div class="bar-label">ce-brainstorm &rarr; ce-work &rarr; git-commit-push-pr</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">5</div></div>
-  <div class="bar-row"><div class="bar-label">ce-work &rarr; git-commit-push-pr</div><div class="bar-track"><div class="bar-fill"></div></div><div class="bar-value">3</div></div>
-</section>
+const WORKFLOW_DATA = {
+  skillInvocations: {
+    "ce-brainstorm": 8,
+    "ce-work": 12,
+    "git-commit-push-pr": 4,
+  },
+  agentDispatches: {
+    "Run tests for auth module": 3,
+    "Lint and format changed files": 2,
+  },
+  workflowPatterns: [
+    {
+      sequence: ["ce-brainstorm", "ce-work", "git-commit-push-pr"],
+      count: 5,
+    },
+    { sequence: ["ce-work", "git-commit-push-pr"], count: 3 },
+  ],
+  phaseTransitions: {
+    "exploration->implementation": 23,
+    "implementation->testing": 15,
+    "testing->shipping": 8,
+  },
+  phaseDistribution: {
+    exploration: 40,
+    implementation: 35,
+    testing: 15,
+    shipping: 10,
+  },
+  phaseStats: {
+    testBeforeShipPct: 60,
+    exploreBeforeImplPct: 75,
+    totalSessionsWithPhases: 8,
+  },
+};
 
-<script type="application/json" id="insight-harness-integrity">{"hash":"test123"}</script>
-</body>
-</html>
-`;
+function buildHtml(data: unknown): string {
+  const json = JSON.stringify(data).replace(/<\/script>/gi, "<\\/script>");
+  return `
+<html><body>
+  <script id="harness-data" type="application/json">${json}</script>
+  <script type="application/json" id="insight-harness-integrity">{"hash":"test123"}</script>
+</body></html>`;
+}
 
 describe("harness-parser workflow data", () => {
-  it("parses workflow phases section", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+  it("parses workflow phases from JSON", () => {
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData).not.toBeNull();
     expect(result.workflowData!.phaseDistribution).toEqual({
       exploration: 40,
@@ -83,7 +117,8 @@ describe("harness-parser workflow data", () => {
   });
 
   it("parses phase transitions", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData!.phaseTransitions).toEqual({
       "exploration->implementation": 23,
       "implementation->testing": 15,
@@ -92,7 +127,8 @@ describe("harness-parser workflow data", () => {
   });
 
   it("parses skill invocations", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData!.skillInvocations).toEqual({
       "ce-brainstorm": 8,
       "ce-work": 12,
@@ -101,7 +137,8 @@ describe("harness-parser workflow data", () => {
   });
 
   it("parses agent dispatches", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData!.agentDispatches).toEqual({
       "Run tests for auth module": 3,
       "Lint and format changed files": 2,
@@ -109,7 +146,8 @@ describe("harness-parser workflow data", () => {
   });
 
   it("parses workflow patterns", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData!.workflowPatterns).toEqual([
       {
         sequence: ["ce-brainstorm", "ce-work", "git-commit-push-pr"],
@@ -120,34 +158,23 @@ describe("harness-parser workflow data", () => {
   });
 
   it("parses phase stats", () => {
-    const result = parseHarnessHtml(MOCK_HTML);
+    const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
+    const result = parseHarnessHtml(buildHtml(data));
     expect(result.workflowData!.phaseStats.exploreBeforeImplPct).toBe(75);
     expect(result.workflowData!.phaseStats.testBeforeShipPct).toBe(60);
     expect(result.workflowData!.phaseStats.totalSessionsWithPhases).toBe(8);
   });
 
-  it("returns null workflowData when sections are missing", () => {
-    const minimalHtml = `
-      <!DOCTYPE html><html><body>
-      <div class="stats-grid">
-        <div class="stat"><div class="stat-value">1</div><div class="stat-label">Sessions</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Tokens</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Duration</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Avg Session</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Skills Used</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Hooks</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">PRs</div></div>
-        <div class="stat"><div class="stat-value">0</div><div class="stat-label">Commits</div></div>
-      </div>
-      <div class="autonomy-box">
-        <div class="autonomy-label">Test</div>
-        <div class="autonomy-desc">test</div>
-      </div>
-      <div class="pills"></div>
-      <script type="application/json" id="insight-harness-integrity">{"hash":"x"}</script>
-      </body></html>
-    `;
-    const result = parseHarnessHtml(minimalHtml);
+  it("returns null workflowData when not present in JSON", () => {
+    const data = { ...BASE_DATA, workflowData: null };
+    const result = parseHarnessHtml(buildHtml(data));
+    expect(result.workflowData).toBeNull();
+  });
+
+  it("returns null workflowData when field is omitted", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { workflowData, ...rest } = BASE_DATA;
+    const result = parseHarnessHtml(buildHtml(rest));
     expect(result.workflowData).toBeNull();
   });
 });

--- a/src/lib/__tests__/harness-parser.test.ts
+++ b/src/lib/__tests__/harness-parser.test.ts
@@ -2,183 +2,122 @@ import { describe, it, expect } from "vitest";
 import { isHarnessReport, parseHarnessHtml } from "../harness-parser";
 
 // ---------------------------------------------------------------------------
-// Minimal HTML fixtures that mirror the real harness report structure
+// Minimal HarnessData JSON matching the HarnessData interface
 // ---------------------------------------------------------------------------
 
-const MINIMAL_HARNESS_HTML = `
+const MINIMAL_HARNESS_DATA = {
+  stats: {
+    totalTokens: 1200000,
+    lifetimeTokens: 9500000,
+    durationHours: 18,
+    avgSessionMinutes: 25.5,
+    skillsUsedCount: 5,
+    hooksCount: 3,
+    prCount: 7,
+    sessionCount: 42,
+    commitCount: 23,
+  },
+  autonomy: {
+    label: "Fire-and-Forget",
+    description: "You launch tasks and let Claude run",
+    userMessages: 150,
+    assistantMessages: 800,
+    turnCount: 950,
+    errorRate: "2%",
+  },
+  featurePills: [
+    { name: "Task Agents", active: true, value: "12%" },
+    { name: "MCP Servers", active: false, value: "" },
+    { name: "Custom Skills", active: true, value: "45%" },
+  ],
+  toolUsage: { Read: 1500, Edit: 800, Bash: 2200 },
+  skillInventory: [
+    {
+      name: "commit",
+      calls: 12,
+      source: "custom",
+      description: "Auto-commit helper",
+    },
+    {
+      name: "review-pr",
+      calls: 5,
+      source: "plugin",
+      description: "PR reviewer",
+    },
+  ],
+  hookDefinitions: [
+    { event: "PreToolUse", matcher: "Bash", script: "validate-bash.sh" },
+    { event: "PostToolUse", matcher: "Edit", script: "format-on-save.sh" },
+  ],
+  hookFrequency: { PreToolUse: 45, PostToolUse: 12 },
+  plugins: [
+    {
+      name: "superpowers",
+      version: "2.1.0",
+      marketplace: "compound-engineering",
+      active: true,
+    },
+  ],
+  harnessFiles: ["CLAUDE.md", ".claude/settings.json"],
+  fileOpStyle: {
+    readPct: 45,
+    editPct: 40,
+    writePct: 15,
+    grepCount: 120,
+    globCount: 80,
+    style: "Surgical Editor",
+  },
+  agentDispatch: null,
+  cliTools: { git: 50, npm: 20 },
+  languages: { TypeScript: 80, Python: 20 },
+  models: { "claude-sonnet-4-20250514": 90, "claude-haiku-4-20250514": 10 },
+  permissionModes: { allowedTools: 5 },
+  mcpServers: { filesystem: 30 },
+  gitPatterns: {
+    prCount: 7,
+    commitCount: 23,
+    linesAdded: "1200",
+    branchPrefixes: { "feat/": 8, "fix/": 12 },
+  },
+  versions: ["1.0.33", "1.0.34"],
+  writeupSections: [
+    {
+      title: "Workflow Analysis",
+      contentHtml: "<p>You use Claude Code heavily for refactoring.</p>",
+    },
+    {
+      title: "Tool Preferences",
+      contentHtml: "<p>Strong preference for Edit over Write.</p>",
+    },
+  ],
+  workflowData: null,
+  integrityHash: "abc123def456",
+  skillVersion: "2.3.0",
+  enhancedStats: {
+    linesAdded: 1200,
+    linesRemoved: 300,
+    fileCount: 45,
+    dayCount: 28,
+    msgsPerDay: 12.5,
+  },
+};
+
+function buildHarnessHtml(
+  data: unknown,
+  opts?: { reverseAttrs?: boolean },
+): string {
+  const json = JSON.stringify(data).replace(/<\/script>/gi, "<\\/script>");
+  const attrs = opts?.reverseAttrs
+    ? 'type="application/json" id="harness-data"'
+    : 'id="harness-data" type="application/json"';
+  return `
 <html><body>
-  <div class="container">
-    <!-- Stats Grid -->
-    <div class="stats-grid">
-      <div class="stat">
-        <div class="stat-value">42</div>
-        <div class="stat-label">Sessions</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">1.2M</div>
-        <div class="stat-label">Tokens</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">18h</div>
-        <div class="stat-label">Duration</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">5</div>
-        <div class="stat-label">Skills Used</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">3</div>
-        <div class="stat-label">Hooks</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">7</div>
-        <div class="stat-label">PRs</div>
-      </div>
-      <div class="stat">
-        <div class="stat-value">23</div>
-        <div class="stat-label">Commits</div>
-      </div>
-    </div>
+  <script ${attrs}>${json}</script>
+  <script type="application/json" id="insight-harness-integrity">{"hash":"abc123def456"}</script>
+</body></html>`;
+}
 
-    <!-- Autonomy Box -->
-    <div class="autonomy-box">
-      <div class="autonomy-label">Fire-and-Forget</div>
-      <div class="autonomy-desc">You launch tasks and let Claude run</div>
-      <div class="autonomy-stat"><strong>150</strong> user msgs</div>
-      <div class="autonomy-stat"><strong>800</strong> assistant msgs</div>
-      <div class="autonomy-stat"><strong>950</strong> turns measured</div>
-    </div>
-
-    <!-- Feature Pills -->
-    <div class="pills">
-      <span class="pill on">Task Agents (12%)</span>
-      <span class="pill">MCP Servers</span>
-      <span class="pill on">Custom Skills (45%)</span>
-    </div>
-
-    <!-- Tool Usage -->
-    <section>
-      <div class="section-header"><h2>Tool Usage</h2></div>
-      <div class="bar-row">
-        <div class="bar-label">Read</div>
-        <div class="bar-value">1,500</div>
-      </div>
-      <div class="bar-row">
-        <div class="bar-label">Edit</div>
-        <div class="bar-value">800</div>
-      </div>
-      <div class="bar-row">
-        <div class="bar-label">Bash</div>
-        <div class="bar-value">2,200</div>
-      </div>
-    </section>
-
-    <!-- Skills Inventory -->
-    <section>
-      <div class="section-header"><h2>Skills</h2></div>
-      <table>
-        <tbody>
-          <tr>
-            <td>
-              <span class="mono accent">commit</span>
-              <span class="badge custom">custom</span>
-              <span class="meta">Auto-commit helper</span>
-            </td>
-            <td>12</td>
-          </tr>
-          <tr>
-            <td>
-              <span class="mono accent">review-pr</span>
-              <span class="badge plugin">plugin</span>
-              <span class="meta">PR reviewer</span>
-            </td>
-            <td>5</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <!-- Hooks -->
-    <section>
-      <div class="section-header"><h2>Hooks</h2></div>
-      <table>
-        <tbody>
-          <tr>
-            <td>PreToolUse</td>
-            <td>Bash</td>
-            <td>validate-bash.sh</td>
-          </tr>
-          <tr>
-            <td>PostToolUse</td>
-            <td>Edit</td>
-            <td>format-on-save.sh</td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
-
-    <!-- Plugins -->
-    <div class="plugin-card">
-      <div class="plugin-name">superpowers</div>
-      <span class="badge active">active</span>
-      <div class="meta">v2.1.0 · compound-engineering</div>
-    </div>
-
-    <!-- File Operation Style -->
-    <section>
-      <div class="section-header"><h2>File Operation Style</h2></div>
-      <div class="donut-item">
-        <div class="ratio">45:40:15</div>
-        <div class="label">Read : Edit : Write</div>
-      </div>
-      <div class="donut-item">
-        <div class="ratio">120:80</div>
-        <div class="label">Grep : Glob</div>
-      </div>
-      <div class="donut-item">
-        <div class="ratio">Surgical Editor</div>
-        <div class="label">Style</div>
-      </div>
-    </section>
-
-    <!-- Git Patterns -->
-    <section>
-      <div class="section-header"><h2>Git Patterns</h2></div>
-      <div class="meta">7 PRs · 23 commits · 1.2K lines added</div>
-      <div class="tags">
-        <span class="tag">feat/ (8)</span>
-        <span class="tag">fix/ (12)</span>
-      </div>
-    </section>
-
-    <!-- Writeup Sections (inside tab-writeup) -->
-    <div id="tab-writeup">
-      <div class="writeup-section">
-        <h2>Workflow Analysis</h2>
-        <p>You use Claude Code heavily for refactoring.</p>
-      </div>
-      <div class="writeup-section">
-        <h2>Tool Preferences</h2>
-        <p>Strong preference for Edit over Write.</p>
-      </div>
-    </div>
-
-    <!-- Integrity Hash -->
-    <script type="application/json" id="insight-harness-integrity">
-      {"hash": "abc123def456"}
-    </script>
-
-    <!-- Versions -->
-    <section>
-      <div class="section-header"><h2>Claude Code Versions</h2></div>
-      <div class="tags">
-        <span class="tag">1.0.33</span>
-        <span class="tag">1.0.34</span>
-      </div>
-    </section>
-  </div>
-</body></html>
-`;
+const MINIMAL_HARNESS_HTML = buildHarnessHtml(MINIMAL_HARNESS_DATA);
 
 // ---------------------------------------------------------------------------
 // isHarnessReport
@@ -202,93 +141,47 @@ describe("isHarnessReport", () => {
 });
 
 // ---------------------------------------------------------------------------
-// parseHarnessHtml — stats
+// parseHarnessHtml — happy path
 // ---------------------------------------------------------------------------
 
 describe("parseHarnessHtml", () => {
-  it("parses without throwing", () => {
+  it("parses valid JSON into HarnessData without throwing", () => {
     expect(() => parseHarnessHtml(MINIMAL_HARNESS_HTML)).not.toThrow();
   });
 
   describe("stats", () => {
-    it("extracts sessionCount", () => {
+    it("extracts all stat fields with correct types", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
-      expect(result.stats.sessionCount).toBe(42);
-    });
-
-    it("extracts totalTokens with M suffix", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
-      expect(result.stats.totalTokens).toBe(1_200_000);
-    });
-
-    it("extracts durationHours", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.stats.totalTokens).toBe(1200000);
+      expect(result.stats.lifetimeTokens).toBe(9500000);
       expect(result.stats.durationHours).toBe(18);
-    });
-
-    it("extracts skillsUsedCount", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.stats.avgSessionMinutes).toBe(25.5);
       expect(result.stats.skillsUsedCount).toBe(5);
-    });
-
-    it("extracts hooksCount", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.stats.hooksCount).toBe(3);
-    });
-
-    it("extracts prCount", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.stats.prCount).toBe(7);
-    });
-
-    it("extracts commitCount", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.stats.sessionCount).toBe(42);
       expect(result.stats.commitCount).toBe(23);
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Autonomy
-  // ---------------------------------------------------------------------------
-
   describe("autonomy", () => {
-    it("extracts autonomy label", () => {
+    it("extracts autonomy fields", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.label).toBe("Fire-and-Forget");
-    });
-
-    it("extracts autonomy description", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.description).toBe(
         "You launch tasks and let Claude run",
       );
-    });
-
-    it("extracts user message count", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.userMessages).toBe(150);
-    });
-
-    it("extracts assistant message count", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.assistantMessages).toBe(800);
-    });
-
-    it("extracts turn count", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.turnCount).toBe(950);
+      expect(result.autonomy.errorRate).toBe("2%");
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Feature Pills
-  // ---------------------------------------------------------------------------
-
   describe("feature pills", () => {
-    it("extracts pill names and active state", () => {
+    it("extracts pill names, active state, and values", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.featurePills).toHaveLength(3);
-
       expect(result.featurePills[0]).toEqual({
         name: "Task Agents",
         active: true,
@@ -307,30 +200,17 @@ describe("parseHarnessHtml", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Tool Usage
-  // ---------------------------------------------------------------------------
-
   describe("tool usage", () => {
     it("extracts tool usage as record", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
-      expect(result.toolUsage).toEqual({
-        Read: 1500,
-        Edit: 800,
-        Bash: 2200,
-      });
+      expect(result.toolUsage).toEqual({ Read: 1500, Edit: 800, Bash: 2200 });
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Skill Inventory
-  // ---------------------------------------------------------------------------
-
   describe("skill inventory", () => {
-    it("extracts skill entries with source badges", () => {
+    it("extracts skill entries", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.skillInventory).toHaveLength(2);
-
       expect(result.skillInventory[0]).toEqual({
         name: "commit",
         calls: 12,
@@ -346,85 +226,48 @@ describe("parseHarnessHtml", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Hook Definitions
-  // ---------------------------------------------------------------------------
-
   describe("hook definitions", () => {
-    it("extracts hook event, matcher, and script", () => {
+    it("extracts hook definitions", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.hookDefinitions).toHaveLength(2);
-
       expect(result.hookDefinitions[0]).toEqual({
         event: "PreToolUse",
         matcher: "Bash",
         script: "validate-bash.sh",
       });
-      expect(result.hookDefinitions[1]).toEqual({
-        event: "PostToolUse",
-        matcher: "Edit",
-        script: "format-on-save.sh",
+    });
+  });
+
+  describe("plugins", () => {
+    it("extracts plugin info", () => {
+      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.plugins).toHaveLength(1);
+      expect(result.plugins[0]).toEqual({
+        name: "superpowers",
+        version: "2.1.0",
+        marketplace: "compound-engineering",
+        active: true,
       });
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Plugins
-  // ---------------------------------------------------------------------------
-
-  describe("plugins", () => {
-    it("extracts plugin name, version, and active state", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
-      expect(result.plugins).toHaveLength(1);
-      expect(result.plugins[0].name).toBe("superpowers");
-      expect(result.plugins[0].active).toBe(true);
-      expect(result.plugins[0].version).toBe("2.1.0");
-      expect(result.plugins[0].marketplace).toBe("compound-engineering");
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  // File Operation Style
-  // ---------------------------------------------------------------------------
-
   describe("file operation style", () => {
-    it("extracts read/edit/write percentages", () => {
+    it("extracts file op style", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.fileOpStyle.readPct).toBe(45);
       expect(result.fileOpStyle.editPct).toBe(40);
       expect(result.fileOpStyle.writePct).toBe(15);
-    });
-
-    it("extracts grep/glob counts", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.fileOpStyle.grepCount).toBe(120);
       expect(result.fileOpStyle.globCount).toBe(80);
-    });
-
-    it("extracts style label", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.fileOpStyle.style).toBe("Surgical Editor");
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Git Patterns
-  // ---------------------------------------------------------------------------
-
   describe("git patterns", () => {
-    it("extracts PR and commit counts from meta", () => {
+    it("extracts git patterns", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.gitPatterns.prCount).toBe(7);
       expect(result.gitPatterns.commitCount).toBe(23);
-    });
-
-    it("extracts lines added", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
-      expect(result.gitPatterns.linesAdded).toBe("1.2K");
-    });
-
-    it("extracts branch prefixes", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.gitPatterns.branchPrefixes).toEqual({
         "feat/": 8,
         "fix/": 12,
@@ -432,12 +275,8 @@ describe("parseHarnessHtml", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Writeup Sections
-  // ---------------------------------------------------------------------------
-
   describe("writeup sections", () => {
-    it("extracts writeup section titles and content", () => {
+    it("extracts writeup sections", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.writeupSections).toHaveLength(2);
       expect(result.writeupSections[0].title).toBe("Workflow Analysis");
@@ -448,52 +287,253 @@ describe("parseHarnessHtml", () => {
     });
   });
 
-  // ---------------------------------------------------------------------------
-  // Integrity Hash
-  // ---------------------------------------------------------------------------
-
-  describe("integrity hash", () => {
-    it("extracts hash from integrity script tag", () => {
+  describe("integrity hash and versions", () => {
+    it("extracts integrity hash", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.integrityHash).toBe("abc123def456");
     });
-  });
 
-  // ---------------------------------------------------------------------------
-  // Versions
-  // ---------------------------------------------------------------------------
-
-  describe("versions", () => {
     it("extracts version tags", () => {
       const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.versions).toEqual(["1.0.33", "1.0.34"]);
     });
+
+    it("extracts skill version", () => {
+      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.skillVersion).toBe("2.3.0");
+    });
+  });
+
+  describe("enhanced stats", () => {
+    it("extracts enhancedStats when present", () => {
+      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      expect(result.enhancedStats).toEqual({
+        linesAdded: 1200,
+        linesRemoved: 300,
+        fileCount: 45,
+        dayCount: 28,
+        msgsPerDay: 12.5,
+      });
+    });
+
+    it("returns null enhancedStats when missing", () => {
+      const dataWithout = { ...MINIMAL_HARNESS_DATA };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { enhancedStats, ...rest } = dataWithout;
+      const html = buildHarnessHtml(rest);
+      const result = parseHarnessHtml(html);
+      expect(result.enhancedStats).toBeNull();
+    });
   });
 
   // ---------------------------------------------------------------------------
-  // Graceful degradation
+  // Error cases
   // ---------------------------------------------------------------------------
 
-  describe("graceful degradation", () => {
-    it("handles minimal HTML without crashing", () => {
-      const minimal = "<html><body><div class='container'></div></body></html>";
-      const result = parseHarnessHtml(minimal);
-      expect(result.stats.totalTokens).toBe(0);
-      expect(result.stats.sessionCount).toBe(0);
-      expect(result.autonomy.label).toBe("");
-      expect(result.featurePills).toEqual([]);
+  describe("error cases", () => {
+    it("throws descriptive error when harness-data tag is missing", () => {
+      const html =
+        '<html><body><script type="application/json" id="insight-harness-integrity">{"hash":"x"}</script></body></html>';
+      expect(() => parseHarnessHtml(html)).toThrow(
+        /missing the embedded data blob/,
+      );
+    });
+
+    it("throws descriptive error for malformed JSON", () => {
+      const html =
+        '<html><body><script id="harness-data" type="application/json">{not valid json}</script></body></html>';
+      expect(() => parseHarnessHtml(html)).toThrow(/malformed JSON/);
+    });
+
+    it("throws error when JSON is missing required fields", () => {
+      const html = buildHarnessHtml({ foo: "bar" });
+      expect(() => parseHarnessHtml(html)).toThrow(/missing required fields/);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Attribute order robustness
+  // ---------------------------------------------------------------------------
+
+  describe("attribute order", () => {
+    it("works with reversed attribute order (type before id)", () => {
+      const html = buildHarnessHtml(MINIMAL_HARNESS_DATA, {
+        reverseAttrs: true,
+      });
+      const result = parseHarnessHtml(html);
+      expect(result.stats.totalTokens).toBe(1200000);
+      expect(result.stats.sessionCount).toBe(42);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // XSS sanitization
+  // ---------------------------------------------------------------------------
+
+  describe("XSS sanitization", () => {
+    it("strips script tags from contentHtml", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml: "<p>Safe</p><script>alert(1)</script><p>Also safe</p>",
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("<script>");
+      expect(result.writeupSections[0].contentHtml).toContain("<p>Safe</p>");
+      expect(result.writeupSections[0].contentHtml).toContain(
+        "<p>Also safe</p>",
+      );
+    });
+
+    it("strips event handler attributes from contentHtml", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<img src="x" onerror="alert(1)"><div onclick="steal()">text</div>',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("onerror");
+      expect(result.writeupSections[0].contentHtml).not.toContain("onclick");
+      // img is not in the allowlist, so it gets stripped entirely
+      expect(result.writeupSections[0].contentHtml).not.toContain("<img");
+      expect(result.writeupSections[0].contentHtml).toContain("text");
+    });
+
+    it("strips iframe, object, and embed tags", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<p>OK</p><iframe src="evil.com"></iframe><object data="x"></object><embed src="y">',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("<iframe");
+      expect(result.writeupSections[0].contentHtml).not.toContain("<object");
+      expect(result.writeupSections[0].contentHtml).not.toContain("<embed");
+      expect(result.writeupSections[0].contentHtml).toContain("<p>OK</p>");
+    });
+
+    it("strips javascript: URLs from href", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<a href="javascript:alert(1)">click</a><a href="https://safe.com">safe</a>',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain(
+        "javascript:",
+      );
+      expect(result.writeupSections[0].contentHtml).toContain(
+        "https://safe.com",
+      );
+    });
+
+    it("strips svg and math tags", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<svg onload="alert(1)"><circle r="10"/></svg><math><maction href="javascript:alert(1)">x</maction></math><p>safe</p>',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("<svg");
+      expect(result.writeupSections[0].contentHtml).not.toContain("<math");
+      expect(result.writeupSections[0].contentHtml).toContain("<p>safe</p>");
+    });
+
+    it("strips arbitrary on* event handlers", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<div onfocus="steal()" onanimationstart="xss()" onpointerenter="hack()">text</div>',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("onfocus");
+      expect(result.writeupSections[0].contentHtml).not.toContain(
+        "onanimationstart",
+      );
+      expect(result.writeupSections[0].contentHtml).not.toContain(
+        "onpointerenter",
+      );
+      expect(result.writeupSections[0].contentHtml).toContain("text");
+    });
+
+    it("strips form and input tags", () => {
+      const data = {
+        ...MINIMAL_HARNESS_DATA,
+        writeupSections: [
+          {
+            title: "Test",
+            contentHtml:
+              '<form action="javascript:alert(1)"><input autofocus onfocus="alert(1)"></form><p>safe</p>',
+          },
+        ],
+      };
+      const html = buildHarnessHtml(data);
+      const result = parseHarnessHtml(html);
+      expect(result.writeupSections[0].contentHtml).not.toContain("<form");
+      expect(result.writeupSections[0].contentHtml).not.toContain("<input");
+      expect(result.writeupSections[0].contentHtml).toContain("<p>safe</p>");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Optional fields / normalizeHarnessData defaults
+  // ---------------------------------------------------------------------------
+
+  describe("optional fields", () => {
+    it("fills defaults for missing optional fields", () => {
+      const minimal = {
+        stats: MINIMAL_HARNESS_DATA.stats,
+        autonomy: MINIMAL_HARNESS_DATA.autonomy,
+        featurePills: MINIMAL_HARNESS_DATA.featurePills,
+      };
+      const html = buildHarnessHtml(minimal);
+      const result = parseHarnessHtml(html);
+      expect(result.toolUsage).toEqual({});
       expect(result.skillInventory).toEqual([]);
       expect(result.hookDefinitions).toEqual([]);
       expect(result.plugins).toEqual([]);
-      expect(result.writeupSections).toEqual([]);
-      expect(result.integrityHash).toBe("");
+      expect(result.harnessFiles).toEqual([]);
       expect(result.versions).toEqual([]);
-    });
-
-    it("handles empty string", () => {
-      const result = parseHarnessHtml("");
-      expect(result.stats.totalTokens).toBe(0);
-      expect(result.featurePills).toEqual([]);
+      expect(result.writeupSections).toEqual([]);
+      expect(result.workflowData).toBeNull();
+      expect(result.integrityHash).toBe("");
+      expect(result.skillVersion).toBeNull();
+      expect(result.enhancedStats).toBeNull();
     });
   });
 });

--- a/src/lib/api-cost.ts
+++ b/src/lib/api-cost.ts
@@ -122,7 +122,8 @@ const MODEL_RATES: ModelRate[] = [
   // IMPORTANT: more specific patterns must come BEFORE generic
   // /haiku/i so they win the match.
   {
-    match: /(?:claude[-_.\s]?)?3[-_.\s]?5[-_.\s]?haiku|haiku[-_.\s]?3[-_.\s]?5/i,
+    match:
+      /(?:claude[-_.\s]?)?3[-_.\s]?5[-_.\s]?haiku|haiku[-_.\s]?3[-_.\s]?5/i,
     inputUsdPerMTok: 0.8,
     outputUsdPerMTok: 4,
     label: "Claude Haiku 3.5",
@@ -197,26 +198,53 @@ export function lookupModelRate(modelName: string): ModelRate {
   return found ?? FALLBACK_RATE;
 }
 
+/** 4-way per-model token breakdown from stats-cache modelUsage. */
+interface ModelTokenBreakdown {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_create: number;
+}
+
 /**
- * Estimate the API cost in USD for a per-model token breakdown.
+ * Estimate the API cost in USD using the best available data.
  *
- * @param modelTokens
- *   A map of `{ modelName: tokenCount }`. Token counts are TOTAL tokens
- *   (input + output combined) — harness reports do not split them.
- *   May be undefined or empty.
- * @param fallbackTotalTokens
- *   When `modelTokens` is missing or empty, this is used with the
- *   fallback (Sonnet 4.6 blended) rate. Pass the totalTokens stat from
- *   the harness report.
- *
- * @returns Estimated USD cost. Always >= 0. Returns 0 when both inputs
- *   are missing or zero.
+ * Tries three paths in order of accuracy:
+ *   1. **4-way breakdown** (`perModelTokens`): exact per-type rates
+ *      (input, output, cache read at 90% discount, cache create at 25% premium)
+ *   2. **Simple model map** (`modelTokens`): input+output only, blended rate
+ *   3. **Fallback total**: single number with Sonnet 4.6 blended rate
  */
 export function estimateApiCostUsd(
   modelTokens: Record<string, number> | undefined,
   fallbackTotalTokens: number = 0,
+  perModelTokens?: Record<string, ModelTokenBreakdown> | null,
 ): number {
-  // Validate the per-model breakdown.
+  // Path 1: 4-way per-model breakdown — most accurate
+  if (perModelTokens && typeof perModelTokens === "object") {
+    const entries = Object.entries(perModelTokens).filter(
+      ([, v]) => v && typeof v === "object",
+    );
+    if (entries.length > 0) {
+      let total = 0;
+      for (const [name, breakdown] of entries) {
+        const rate = lookupModelRate(name);
+        const inp = breakdown.input ?? 0;
+        const out = breakdown.output ?? 0;
+        const cr = breakdown.cache_read ?? 0;
+        const cc = breakdown.cache_create ?? 0;
+        if (inp + out + cr + cc <= 0) continue;
+        total +=
+          (inp / 1_000_000) * rate.inputUsdPerMTok +
+          (out / 1_000_000) * rate.outputUsdPerMTok +
+          (cr / 1_000_000) * rate.inputUsdPerMTok * 0.1 + // cache reads: 90% discount
+          (cc / 1_000_000) * rate.inputUsdPerMTok * 1.25; // cache creation: 25% premium
+      }
+      if (total > 0) return total;
+    }
+  }
+
+  // Path 2: simple per-model counts (input+output combined)
   if (modelTokens && typeof modelTokens === "object") {
     const entries = Object.entries(modelTokens).filter(
       ([name, tokens]) =>
@@ -226,25 +254,10 @@ export function estimateApiCostUsd(
         tokens > 0,
     );
 
-    // Detect when the `models` map isn't really per-model token counts:
-    //
-    //   a) Percentage-encoded: values sum to ~100.
-    //   b) Dispatch-count / proportion-encoded: values are small
-    //      integers (e.g. {sonnet: 890, opus: 240, haiku: 120}) while
-    //      the real totalTokens is in the millions. Some seeded demo
-    //      reports ship this shape — see prisma/seed-demos.ts.
-    //
-    // In both cases we treat the values as PROPORTIONS and rescale to
-    // `fallbackTotalTokens`. The threshold: if the sum is less than
-    // 10% of the known total tokens, the map can't possibly be raw
-    // token counts, so treat it as proportional. This is the heuristic
-    // that prevents a $0.02 answer when the breakdown is count-shaped.
     if (entries.length > 0) {
       const sum = entries.reduce((acc, [, v]) => acc + v, 0);
       const looksLikeProportion =
-        fallbackTotalTokens > 0 &&
-        sum > 0 &&
-        sum < fallbackTotalTokens * 0.1;
+        fallbackTotalTokens > 0 && sum > 0 && sum < fallbackTotalTokens * 0.1;
 
       const scaled: Array<[string, number]> = looksLikeProportion
         ? entries.map(([name, share]) => [
@@ -262,9 +275,7 @@ export function estimateApiCostUsd(
     }
   }
 
-  // Fallback path — no usable breakdown. Use Sonnet 4.6 blended rate
-  // over the total token count. Documented as the safe default in the
-  // module-level comment.
+  // Path 3: fallback — Sonnet 4.6 blended rate over total tokens
   if (fallbackTotalTokens > 0) {
     return (fallbackTotalTokens / 1_000_000) * blendedRate(FALLBACK_RATE);
   }

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -1,19 +1,7 @@
 import * as cheerio from "cheerio";
-import type {
-  HarnessData,
-  HarnessStats,
-  HarnessAutonomy,
-  HarnessFeaturePill,
-  HarnessSkillEntry,
-  HarnessHookDef,
-  HarnessPlugin,
-  HarnessFileOpStyle,
-  HarnessAgentDispatch,
-  HarnessGitPatterns,
-  HarnessWriteupSection,
-  HarnessWorkflowData,
-  HarnessPhaseStats,
-} from "@/types/insights";
+import sanitize from "sanitize-html";
+import type { HarnessData } from "@/types/insights";
+import { normalizeHarnessData } from "@/types/insights";
 
 /**
  * Detect whether an HTML string is an insight-harness report (vs plain /insights).
@@ -25,664 +13,116 @@ export function isHarnessReport(html: string): boolean {
 
 /**
  * Parse an insight-harness HTML report into structured HarnessData.
+ * Extracts the embedded JSON blob from <script id="harness-data"> via cheerio,
+ * sanitizes writeup HTML, and validates the shape.
+ * Throws a descriptive error if the tag is missing or JSON is malformed.
  */
 export function parseHarnessHtml(html: string): HarnessData {
   const $ = cheerio.load(html);
+  const script = $("script#harness-data").first();
+  const jsonString = script.html();
 
-  return {
-    stats: parseHarnessStats($),
-    autonomy: parseAutonomy($),
-    featurePills: parseFeaturePills($),
-    toolUsage: parseBarChart($, "Tool Usage"),
-    skillInventory: parseSkillInventory($),
-    hookDefinitions: parseHookDefinitions($),
-    hookFrequency: parseBarChart($, "Hook Execution Frequency"),
-    plugins: parsePlugins($),
-    harnessFiles: parseHarnessFiles($),
-    fileOpStyle: parseFileOpStyle($),
-    agentDispatch: parseAgentDispatch($),
-    cliTools: parseBarChart($, "CLI Tools"),
-    languages: parseBarChart($, "Languages"),
-    models: parseBarChart($, "Models"),
-    permissionModes: parseKvSection($, "Permission Modes"),
-    mcpServers: parseKvSection($, "MCP Servers"),
-    gitPatterns: parseGitPatterns($),
-    versions: parseVersionTags($, "Claude Code Versions"),
-    writeupSections: parseWriteupSections($),
-    workflowData: parseWorkflowData($),
-    integrityHash: parseIntegrityHash($),
-    skillVersion: parseSkillVersion($),
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Stats Grid
-// ---------------------------------------------------------------------------
-
-function parseHarnessStats($: cheerio.CheerioAPI): HarnessStats {
-  const statValues: Record<string, string> = {};
-  $(".stats-grid .stat").each((_, el) => {
-    const label = $(el).find(".stat-label").text().trim().toLowerCase();
-    const value = $(el).find(".stat-value").text().trim();
-    statValues[label] = value;
-  });
-
-  return {
-    totalTokens: parseNumericValue(statValues["tokens"] ?? "0"),
-    lifetimeTokens: parseNumericValue(statValues["lifetime tokens"] ?? "0"),
-    durationHours:
-      parseInt(statValues["duration"]?.replace(/h$/i, "") ?? "0", 10) || 0,
-    avgSessionMinutes:
-      parseFloat(statValues["avg session"]?.replace(/m$/i, "") ?? "0") || 0,
-    skillsUsedCount: parseInt(statValues["skills used"] ?? "0", 10) || 0,
-    hooksCount: parseInt(statValues["hooks"] ?? "0", 10) || 0,
-    prCount: parseInt(statValues["prs"] ?? "0", 10) || 0,
-    sessionCount: parseInt(statValues["sessions"] ?? "0", 10) || 0,
-    commitCount: parseInt(statValues["commits"] ?? "0", 10) || 0,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Autonomy Box
-// ---------------------------------------------------------------------------
-
-function parseAutonomy($: cheerio.CheerioAPI): HarnessAutonomy {
-  const box = $(".autonomy-box");
-  const label = box.find(".autonomy-label").text().trim();
-  const desc = box.find(".autonomy-desc").text().trim();
-
-  const stats: Record<string, string> = {};
-  box.find(".autonomy-stat").each((_, el) => {
-    const text = $(el).text().trim();
-    const strong = $(el).find("strong").text().trim();
-    // "1234 user msgs" -> key="user msgs", value="1234"
-    const remainder = text.replace(strong, "").trim();
-    stats[remainder] = strong;
-  });
-
-  return {
-    label,
-    description: desc,
-    userMessages: parseInt(stats["user msgs"] ?? "0", 10) || 0,
-    assistantMessages: parseInt(stats["assistant msgs"] ?? "0", 10) || 0,
-    turnCount: parseInt(stats["turns measured"] ?? "0", 10) || 0,
-    errorRate: Object.keys(stats).find((k) => k.includes("error"))
-      ? stats[Object.keys(stats).find((k) => k.includes("error"))!]
-      : "0%",
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Feature Pills
-// ---------------------------------------------------------------------------
-
-function parseFeaturePills($: cheerio.CheerioAPI): HarnessFeaturePill[] {
-  const pills: HarnessFeaturePill[] = [];
-  $(".pills .pill").each((_, el) => {
-    const text = $(el).text().trim();
-    const active = $(el).hasClass("on");
-    // "Task Agents (12%)" -> name="Task Agents", value="12%"
-    const match = text.match(/^(.+?)\s*\((.+?)\)$/);
-    if (match) {
-      pills.push({ name: match[1].trim(), active, value: match[2].trim() });
-    } else {
-      pills.push({ name: text, active, value: "" });
-    }
-  });
-  return pills;
-}
-
-// ---------------------------------------------------------------------------
-// Bar Charts (Tool Usage, CLI Tools, Languages, Models)
-// ---------------------------------------------------------------------------
-
-function parseBarChart(
-  $: cheerio.CheerioAPI,
-  sectionTitle: string,
-): Record<string, number> {
-  const result: Record<string, number> = {};
-  const section = findSectionByTitle($, sectionTitle);
-  if (!section) return result;
-
-  section.find(".bar-row").each((_, el) => {
-    const label = $(el).find(".bar-label").text().trim();
-    const value = $(el).find(".bar-value").text().trim();
-    if (label) {
-      result[label] = parseNumericValue(value);
-    }
-  });
-
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Skills Inventory
-// ---------------------------------------------------------------------------
-
-function parseSkillInventory($: cheerio.CheerioAPI): HarnessSkillEntry[] {
-  const skills: HarnessSkillEntry[] = [];
-  const section = findSectionByTitle($, "Skills");
-  if (!section) return skills;
-
-  section.find("tbody tr").each((_, el) => {
-    const cells = $(el).find("td");
-    if (cells.length < 2) return;
-
-    const nameCell = cells.eq(0);
-    const name = nameCell.find(".mono.accent").text().trim();
-    const calls = parseInt(cells.eq(1).text().trim(), 10) || 0;
-
-    // Determine source from badge
-    let source = "unknown";
-    const badge = nameCell.find(".badge");
-    if (badge.hasClass("custom")) source = "custom";
-    else if (badge.hasClass("plugin")) source = "plugin";
-
-    const description = nameCell.find(".meta").text().trim();
-
-    if (name) {
-      skills.push({ name, calls, source, description });
-    }
-  });
-
-  return skills;
-}
-
-// ---------------------------------------------------------------------------
-// Hook Definitions
-// ---------------------------------------------------------------------------
-
-function parseHookDefinitions($: cheerio.CheerioAPI): HarnessHookDef[] {
-  const hooks: HarnessHookDef[] = [];
-  const section = findSectionByTitle($, "Hooks");
-  if (!section) return hooks;
-
-  section.find("tbody tr").each((_, el) => {
-    const cells = $(el).find("td");
-    if (cells.length < 3) return;
-    const event = cells.eq(0).text().trim();
-    const matcher = cells.eq(1).text().trim();
-    const script = cells.eq(2).text().trim();
-    if (event && !cells.eq(0).hasClass("empty")) {
-      hooks.push({ event, matcher, script });
-    }
-  });
-
-  return hooks;
-}
-
-// ---------------------------------------------------------------------------
-// Plugins
-// ---------------------------------------------------------------------------
-
-function parsePlugins($: cheerio.CheerioAPI): HarnessPlugin[] {
-  const plugins: HarnessPlugin[] = [];
-  $(".plugin-card").each((_, el) => {
-    const name = $(el).find(".plugin-name").text().trim();
-    const badge = $(el).find(".badge");
-    const active = badge.hasClass("active");
-    const meta = $(el).find(".meta").text().trim();
-    // "v1.0.3 · compound-engineering"
-    const versionMatch = meta.match(/^v([\d.]+)/);
-    const version = versionMatch ? versionMatch[1] : "";
-    const marketplace = meta.replace(/^v[\d.]+\s*·\s*/, "").trim();
-
-    if (name) {
-      plugins.push({ name, version, marketplace, active });
-    }
-  });
-  return plugins;
-}
-
-// ---------------------------------------------------------------------------
-// Harness Files
-// ---------------------------------------------------------------------------
-
-function parseHarnessFiles($: cheerio.CheerioAPI): string[] {
-  const files: string[] = [];
-  const section = findSectionByTitle($, "Harness File Ecosystem");
-  if (!section) return files;
-
-  section.find(".file-item").each((_, el) => {
-    const text = $(el).text().trim();
-    if (text) files.push(text);
-  });
-  return files;
-}
-
-// ---------------------------------------------------------------------------
-// File Operation Style
-// ---------------------------------------------------------------------------
-
-function parseFileOpStyle($: cheerio.CheerioAPI): HarnessFileOpStyle {
-  const section = findSectionByTitle($, "File Operation Style");
-  if (!section) {
-    return {
-      readPct: 0,
-      editPct: 0,
-      writePct: 0,
-      grepCount: 0,
-      globCount: 0,
-      style: "",
-    };
+  if (!jsonString) {
+    throw new Error(
+      'Harness report is missing the embedded data blob. Expected a <script id="harness-data" type="application/json"> tag containing the report data as JSON.',
+    );
   }
 
-  const donutItems = section.find(".donut-item");
-  let readPct = 0,
-    editPct = 0,
-    writePct = 0,
-    grepCount = 0,
-    globCount = 0;
-  let style = "";
-
-  donutItems.each((i, el) => {
-    const ratio = $(el).find(".ratio").text().trim();
-    const label = $(el).find(".label").text().trim().toLowerCase();
-
-    if (
-      label.includes("read") &&
-      label.includes("edit") &&
-      label.includes("write")
-    ) {
-      // "45:40:15" -> read:edit:write
-      const parts = ratio.split(":").map((s) => parseInt(s.trim(), 10) || 0);
-      readPct = parts[0] ?? 0;
-      editPct = parts[1] ?? 0;
-      writePct = parts[2] ?? 0;
-    } else if (label.includes("grep") && label.includes("glob")) {
-      const parts = ratio.split(":").map((s) => parseInt(s.trim(), 10) || 0);
-      grepCount = parts[0] ?? 0;
-      globCount = parts[1] ?? 0;
-    } else {
-      // Style label like "Surgical Editor"
-      style = ratio;
-    }
-  });
-
-  return { readPct, editPct, writePct, grepCount, globCount, style };
-}
-
-// ---------------------------------------------------------------------------
-// Agent Dispatch
-// ---------------------------------------------------------------------------
-
-function parseAgentDispatch(
-  $: cheerio.CheerioAPI,
-): HarnessAgentDispatch | null {
-  const section = findSectionByTitle($, "Agent Dispatch");
-  if (!section) return null;
-
-  const countText = section.find(".section-header .count").text().trim();
-  const countMatch = countText.match(/(\d+)/);
-  const totalAgents = countMatch ? parseInt(countMatch[1], 10) : 0;
-
-  const types: Record<string, number> = {};
-  const models: Record<string, number> = {};
-  let backgroundPct = 0;
-  const customAgents: string[] = [];
-
-  // Parse the two-col layout
-  const columns = section.find(".two-col > div");
-  columns.each((_, col) => {
-    const heading = $(col).find("h3").text().trim().toLowerCase();
-    if (heading.includes("agent types")) {
-      $(col)
-        .find(".kv-row")
-        .each((__, row) => {
-          const key = $(row).find(".mono").text().trim();
-          const val = $(row).find(".meta").text().trim();
-          if (key) types[key] = parseInt(val, 10) || 0;
-        });
-    } else if (heading.includes("model tiering")) {
-      $(col)
-        .find(".kv-row")
-        .each((__, row) => {
-          const key = $(row).find(".mono").text().trim();
-          const val = $(row).find(".meta").text().trim();
-          if (key) models[key] = parseInt(val, 10) || 0;
-        });
-      const bgMeta = $(col).find(".meta").last().text();
-      const bgMatch = bgMeta.match(/(\d+)%/);
-      if (bgMatch) backgroundPct = parseInt(bgMatch[1], 10);
-    }
-  });
-
-  // Custom agents
-  const customSection = section
-    .find("h3")
-    .filter((_, el) => $(el).text().toLowerCase().includes("custom agent"));
-  if (customSection.length) {
-    customSection
-      .next(".tags")
-      .find(".tag")
-      .each((_, el) => {
-        customAgents.push($(el).text().trim());
-      });
-  }
-
-  return { totalAgents, types, models, backgroundPct, customAgents };
-}
-
-// ---------------------------------------------------------------------------
-// Key-Value Sections (Permission Modes, MCP Servers)
-// ---------------------------------------------------------------------------
-
-function parseKvSection(
-  $: cheerio.CheerioAPI,
-  sectionTitle: string,
-): Record<string, number> {
-  const result: Record<string, number> = {};
-  const section = findSectionByTitle($, sectionTitle);
-  if (!section) return result;
-
-  section.find(".kv-row").each((_, el) => {
-    const key = $(el).find(".mono").text().trim();
-    const valText = $(el).find(".meta").text().trim();
-    const numMatch = valText.match(/([\d,.]+)/);
-    if (key && numMatch) {
-      result[key] = parseNumericValue(numMatch[1]);
-    }
-  });
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Git Patterns
-// ---------------------------------------------------------------------------
-
-function parseGitPatterns($: cheerio.CheerioAPI): HarnessGitPatterns {
-  const section = findSectionByTitle($, "Git Patterns");
-  const branchPrefixes: Record<string, number> = {};
-
-  if (!section) {
-    return { prCount: 0, commitCount: 0, linesAdded: "0", branchPrefixes };
-  }
-
-  // Parse summary meta: "12 PRs · 45 commits · 1.2K lines added"
-  const meta = section.find(".meta").first().text();
-  const prMatch = meta.match(/([\d,]+)\s*PRs/);
-  const commitMatch = meta.match(/([\d,]+)\s*commits/);
-  const linesMatch = meta.match(/([\d,.]+[KM]?)\s*lines added/);
-
-  // Branch convention tags: "feat/ (12)"
-  section.find(".tags .tag").each((_, el) => {
-    const text = $(el).text().trim();
-    const match = text.match(/^(.+?)\s*\((\d+)\)$/);
-    if (match) {
-      branchPrefixes[match[1].trim()] = parseInt(match[2], 10);
-    }
-  });
-
-  return {
-    prCount: prMatch ? parseNumericValue(prMatch[1]) : 0,
-    commitCount: commitMatch ? parseNumericValue(commitMatch[1]) : 0,
-    linesAdded: linesMatch ? linesMatch[1] : "0",
-    branchPrefixes,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Version Tags
-// ---------------------------------------------------------------------------
-
-function parseVersionTags(
-  $: cheerio.CheerioAPI,
-  sectionTitle: string,
-): string[] {
-  const versions: string[] = [];
-  const section = findSectionByTitle($, sectionTitle);
-  if (!section) return versions;
-
-  section.find(".tags .tag").each((_, el) => {
-    versions.push($(el).text().trim());
-  });
-  return versions;
-}
-
-// ---------------------------------------------------------------------------
-// Writeup Sections
-// ---------------------------------------------------------------------------
-
-function parseWriteupSections($: cheerio.CheerioAPI): HarnessWriteupSection[] {
-  const sections: HarnessWriteupSection[] = [];
-  const writeupTab = $("#tab-writeup");
-  if (!writeupTab.length) return sections;
-
-  writeupTab.find(".writeup-section").each((_, el) => {
-    const title = $(el).find("h2").first().text().trim();
-    // Get inner HTML minus the h2
-    const clone = $(el).clone();
-    clone.find("h2").first().remove();
-    // Sanitize: strip script tags, event handlers, and iframes
-    clone.find("script, iframe, object, embed").remove();
-    clone
-      .find("[onclick], [onerror], [onload], [onmouseover]")
-      .each((_, node) => {
-        const $node = $(node);
-        $node.removeAttr("onclick");
-        $node.removeAttr("onerror");
-        $node.removeAttr("onload");
-        $node.removeAttr("onmouseover");
-      });
-    const contentHtml = clone.html()?.trim() ?? "";
-    if (title) {
-      sections.push({ title, contentHtml });
-    }
-  });
-
-  return sections;
-}
-
-// ---------------------------------------------------------------------------
-// Integrity Hash
-// ---------------------------------------------------------------------------
-
-function parseIntegrityHash($: cheerio.CheerioAPI): string {
-  const script = $("#insight-harness-integrity").html();
-  if (!script) return "";
+  let parsed: unknown;
   try {
-    const data = JSON.parse(script);
-    return data.hash ?? "";
-  } catch {
-    return "";
-  }
-}
-
-function parseSkillVersion($: cheerio.CheerioAPI): string | null {
-  const script = $("#insight-harness-integrity").html();
-  if (!script) return null;
-  try {
-    const data = JSON.parse(script);
-    const payload = JSON.parse(data.payload ?? "{}");
-    return payload.skill_version ?? null;
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Workflow Data (Phases & Tool Transitions)
-// ---------------------------------------------------------------------------
-
-function parseWorkflowData($: cheerio.CheerioAPI): HarnessWorkflowData | null {
-  const phaseSection = findSectionByTitle($, "Workflow Phases");
-  const skillSection = findSectionByTitle($, "Skill Workflow");
-
-  if (!phaseSection && !skillSection) return null;
-
-  // Parse skill invocations from bar-rows in Skill Workflow section
-  const skillInvocations: Record<string, number> = {};
-  const agentDispatches: Record<string, number> = {};
-  const workflowPatterns: Array<{ sequence: string[]; count: number }> = [];
-
-  if (skillSection) {
-    // The section has three groups separated by .footnote labels:
-    // 1. Skill invocations (bar-rows after "Skill invocations" footnote)
-    // 2. Agent dispatches (bar-rows after "Agent dispatches" footnote)
-    // 3. Workflow patterns (bar-rows after "Common workflow patterns" footnote)
-    let currentGroup = "skills";
-    skillSection.children().each((_, el) => {
-      const $el = $(el);
-      if ($el.hasClass("footnote")) {
-        const text = $el.text().trim().toLowerCase();
-        if (text.includes("agent dispatch")) {
-          currentGroup = "agents";
-        } else if (text.includes("workflow pattern")) {
-          currentGroup = "patterns";
-        } else if (text.includes("skill invocation")) {
-          currentGroup = "skills";
-        }
-        return;
-      }
-      if ($el.hasClass("bar-row")) {
-        const label = $el.find(".bar-label").text().trim();
-        const value = $el.find(".bar-value").text().trim();
-        if (!label) return;
-        if (currentGroup === "skills") {
-          skillInvocations[label] = parseNumericValue(value);
-        } else if (currentGroup === "agents") {
-          agentDispatches[label] = parseNumericValue(value);
-        } else if (currentGroup === "patterns") {
-          // Pattern labels use " → " as separator
-          const parts = label.split(/\s*→\s*/);
-          workflowPatterns.push({
-            sequence: parts,
-            count: parseNumericValue(value),
-          });
-        }
-      }
-    });
+    parsed = JSON.parse(jsonString);
+  } catch (e) {
+    throw new Error(
+      `Harness report contains malformed JSON in the harness-data script tag: ${e instanceof Error ? e.message : String(e)}`,
+    );
   }
 
-  // Parse phase distribution from kv-rows
-  const phaseDistribution: Record<string, number> = {};
-  if (phaseSection) {
-    phaseSection.find(".kv-row").each((_, el) => {
-      const key = $(el).find(".mono").text().trim();
-      const valText = $(el).find(".meta").text().trim();
-      const numMatch = valText.match(/(\d+)/);
-      if (key && numMatch) {
-        phaseDistribution[key] = parseInt(numMatch[1], 10);
-      }
-    });
-  }
-
-  // Parse phase transitions from bar chart rows
-  const phaseTransitions: Record<string, number> = {};
-  if (phaseSection) {
-    // Phase transitions are in the second column of the two-col layout
-    const columns = phaseSection.find(".two-col > div");
-    if (columns.length >= 2) {
-      $(columns[1])
-        .find(".bar-row")
-        .each((_, el) => {
-          const label = $(el).find(".bar-label").text().trim();
-          const value = $(el).find(".bar-value").text().trim();
-          if (label) {
-            phaseTransitions[label] = parseNumericValue(value);
-          }
-        });
-    }
-  }
-
-  // Parse phase stats from meta elements
-  const phaseStats: HarnessPhaseStats = {
-    testBeforeShipPct: 0,
-    exploreBeforeImplPct: 0,
-    totalSessionsWithPhases: 0,
-  };
-
-  if (phaseSection) {
-    phaseSection.find(".meta").each((_, el) => {
-      const text = $(el).text().trim();
-      const strongVal = $(el).find("strong").text().trim();
-      if (text.includes("explore before")) {
-        phaseStats.exploreBeforeImplPct = parseInt(strongVal, 10) || 0;
-      } else if (text.includes("test before")) {
-        phaseStats.testBeforeShipPct = parseInt(strongVal, 10) || 0;
-      }
-    });
-
-    // Total sessions from section header count
-    const countText = phaseSection.find(".section-header .count").text().trim();
-    const countMatch = countText.match(/(\d+)/);
-    if (countMatch) {
-      phaseStats.totalSessionsWithPhases = parseInt(countMatch[1], 10);
-    }
-  }
-
-  return {
-    skillInvocations,
-    agentDispatches,
-    workflowPatterns,
-    phaseTransitions,
-    phaseDistribution,
-    phaseStats,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Find a <section> element by looking for a matching h2 text in .section-header.
- * Falls back to searching all section > h2 elements.
- */
-function findSectionByTitle(
-  $: cheerio.CheerioAPI,
-  title: string,
-): ReturnType<cheerio.CheerioAPI> | null {
-  const lowerTitle = title.toLowerCase();
-
-  // Try section-header h2 first
-  let found: ReturnType<cheerio.CheerioAPI> | null = null;
-  $("section").each((_, el) => {
-    const h2 = $(el).find(".section-header h2").text().trim().toLowerCase();
-    if (h2.includes(lowerTitle)) {
-      found = $(el);
-      return false; // break
-    }
-  });
-  if (found) return found;
-
-  // Fallback: any h2 containing the title, return its parent section
-  $("h2").each((_, el) => {
-    if ($(el).text().trim().toLowerCase().includes(lowerTitle)) {
-      const parent = $(el).closest("section");
-      if (parent.length) {
-        found = parent;
-        return false;
+  // Sanitize writeup contentHtml before validation
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    Array.isArray((parsed as Record<string, unknown>).writeupSections)
+  ) {
+    const sections = (parsed as Record<string, unknown>)
+      .writeupSections as Array<{ title: string; contentHtml: string }>;
+    for (const section of sections) {
+      if (section.contentHtml) {
+        section.contentHtml = sanitizeWriteupHtml(section.contentHtml);
       }
     }
-  });
+  }
 
-  return found;
+  const data = normalizeHarnessData(parsed);
+  if (!data) {
+    throw new Error(
+      "Harness report JSON is missing required fields (stats, autonomy, featurePills). The embedded data does not match the expected HarnessData shape.",
+    );
+  }
+
+  return data;
 }
 
 /**
- * Parse a numeric value that may have K/M suffixes or commas.
+ * Allowlist-based HTML sanitizer for writeup contentHtml.
+ * Only permits safe formatting tags. Strips all event handlers, javascript: URLs,
+ * and dangerous tags (script, iframe, object, embed, svg, math, form, input, etc.).
  */
-function parseNumericValue(s: string): number {
-  if (!s) return 0;
-  s = s.replace(/,/g, "").trim();
-
-  const tokenMatch = s.match(
-    /(\d+(?:\.\d+)?)\s*([BKMG])?\s*(?:tokens?|tok)\b/i,
-  );
-  if (tokenMatch) {
-    const value = parseFloat(tokenMatch[1]);
-    const suffix = tokenMatch[2]?.toUpperCase();
-    if (suffix === "B") return Math.round(value * 1_000_000_000);
-    if (suffix === "G") return Math.round(value * 1_000_000_000);
-    if (suffix === "M") return Math.round(value * 1_000_000);
-    if (suffix === "K") return Math.round(value * 1_000);
-    return Math.round(value) || 0;
-  }
-
-  const upper = s.toUpperCase();
-  if (upper.endsWith("B")) return Math.round(parseFloat(s) * 1_000_000_000);
-  if (upper.endsWith("M")) return Math.round(parseFloat(s) * 1_000_000);
-  if (upper.endsWith("K")) return Math.round(parseFloat(s) * 1_000);
-  return Math.round(parseFloat(s)) || 0;
+function sanitizeWriteupHtml(html: string): string {
+  return sanitize(html, {
+    allowedTags: [
+      // Block
+      "p",
+      "div",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "blockquote",
+      "pre",
+      "code",
+      "hr",
+      "br",
+      // Lists
+      "ul",
+      "ol",
+      "li",
+      // Inline
+      "a",
+      "strong",
+      "em",
+      "b",
+      "i",
+      "u",
+      "s",
+      "span",
+      "sub",
+      "sup",
+      "mark",
+      // Tables
+      "table",
+      "thead",
+      "tbody",
+      "tr",
+      "th",
+      "td",
+      // Definition lists
+      "dl",
+      "dt",
+      "dd",
+    ],
+    allowedAttributes: {
+      a: ["href", "title", "target", "rel"],
+      span: ["class"],
+      div: ["class"],
+      pre: ["class"],
+      code: ["class"],
+      td: ["colspan", "rowspan"],
+      th: ["colspan", "rowspan"],
+    },
+    allowedSchemes: ["http", "https", "mailto"],
+    // Strip all on* event handlers
+    exclusiveFilter: undefined,
+  });
 }

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -207,6 +207,14 @@ export interface HarnessWorkflowData {
   phaseStats: HarnessPhaseStats;
 }
 
+export interface HarnessEnhancedStats {
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  fileCount: number | null;
+  dayCount: number | null;
+  msgsPerDay: number | null;
+}
+
 export interface HarnessData {
   stats: HarnessStats;
   autonomy: HarnessAutonomy;
@@ -230,6 +238,7 @@ export interface HarnessData {
   workflowData: HarnessWorkflowData | null;
   integrityHash: string;
   skillVersion: string | null;
+  enhancedStats?: HarnessEnhancedStats | null;
 }
 
 // v2: Chart data parsed from HTML report
@@ -430,5 +439,6 @@ export function normalizeHarnessData(raw: unknown): HarnessData | null {
     workflowData: (obj.workflowData as HarnessData["workflowData"]) ?? null,
     integrityHash: (obj.integrityHash as string) ?? "",
     skillVersion: (obj.skillVersion as string) ?? null,
+    enhancedStats: (obj.enhancedStats as HarnessData["enhancedStats"]) ?? null,
   };
 }

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -207,6 +207,13 @@ export interface HarnessWorkflowData {
   phaseStats: HarnessPhaseStats;
 }
 
+export interface HarnessModelTokenBreakdown {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_create: number;
+}
+
 export interface HarnessEnhancedStats {
   linesAdded: number | null;
   linesRemoved: number | null;
@@ -239,6 +246,7 @@ export interface HarnessData {
   integrityHash: string;
   skillVersion: string | null;
   enhancedStats?: HarnessEnhancedStats | null;
+  perModelTokens?: Record<string, HarnessModelTokenBreakdown> | null;
 }
 
 // v2: Chart data parsed from HTML report
@@ -440,5 +448,7 @@ export function normalizeHarnessData(raw: unknown): HarnessData | null {
     integrityHash: (obj.integrityHash as string) ?? "",
     skillVersion: (obj.skillVersion as string) ?? null,
     enhancedStats: (obj.enhancedStats as HarnessData["enhancedStats"]) ?? null,
+    perModelTokens:
+      (obj.perModelTokens as HarnessData["perModelTokens"]) ?? null,
   };
 }


### PR DESCRIPTION
## Summary

- Replace 21 cheerio HTML-scraping parse functions (689 lines) with a single JSON extraction path (~130 lines)
- extract.py v2.3.0 embeds a complete `HarnessData` JSON blob in `<script id="harness-data">` — parser reads it directly, eliminating the lossy HTML→cheerio→data round-trip that caused token count bugs (#42, #43, #52, #53)
- Writeup `contentHtml` sanitized via `sanitize-html` allowlist (blocks `javascript:` URLs, svg/math, all `on*` handlers, form/input)
- Upload route sources enhanced stats from JSON blob, not HTML scraping; prefers JSON stats via `??` over `||`
- Adds `HarnessEnhancedStats` type for `linesAdded`/`linesRemoved`/`fileCount`/`dayCount`/`msgsPerDay`

## Test plan

- [x] 350 tests pass (39 parser tests with JSON fixtures, 5 XSS regression tests)
- [x] TypeScript compiles clean
- [x] Real report generated with extract.py v2.3.0 — JSON blob present, 23 keys, 19KB, all numbers raw
- [x] Parser extracts real report correctly — all field types verified
- [x] Upload route simulation — enhanced stats from JSON, scalar fields carry raw numbers
- [x] Codex CLI (gpt-5.4) reviewed: 2 high issues fixed (sanitizer + regex), 2 medium fixed (stats preference + test gaps)
- [ ] Manual: run /insight-harness, upload to site, verify profile page renders correctly