### PR TITLE
fix(ui): prevent project card OG image from cropping content

### DIFF
--- a/src/components/ProjectLinks.tsx
+++ b/src/components/ProjectLinks.tsx
@@ -129,7 +129,7 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
       )}
     >
       {showImage && safeOgImage && (
-        <div className="relative aspect-[16/7] w-full overflow-hidden bg-slate-100 dark:bg-slate-900">
+        <div className="relative aspect-[1.91/1] w-full overflow-hidden bg-slate-100 dark:bg-slate-900">
           {/* Plain <img> on purpose — OG images come from arbitrary
               third-party hosts and next/image would require wildcard
               remotePatterns in next.config.ts. URL has been gated by
@@ -138,7 +138,7 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
           <img
             src={safeOgImage}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full object-contain"
             onError={() => setImageFailed(true)}
             loading="lazy"
             referrerPolicy="no-referrer"


### PR DESCRIPTION
## Summary
- Project card previews used `aspect-[16/7]` with `object-cover`, cropping top/bottom of standard 1200×630 OG images and slicing off edge content (e.g. the "2.1M TOKENS/WK" strip on the Insight Harness share card).
- Switched to the standard 1.91:1 OG ratio with `object-contain` so the whole image is shown, letterboxed onto the existing slate backdrop when a source has a different native ratio.

## Test plan
- [ ] Visit a report detail page with attached projects and verify OG preview images are shown in full (no cropped text at top/bottom)
- [ ] Confirm cards with non-16:7 source images letterbox cleanly instead of clipping
- [ ] Dark mode letterbox looks right against `bg-slate-900`