### PR TITLE
feat(pricing): overlay LiteLLM snapshot onto api-cost rates

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "db:seed": "npx tsx prisma/seed.ts",
     "db:reset": "npx prisma migrate reset --force",
-    "db:studio": "npx prisma studio"
+    "db:studio": "npx prisma studio",
+    "pricing:update": "tsx scripts/update-pricing.ts"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.11.1",

--- a/scripts/update-pricing.ts
+++ b/scripts/update-pricing.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+/**
+ * Refresh the Anthropic pricing snapshot used by src/lib/api-cost.ts.
+ *
+ * Source: LiteLLM's community-maintained price table
+ *   https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
+ *
+ * Run: `pnpm pricing:update` (or `npx tsx scripts/update-pricing.ts`).
+ * Commit the resulting src/lib/pricing-snapshot.json.
+ *
+ * The snapshot is keyed by the label strings used in api-cost.ts's
+ * MODEL_RATES table, so the loader can overlay numeric rates onto the
+ * existing regex-based lookup without changing any matching logic.
+ */
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const LITELLM_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
+// Maps our ModelRate.label → the LiteLLM model IDs to pull rates from.
+// First ID that exists in the upstream table wins. Keep in sync with
+// src/lib/api-cost.ts MODEL_RATES.
+const LABEL_TO_LITELLM_IDS: Record<string, string[]> = {
+  "Claude Opus 4.6": ["claude-opus-4-6"],
+  "Claude Opus 4.5": ["claude-opus-4-5", "claude-opus-4-5-20251101"],
+  "Claude Sonnet 4.6": ["claude-sonnet-4-6"],
+  "Claude Sonnet 4.5": ["claude-sonnet-4-5", "claude-sonnet-4-5-20250929"],
+  "Claude Haiku 4.5": ["claude-haiku-4-5", "claude-haiku-4-5-20251001"],
+  "Claude Opus 4.1": ["claude-opus-4-1"],
+  "Claude Opus 4": ["claude-opus-4", "claude-opus-4-20250514"],
+  "Claude Sonnet 4": ["claude-sonnet-4", "claude-sonnet-4-20250514"],
+  "Claude Sonnet 3.7": [
+    "claude-3-7-sonnet-latest",
+    "claude-3-7-sonnet-20250219",
+  ],
+  "Claude Sonnet 3.5": [
+    "claude-3-5-sonnet-latest",
+    "claude-3-5-sonnet-20241022",
+  ],
+  "Claude Haiku 3.5": ["claude-3-5-haiku-latest", "claude-3-5-haiku-20241022"],
+  "Claude Haiku 3": ["claude-3-haiku-20240307"],
+  "Claude Opus 3": ["claude-3-opus-latest", "claude-3-opus-20240229"],
+};
+
+interface LiteLLMEntry {
+  input_cost_per_token?: number;
+  output_cost_per_token?: number;
+  litellm_provider?: string;
+}
+
+async function main() {
+  const res = await fetch(LITELLM_URL);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch LiteLLM pricing: ${res.status} ${res.statusText}`,
+    );
+  }
+  const table = (await res.json()) as Record<string, LiteLLMEntry>;
+
+  const rates: Record<
+    string,
+    { inputUsdPerMTok: number; outputUsdPerMTok: number; source: string }
+  > = {};
+  const missing: string[] = [];
+
+  for (const [label, candidates] of Object.entries(LABEL_TO_LITELLM_IDS)) {
+    // Require BOTH input and output costs to be finite, positive numbers.
+    // A partial upstream entry (schema change, typo) would otherwise emit
+    // a 0-output override that silently undercounts real cost.
+    const match = candidates.find((id) => {
+      const entry = table[id];
+      return (
+        entry &&
+        Number.isFinite(entry.input_cost_per_token) &&
+        Number.isFinite(entry.output_cost_per_token) &&
+        (entry.input_cost_per_token ?? 0) > 0 &&
+        (entry.output_cost_per_token ?? 0) > 0
+      );
+    });
+    if (!match) {
+      missing.push(label);
+      continue;
+    }
+    const entry = table[match];
+    // LiteLLM stores USD per single token; we store USD per million.
+    rates[label] = {
+      inputUsdPerMTok: (entry.input_cost_per_token as number) * 1_000_000,
+      outputUsdPerMTok: (entry.output_cost_per_token as number) * 1_000_000,
+      source: match,
+    };
+  }
+
+  const snapshot = {
+    pricingAsOf: new Date().toISOString().slice(0, 10),
+    source: LITELLM_URL,
+    rates,
+  };
+
+  const outPath = resolve(
+    __dirname,
+    "..",
+    "src",
+    "lib",
+    "pricing-snapshot.json",
+  );
+  writeFileSync(outPath, JSON.stringify(snapshot, null, 2) + "\n");
+
+  console.log(`Wrote ${outPath}`);
+  console.log(`pricingAsOf: ${snapshot.pricingAsOf}`);
+  console.log(`Models captured: ${Object.keys(rates).length}`);
+  if (missing.length) {
+    console.warn(
+      `Missing from LiteLLM (kept hardcoded fallback): ${missing.join(", ")}`,
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/__tests__/api-cost.test.ts
+++ b/src/lib/__tests__/api-cost.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   estimateApiCostUsd,
+  getPricingAsOf,
   lookupModelRate,
   __testing__,
 } from "../api-cost";
@@ -247,5 +248,11 @@ describe("estimateApiCostUsd", () => {
     // Sonnet 4.6: 6.6
     expect(haikuCost).toBeCloseTo(2.2, 5);
     expect(haikuCost).toBeLessThan(sonnetCost);
+  });
+});
+
+describe("getPricingAsOf", () => {
+  it("returns an ISO date (YYYY-MM-DD) from the pricing snapshot", () => {
+    expect(getPricingAsOf()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 });

--- a/src/lib/api-cost.ts
+++ b/src/lib/api-cost.ts
@@ -20,9 +20,37 @@
  * estimate, not a billable invoice.
  */
 
+import pricingSnapshot from "./pricing-snapshot.json";
+
 /** Fraction of tokens assumed to be input vs output for the blended rate. */
 const INPUT_RATIO = 0.7;
 const OUTPUT_RATIO = 1 - INPUT_RATIO; // 0.3
+
+/**
+ * Snapshot of Anthropic pricing pulled from LiteLLM's community price
+ * table. Regenerate with `pnpm pricing:update` — see
+ * scripts/update-pricing.ts. Numeric rates below are overlaid onto the
+ * hardcoded MODEL_RATES at module load, keyed by the `label` field.
+ *
+ * The hardcoded table stays the fallback: it carries the regex patterns
+ * and covers older models (Sonnet 3.5, Haiku 3.5) that LiteLLM no longer
+ * lists as Anthropic-native.
+ */
+interface PricingSnapshot {
+  pricingAsOf: string;
+  source: string;
+  rates: Record<
+    string,
+    { inputUsdPerMTok: number; outputUsdPerMTok: number; source?: string }
+  >;
+}
+
+const SNAPSHOT = pricingSnapshot as PricingSnapshot;
+
+/** Date the in-tree pricing snapshot was last refreshed (YYYY-MM-DD). */
+export function getPricingAsOf(): string {
+  return SNAPSHOT.pricingAsOf;
+}
 
 /** Rate per 1M tokens, in USD, split by input and output. */
 interface ModelRate {
@@ -51,7 +79,7 @@ interface ModelRate {
  * "claude-3-5-haiku-20241022"). Patterns below are written to handle
  * both shapes.
  */
-const MODEL_RATES: ModelRate[] = [
+const HARDCODED_MODEL_RATES: ModelRate[] = [
   // ── Current generation (4.6 / 4.5) ───────────────────────────
   {
     match: /opus[-_.\s]?4[-_.\s]?6/i,
@@ -169,6 +197,33 @@ const MODEL_RATES: ModelRate[] = [
     label: "Haiku (generic)",
   },
 ];
+
+/**
+ * Final rate table: snapshot values overlaid onto the hardcoded
+ * patterns by label. Any label missing from the snapshot (e.g. legacy
+ * Sonnet/Haiku 3.5, or the generic "Opus (generic)" catch-alls) keeps
+ * its hardcoded numbers.
+ */
+const MODEL_RATES: ModelRate[] = HARDCODED_MODEL_RATES.map((rate) => {
+  const override = SNAPSHOT.rates?.[rate.label];
+  // Reject malformed snapshot entries — a non-finite or non-positive
+  // rate would silently poison downstream cost math. Fall back to the
+  // hardcoded value rather than trust a broken snapshot.
+  if (
+    !override ||
+    !Number.isFinite(override.inputUsdPerMTok) ||
+    !Number.isFinite(override.outputUsdPerMTok) ||
+    override.inputUsdPerMTok <= 0 ||
+    override.outputUsdPerMTok <= 0
+  ) {
+    return rate;
+  }
+  return {
+    ...rate,
+    inputUsdPerMTok: override.inputUsdPerMTok,
+    outputUsdPerMTok: override.outputUsdPerMTok,
+  };
+});
 
 /**
  * Default fallback rate when no model name matches and no breakdown

--- a/src/lib/pricing-snapshot.json
+++ b/src/lib/pricing-snapshot.json
@@ -1,0 +1,61 @@
+{
+  "pricingAsOf": "2026-04-12",
+  "source": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+  "rates": {
+    "Claude Opus 4.6": {
+      "inputUsdPerMTok": 5,
+      "outputUsdPerMTok": 25,
+      "source": "claude-opus-4-6"
+    },
+    "Claude Opus 4.5": {
+      "inputUsdPerMTok": 5,
+      "outputUsdPerMTok": 25,
+      "source": "claude-opus-4-5"
+    },
+    "Claude Sonnet 4.6": {
+      "inputUsdPerMTok": 3,
+      "outputUsdPerMTok": 15,
+      "source": "claude-sonnet-4-6"
+    },
+    "Claude Sonnet 4.5": {
+      "inputUsdPerMTok": 3,
+      "outputUsdPerMTok": 15,
+      "source": "claude-sonnet-4-5"
+    },
+    "Claude Haiku 4.5": {
+      "inputUsdPerMTok": 1,
+      "outputUsdPerMTok": 5,
+      "source": "claude-haiku-4-5"
+    },
+    "Claude Opus 4.1": {
+      "inputUsdPerMTok": 15,
+      "outputUsdPerMTok": 75,
+      "source": "claude-opus-4-1"
+    },
+    "Claude Opus 4": {
+      "inputUsdPerMTok": 15,
+      "outputUsdPerMTok": 75,
+      "source": "claude-opus-4-20250514"
+    },
+    "Claude Sonnet 4": {
+      "inputUsdPerMTok": 3,
+      "outputUsdPerMTok": 15,
+      "source": "claude-sonnet-4-20250514"
+    },
+    "Claude Sonnet 3.7": {
+      "inputUsdPerMTok": 3,
+      "outputUsdPerMTok": 15,
+      "source": "claude-3-7-sonnet-20250219"
+    },
+    "Claude Haiku 3": {
+      "inputUsdPerMTok": 0.25,
+      "outputUsdPerMTok": 1.25,
+      "source": "claude-3-haiku-20240307"
+    },
+    "Claude Opus 3": {
+      "inputUsdPerMTok": 15,
+      "outputUsdPerMTok": 75,
+      "source": "claude-3-opus-20240229"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Anthropic pricing is now sourced from a committed snapshot (`src/lib/pricing-snapshot.json`) pulled from LiteLLM's community price table. Re-run `pnpm pricing:update` whenever Anthropic changes rates — no code edits needed.
- Overlay keeps the existing regex-based lookup in `api-cost.ts` intact; snapshot numbers replace hardcoded rates by `label`. Hardcoded values stay as the fallback for models LiteLLM doesn't list (legacy Sonnet/Haiku 3.5) or if a snapshot entry is malformed.
- Exports `getPricingAsOf()` so reports can surface a "Pricing as of YYYY-MM-DD" footer (not wired into the UI in this PR).

## Rationale
Anthropic changes prices mid-cycle when they ship new models. Previously every price change required editing the hardcoded table. Now users on the same deploy stay consistent with each other, and drift is closed by a one-command refresh.

## Validation
- Current snapshot (2026-04-12) confirms Opus 4.6 at \$5/\$25 — 30-day cost for this profile lands at ~\$4,972, matching expectations against `/usage`.
- All 351 existing tests pass; added one test for `getPricingAsOf` format.
- Codex review flagged two gaps that are fixed in this PR: (a) update script now requires both input + output costs finite/positive before emitting an override, (b) overlay validates finite positive numbers before trusting a snapshot entry.

## Test plan
- [ ] `pnpm pricing:update` runs cleanly and rewrites the snapshot
- [ ] `pnpm test src/lib/__tests__/api-cost.test.ts` passes
- [ ] Profile pages still render cost numbers correctly