### PR TITLE
feat(upload): show example profile above the fold (#66)

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import {
   Upload,
   Check,
@@ -86,6 +87,11 @@ const EMPTY_FORM: ProjectFormInput = {
 
 const INSIGHTS_PATH = "~/.claude/usage-data/report.html";
 const HARNESS_PATH = "~/.claude/usage-data/insight-harness.html";
+
+const SAMPLE_PROFILE_SLUG = "kabirdos-20260412-5x373x";
+const SAMPLE_PROFILE_HREF = `/insights/${SAMPLE_PROFILE_SLUG}`;
+const SAMPLE_PROFILE_OG = `/api/og/${SAMPLE_PROFILE_SLUG}`;
+const SAMPLE_PROFILE_LABEL = "Kabir's Insight Harness — Apr 2026";
 
 function CopyButton({
   text,
@@ -842,9 +848,51 @@ export default function UploadPage() {
       <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
         Share Your Insights
       </h1>
-      <p className="mb-8 text-slate-500 dark:text-slate-400">
+      <p className="mb-4 text-slate-500 dark:text-slate-400">
         Upload your Claude Code insights report and share it with the community.
       </p>
+
+      <div className="mb-8 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-slate-800/40">
+        <div className="flex flex-col gap-4 p-4 sm:flex-row sm:items-center sm:gap-5">
+          <Link
+            href={SAMPLE_PROFILE_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block shrink-0 overflow-hidden rounded-lg border border-slate-200 bg-slate-100 transition-opacity hover:opacity-90 dark:border-slate-700 dark:bg-slate-900 sm:w-64"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={SAMPLE_PROFILE_OG}
+              alt={`Preview of ${SAMPLE_PROFILE_LABEL}`}
+              loading="lazy"
+              className="block h-auto w-full"
+              width={1200}
+              height={630}
+            />
+          </Link>
+          <div className="min-w-0 flex-1">
+            <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+              What your profile will look like
+            </div>
+            <div className="mb-2 text-base font-semibold text-slate-900 dark:text-slate-100">
+              {SAMPLE_PROFILE_LABEL}
+            </div>
+            <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
+              Rich stats, skill inventory, and workflow patterns —
+              auto-generated from your local usage data.
+            </p>
+            <Link
+              href={SAMPLE_PROFILE_HREF}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-sm font-semibold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            >
+              See a sample profile
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
 
       {/* Step indicator */}
       <div className="mb-8 flex items-center gap-2">


### PR DESCRIPTION
## Summary

Adds a visible sample profile preview above the fold on `/upload` so users can see what a published profile looks like before uploading blind. Closes #66.

### What changed
- New preview block in the upload page hero (between subtitle and step indicator)
- Embeds the existing OG card image via `/api/og/[slug]` as a thumbnail — no new dependencies, no new card component
- Prominent **"See a sample profile ->"** link with `ArrowRight` icon (already imported)
- Thumbnail itself is a click target that opens the profile in a new tab
- Responsive: stacks column on mobile, row on `sm+`
- Featured slug extracted to `SAMPLE_PROFILE_SLUG` constant at top of file for easy future swap

### Featured profile
**Kabir's Insight Harness — Apr 2026** (`kabirdos-20260412-5x373x`)

Picked because it's a harness report (richer stats than plain `insights`), has real published data (9.8M tokens, 88 sessions, 105 PRs, 47 skills, Fire-and-Forget autonomy), and is owned by the repo author so unlikely to disappear. Swap by editing `SAMPLE_PROFILE_SLUG` / `SAMPLE_PROFILE_LABEL` near the top of `src/app/upload/page.tsx`.

### Scope discipline
- Did **not** change H1 copy
- Did **not** restructure the two-column layout
- Did **not** touch auth
- Did **not** add new deps

## Test plan
- [ ] Load `/upload` signed-in — verify preview appears between subtitle and step indicator
- [ ] Verify OG card image loads (same-origin `/api/og/kabirdos-20260412-5x373x`)
- [ ] Click thumbnail and "See a sample profile" link — both open `/insights/kabirdos-20260412-5x373x` in a new tab
- [ ] Mobile viewport: thumbnail stacks above text
- [ ] Dark mode: colors look correct