### PR TITLE
feat(upload): remove auth wall, only gate publish (#64)

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
 import {
   Upload,
   Check,
@@ -688,6 +688,10 @@ export default function UploadPage() {
 
   const handlePublish = async () => {
     if (!parsed) return;
+    if (!session) {
+      signIn("github", { callbackUrl: "/upload" });
+      return;
+    }
     setPublishing(true);
     setError(null);
 
@@ -837,22 +841,6 @@ export default function UploadPage() {
   const totalSensitive = redactions.length;
   const allRedacted = totalSensitive > 0 && redactedCount === totalSensitive;
 
-  if (!session) {
-    return (
-      <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-center">
-          <Upload className="mx-auto mb-4 h-12 w-12 text-slate-400" />
-          <h2 className="mb-2 text-xl font-semibold text-slate-900 dark:text-white">
-            Sign in to share your insights
-          </h2>
-          <p className="text-slate-500 dark:text-slate-400">
-            You need to be logged in to upload insights.
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
       <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
@@ -953,7 +941,11 @@ export default function UploadPage() {
               disabled={publishing || formSaving}
               className="rounded-lg bg-blue-600 px-6 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:bg-slate-300 disabled:dark:bg-slate-700"
             >
-              {publishing ? "Publishing..." : "Publish Insights"}
+              {publishing
+                ? "Publishing..."
+                : !session
+                  ? "Sign in to publish"
+                  : "Publish Insights"}
             </button>
           ) : (
             <button
@@ -2278,13 +2270,23 @@ export default function UploadPage() {
           )}
 
           {/* ── Bottom Publish CTA ── */}
-          <div className="mt-8 flex justify-end">
+          <div className="mt-8 flex flex-col items-end gap-2">
+            {!session && (
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                Sign in to publish your profile — your data stays in this
+                browser until you do.
+              </p>
+            )}
             <button
               onClick={handlePublish}
               disabled={publishing || formSaving}
               className="rounded-lg bg-blue-600 px-8 py-3 font-medium text-white transition-colors hover:bg-blue-700 disabled:bg-slate-300 disabled:dark:bg-slate-700"
             >
-              {publishing ? "Publishing..." : "Publish Insights"}
+              {publishing
+                ? "Publishing..."
+                : !session
+                  ? "Sign in to publish"
+                  : "Publish Insights"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Closes #64.

## Summary
Logged-out visitors can now read and walk through the entire `/upload` instructional flow. Auth is required only at the final Publish step.

## What changed
- Removed the page-level `if (!session)` early return in `src/app/upload/page.tsx` that previously blocked all logged-out visitors with a "Sign in to share your insights" stub.
- Added a publish-time gate inside `handlePublish`: if there is no session, the handler triggers `signIn("github", { callbackUrl: "/upload" })` instead of POSTing.
- Updated the two Publish CTAs (sticky header + bottom of Step 3) to read "Sign in to publish" when logged out, and added a small inline note above the bottom CTA explaining the data stays in-browser until they sign in.
- No changes to copy, layout, or UX from PR #78 (H1, sample profile preview, primary card, `/insights` disclosure, comparison table, redaction promise, drop zone, back-to-home link all preserved).

## Logged-out users can now
- See the full page (H1, sample profile preview, primary insight-harness card, `/insights` disclosure, comparison table, redaction promise)
- Run the install command locally
- Drop their report file (parsing is fully client-side)
- Walk through Projects + Review wizard steps
- See the redaction review UI
- Hit Publish, which redirects to GitHub OAuth and returns to `/upload`

## Defense in depth
`POST /api/insights` already requires `await auth()` and returns 401 if missing — left untouched. No middleware protects `/upload`.

## Test plan
- [ ] Visit `/upload` while logged out — confirm full page renders, wizard is navigable, file drop parses locally
- [ ] Click "Sign in to publish" — confirm GitHub OAuth flow returns to `/upload`
- [ ] Visit `/upload` while logged in — confirm Publish CTA still reads "Publish Insights" and works as before