### PR TITLE
feat(upload): marketplace-primary install for insight-harness (#68)

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -488,6 +488,7 @@ export default function UploadPage() {
   const [dragOverHarness, setDragOverHarness] = useState(false);
   const [showAllFeatures, setShowAllFeatures] = useState(true);
   const [showStandard, setShowStandard] = useState(false);
+  const [showCurlFallback, setShowCurlFallback] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const harnessFileInputRef = useRef<HTMLInputElement>(null);
 
@@ -1048,10 +1049,42 @@ export default function UploadPage() {
                   </span>
                 </span>
               </div>
-              <CommandBlock
-                command="curl -sL https://github.com/craigdossantos/claude-toolkit/archive/main.tar.gz | tar xz -C /tmp && cp -r /tmp/claude-toolkit-main/skills/insight-harness ~/.claude/skills/ && rm -rf /tmp/claude-toolkit-main"
-                small
-              />
+              <CommandBlock command="claude plugin marketplace add kabirdos/insight-harness" />
+              <CommandBlock command="/plugin install insight-harness@kabirdos-insight-harness" />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Auto-updates when new versions ship. Inspect the source at{" "}
+                <a
+                  href="https://github.com/kabirdos/insight-harness"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-slate-600 underline decoration-slate-300 underline-offset-2 hover:text-slate-900 hover:decoration-slate-500 dark:text-slate-300 dark:decoration-slate-600 dark:hover:text-slate-100 dark:hover:decoration-slate-400"
+                >
+                  github.com/kabirdos/insight-harness
+                </a>
+                .
+              </p>
+              <div className="mt-1">
+                <button
+                  type="button"
+                  onClick={() => setShowCurlFallback((v) => !v)}
+                  className="flex items-center gap-1.5 text-[12px] font-medium text-slate-500 transition-colors hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+                >
+                  Prefer curl or no plugin support?
+                  {showCurlFallback ? (
+                    <ChevronUp className="h-3.5 w-3.5" />
+                  ) : (
+                    <ChevronDown className="h-3.5 w-3.5" />
+                  )}
+                </button>
+                {showCurlFallback && (
+                  <div className="mt-2">
+                    <CommandBlock
+                      command="curl -sL https://github.com/craigdossantos/claude-toolkit/archive/main.tar.gz | tar xz -C /tmp && cp -r /tmp/claude-toolkit-main/skills/insight-harness ~/.claude/skills/ && rm -rf /tmp/claude-toolkit-main"
+                      small
+                    />
+                  </div>
+                )}
+              </div>
               <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                 Then run:
               </p>


### PR DESCRIPTION
## Summary

Updates the `/upload` page Enhanced primary card to promote the new Claude Code plugin marketplace as the default install path for `insight-harness`. The previous curl+tar+cp one-liner is preserved as a collapsible fallback for users without plugin support.

## Changes

- **Primary install block** now shows two commands:
  - `claude plugin marketplace add kabirdos/insight-harness`
  - `/plugin install insight-harness@kabirdos-insight-harness`
- One-line note: "Auto-updates when new versions ship."
- Trust link to `github.com/kabirdos/insight-harness` so users can inspect the source before installing.
- **Collapsible fallback** labeled "Prefer curl or no plugin support?" reveals the original curl command unchanged. Matches the existing `/insights` disclosure pattern already used on this page.
- All other card content (steps, drop zone, filenames, comparison table, redaction banner) is untouched.

## Companion

The harness is being published at `kabirdos/insight-harness` as a Claude Code plugin marketplace repo by a sibling task. This PR's marketplace command references that repo.

## Notes for reviewers

- Third-party marketplace auto-update is OFF by default in Claude Code — users can toggle it on via `/plugin` if they want automatic updates.
- Collapse pattern reuses `ChevronDown` / `ChevronUp` already imported in this file.
- No new dependencies.

## Test plan

- [ ] Visit `/upload`, confirm the primary Enhanced card shows the two marketplace commands followed by `/insight-harness`.
- [ ] Click "Prefer curl or no plugin support?" — the original curl one-liner expands.
- [ ] Click the `github.com/kabirdos/insight-harness` link — opens the repo in a new tab.
- [ ] Verify mobile viewport: commands wrap cleanly, disclosure toggles correctly.
- [ ] `/insights` disclosure and comparison table below still work unchanged.