### PR TITLE
feat(share): add share buttons to profile cards

### DIFF
--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -9,8 +9,9 @@ import { useParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Calendar, Pencil, Share2, Sparkles } from "lucide-react";
+import { Calendar, Pencil, Sparkles } from "lucide-react";
 import SectionRenderer from "@/components/SectionRenderer";
+import ShareButton from "@/components/ShareButton";
 import CommentSection from "@/components/CommentSection";
 import ProjectLinks from "@/components/ProjectLinks";
 import SnapshotCard from "@/components/SnapshotCard";
@@ -212,7 +213,6 @@ export default function InsightDetailPage() {
   const [report, setReport] = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
   const [activeTab, setActiveTab] = useState<ProfileTab>("dashboard");
 
   // Scroll to top of tab content when switching tabs so readers don't
@@ -242,12 +242,6 @@ export default function InsightDetailPage() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }, [slug]);
-
-  const handleShare = async () => {
-    await navigator.clipboard.writeText(window.location.href);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   if (loading) {
     return (
@@ -336,13 +330,14 @@ export default function InsightDetailPage() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button
-            onClick={handleShare}
-            className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
-          >
-            <Share2 className="h-4 w-4" />
-            {copied ? "Copied!" : "Share"}
-          </button>
+          <ShareButton
+            url={
+              typeof window !== "undefined"
+                ? window.location.href
+                : `/insights/${slug}`
+            }
+            title={report.title}
+          />
           {session?.user?.id === report.authorId && (
             <Link
               href={`/insights/${slug}/edit`}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { TrendingUp, Clock, Flame, Upload } from "lucide-react";
 import Link from "next/link";
+import ShareButton from "@/components/ShareButton";
 import Image from "next/image";
 import clsx from "clsx";
 import {
@@ -587,13 +588,24 @@ function ProfileCard({
               className="shrink-0"
             />
             <div className="min-w-0">
-              <div
-                className={clsx(
-                  "truncate font-bold text-slate-900 group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400",
-                  featured ? "text-lg" : "text-base",
-                )}
-              >
-                {identityName}
+              <div className="flex items-center gap-2">
+                <div
+                  className={clsx(
+                    "truncate font-bold text-slate-900 group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400",
+                    featured ? "text-lg" : "text-base",
+                  )}
+                >
+                  {identityName}
+                </div>
+                <ShareButton
+                  url={
+                    typeof window !== "undefined"
+                      ? `${window.location.origin}/insights/${insight.slug}`
+                      : `/insights/${insight.slug}`
+                  }
+                  title={identityName}
+                  className="shrink-0 px-2 py-1 text-xs"
+                />
               </div>
               <div className="truncate text-xs text-slate-400">
                 @{insight.author.username}

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { Search, SlidersHorizontal, Sparkles } from "lucide-react";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
+import ShareButton from "@/components/ShareButton";
 
 interface TopReport {
   slug: string;
@@ -112,6 +113,15 @@ function ProfileCard({ report }: { report: TopReport }) {
             @{report.author.username}
           </span>
         </div>
+        <ShareButton
+          url={
+            typeof window !== "undefined"
+              ? `${window.location.origin}/insights/${report.slug}`
+              : `/insights/${report.slug}`
+          }
+          title={report.author.displayName || report.author.username}
+          className="shrink-0 px-2 py-1 text-xs"
+        />
       </div>
 
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500 dark:text-slate-400">

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState, useCallback, type MouseEvent } from "react";
+import { Share2 } from "lucide-react";
+import clsx from "clsx";
+
+export interface ShareButtonProps {
+  /** URL to share. Can be absolute or a path (callers should pass an absolute URL for best share UX). */
+  url: string;
+  /** Optional title passed to navigator.share. Ignored by the clipboard fallback. */
+  title?: string;
+  /** Extra classes appended to the button. Defaults preserve the detail-page styling. */
+  className?: string;
+}
+
+/**
+ * Shared share-action logic. Exported for unit testing — the component wraps
+ * this with React state for the "Copied!" confirmation. Returns `true` if the
+ * clipboard fallback ran (so the caller can flash a "Copied!" label), or
+ * `false` if the native Web Share API handled it.
+ */
+export async function performShare({
+  url,
+  title,
+}: {
+  url: string;
+  title?: string;
+}): Promise<boolean> {
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.share === "function"
+  ) {
+    try {
+      await navigator.share(title ? { title, url } : { url });
+      return false;
+    } catch (err) {
+      // User-cancelled shares throw AbortError — don't fall through to
+      // clipboard in that case (they deliberately backed out).
+      if (err instanceof DOMException && err.name === "AbortError") {
+        return false;
+      }
+      // Any other failure (permissions, unsupported payload): fall through
+      // to the clipboard path so sharing still works.
+    }
+  }
+  await navigator.clipboard.writeText(url);
+  return true;
+}
+
+/**
+ * Factory for the button's click handler. Extracted so unit tests can
+ * drive the exact logic (stopPropagation, preventDefault, copied state
+ * transitions) without a React renderer/DOM.
+ */
+export function createShareClickHandler({
+  url,
+  title,
+  setCopied,
+  copiedDurationMs = 2000,
+}: {
+  url: string;
+  title?: string;
+  setCopied: (value: boolean) => void;
+  copiedDurationMs?: number;
+}) {
+  return async (e: Pick<MouseEvent, "stopPropagation" | "preventDefault">) => {
+    // Cards wrap this button in a <Link>, so we must stop the event from
+    // bubbling up and triggering navigation. preventDefault also guards
+    // against any ancestor <form> or default action.
+    e.stopPropagation();
+    e.preventDefault();
+    const usedClipboard = await performShare({ url, title });
+    if (usedClipboard) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), copiedDurationMs);
+    }
+  };
+}
+
+export default function ShareButton({
+  url,
+  title,
+  className,
+}: ShareButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const onClick = useCallback(
+    async (e: MouseEvent<HTMLButtonElement>) => {
+      await createShareClickHandler({ url, title, setCopied })(e);
+    },
+    [url, title],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Share"
+      className={clsx(
+        "flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-1.5 text-sm text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800",
+        className,
+      )}
+    >
+      <Share2 className="h-4 w-4" />
+      {copied ? "Copied!" : "Share"}
+    </button>
+  );
+}

--- a/src/components/__tests__/ShareButton.test.tsx
+++ b/src/components/__tests__/ShareButton.test.tsx
@@ -1,0 +1,163 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import {
+  performShare,
+  createShareClickHandler,
+} from "@/components/ShareButton";
+
+// The component itself requires a DOM + React renderer to mount. This repo
+// doesn't ship jsdom/testing-library, so we test the component's behavior via
+// its two exported primitives:
+//   - performShare: the clipboard-vs-navigator.share logic
+//   - createShareClickHandler: the click handler (stopPropagation + copied state)
+// Those two cover every branch the integration test would cover.
+
+type NavShareFn = (data: ShareData) => Promise<void>;
+type NavWriteTextFn = (text: string) => Promise<void>;
+
+interface MutableNavigator {
+  share?: NavShareFn;
+  clipboard?: { writeText: NavWriteTextFn };
+}
+
+const nav = globalThis.navigator as unknown as MutableNavigator;
+let originalShare: NavShareFn | undefined;
+let originalClipboard: { writeText: NavWriteTextFn } | undefined;
+
+beforeEach(() => {
+  originalShare = nav.share;
+  originalClipboard = nav.clipboard;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  if (originalShare === undefined) {
+    delete nav.share;
+  } else {
+    nav.share = originalShare;
+  }
+  if (originalClipboard === undefined) {
+    delete nav.clipboard;
+  } else {
+    nav.clipboard = originalClipboard;
+  }
+  vi.useRealTimers();
+});
+
+describe("performShare", () => {
+  it("falls back to clipboard.writeText when navigator.share is unavailable", async () => {
+    delete nav.share;
+    const writeText = vi.fn<NavWriteTextFn>().mockResolvedValue(undefined);
+    nav.clipboard = { writeText };
+
+    const result = await performShare({ url: "https://example.test/x" });
+
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith("https://example.test/x");
+  });
+
+  it("prefers navigator.share when available and does NOT write to clipboard", async () => {
+    const share = vi.fn<NavShareFn>().mockResolvedValue(undefined);
+    const writeText = vi.fn<NavWriteTextFn>().mockResolvedValue(undefined);
+    nav.share = share;
+    nav.clipboard = { writeText };
+
+    const result = await performShare({
+      url: "https://example.test/x",
+      title: "Hello",
+    });
+
+    expect(result).toBe(false);
+    expect(share).toHaveBeenCalledWith({
+      title: "Hello",
+      url: "https://example.test/x",
+    });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("falls back to clipboard when navigator.share rejects with a non-abort error", async () => {
+    nav.share = vi
+      .fn<NavShareFn>()
+      .mockRejectedValue(new Error("unsupported payload"));
+    const writeText = vi.fn<NavWriteTextFn>().mockResolvedValue(undefined);
+    nav.clipboard = { writeText };
+
+    const result = await performShare({ url: "https://example.test/x" });
+
+    expect(result).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("https://example.test/x");
+  });
+});
+
+describe("createShareClickHandler", () => {
+  it("calls stopPropagation and preventDefault on the event", async () => {
+    delete nav.share;
+    nav.clipboard = {
+      writeText: vi.fn<NavWriteTextFn>().mockResolvedValue(undefined),
+    };
+
+    const setCopied = vi.fn();
+    const stopPropagation = vi.fn();
+    const preventDefault = vi.fn();
+
+    const handler = createShareClickHandler({
+      url: "https://example.test/a",
+      setCopied,
+    });
+
+    await handler({ stopPropagation, preventDefault });
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles copied state — true immediately, false after timeout", async () => {
+    delete nav.share;
+    nav.clipboard = {
+      writeText: vi.fn<NavWriteTextFn>().mockResolvedValue(undefined),
+    };
+
+    const setCopied = vi.fn() as Mock;
+    const handler = createShareClickHandler({
+      url: "https://example.test/a",
+      setCopied,
+      copiedDurationMs: 2000,
+    });
+
+    await handler({ stopPropagation: vi.fn(), preventDefault: vi.fn() });
+
+    expect(setCopied).toHaveBeenNthCalledWith(1, true);
+    // The "Copied!" label should NOT have cleared yet.
+    expect(setCopied).toHaveBeenCalledTimes(1);
+
+    // Advance past the hold duration and confirm the label clears.
+    vi.advanceTimersByTime(2000);
+    expect(setCopied).toHaveBeenNthCalledWith(2, false);
+    expect(setCopied).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not flip copied state when navigator.share handles the share natively", async () => {
+    nav.share = vi.fn<NavShareFn>().mockResolvedValue(undefined);
+    nav.clipboard = {
+      writeText: vi.fn<NavWriteTextFn>().mockResolvedValue(undefined),
+    };
+
+    const setCopied = vi.fn();
+    const handler = createShareClickHandler({
+      url: "https://example.test/a",
+      setCopied,
+    });
+
+    await handler({ stopPropagation: vi.fn(), preventDefault: vi.fn() });
+
+    expect(setCopied).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- New reusable `ShareButton` component at `src/components/ShareButton.tsx` (prefers `navigator.share`, falls back to clipboard + "Copied!" confirmation, stops propagation so wrapped `<Link>` cards don't navigate).
- Wired into `ProfileCard` on the homepage, the `/top` page's own card, and the detail view (replaces the inline share handler).
- 6 unit tests covering clipboard fallback, native-share path, event guards, and the copied-state transition.

## Test plan
- [ ] Click share on a homepage card — clipboard populated, "Copied!" toast appears ~2s
- [ ] Click share doesn't navigate into the card
- [ ] Detail page share button still works unchanged
- [ ] Mobile Safari / PWA surfaces native share sheet

Closes #60