### PR TITLE
fix(upload): H1 emphasis, actionable drop zone, dark mode audit

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -200,8 +200,8 @@ function MiniDropZone({
         className={clsx(
           "flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 transition-colors",
           dragOver
-            ? "border-blue-400 bg-blue-50 dark:border-blue-500 dark:bg-blue-950/30"
-            : "border-slate-300 bg-slate-50 hover:border-slate-400 dark:border-slate-600 dark:bg-slate-800/50 dark:hover:border-slate-500",
+            ? "border-blue-500 bg-blue-100 dark:border-blue-400 dark:bg-blue-950/50"
+            : "border-blue-300 bg-blue-50/60 hover:border-blue-500 hover:bg-blue-50 dark:border-blue-700 dark:bg-blue-950/20 dark:hover:border-blue-500 dark:hover:bg-blue-950/40",
         )}
       >
         {loading ? (
@@ -214,15 +214,15 @@ function MiniDropZone({
           </div>
         ) : (
           <>
-            <Upload className="mb-2 h-6 w-6 text-slate-400 dark:text-slate-500" />
-            <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
+            <Upload className="mb-2 h-6 w-6 text-blue-500 dark:text-blue-400" />
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
               Drop{" "}
-              <code className="rounded bg-slate-200 px-1 py-0.5 font-mono text-[12px] text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+              <code className="rounded bg-white px-1 py-0.5 font-mono text-[12px] text-slate-700 dark:bg-slate-700 dark:text-slate-200">
                 {filename}
               </code>{" "}
               here — or click to choose.
             </p>
-            <p className="mt-1 text-[11px] text-slate-400 dark:text-slate-500">
+            <p className="mt-1 text-[11px] text-blue-600/70 dark:text-blue-300/70">
               Accepts .html files
             </p>
           </>
@@ -987,8 +987,8 @@ export default function UploadPage() {
           {/* Header */}
           <div className="mb-7 text-center">
             <h1 className="text-xl font-extrabold text-slate-900 dark:text-slate-100">
-              Turn your Claude Code session data into your profile in one
-              minute.
+              Turn your Claude Code session data into your{" "}
+              <span className="text-2xl">profile</span> in one minute
             </h1>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               Generate a report in Claude Code, drop the file below, and preview
@@ -1598,14 +1598,14 @@ export default function UploadPage() {
                               className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${
                                 plugin.active
                                   ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                                  : "bg-slate-100 text-slate-400 dark:bg-slate-800"
+                                  : "bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-500"
                               }`}
                             >
                               {plugin.active ? "on" : "off"}
                             </span>
                           </div>
                           {(plugin.version || plugin.marketplace) && (
-                            <div className="mt-0.5 text-[11px] text-slate-400">
+                            <div className="mt-0.5 text-[11px] text-slate-400 dark:text-slate-500">
                               {plugin.version && `v${plugin.version}`}
                               {plugin.version && plugin.marketplace && " · "}
                               {plugin.marketplace}
@@ -1683,7 +1683,7 @@ export default function UploadPage() {
                         {Object.keys(parsed.harnessData.agentDispatch.types)
                           .length > 0 && (
                           <div>
-                            <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                            <h4 className="mb-2 text-xs font-semibold text-slate-500 dark:text-slate-400">
                               Agent Types
                             </h4>
                             <MiniBarChart
@@ -1698,7 +1698,7 @@ export default function UploadPage() {
                         {Object.keys(parsed.harnessData.agentDispatch.models)
                           .length > 0 && (
                           <div>
-                            <h4 className="mb-2 text-xs font-semibold text-slate-500">
+                            <h4 className="mb-2 text-xs font-semibold text-slate-500 dark:text-slate-400">
                               Model Tiering
                             </h4>
                             <MiniBarChart
@@ -1710,7 +1710,7 @@ export default function UploadPage() {
                             />
                             {parsed.harnessData.agentDispatch.backgroundPct >
                               0 && (
-                              <p className="mt-1 text-xs text-slate-400">
+                              <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
                                 {parsed.harnessData.agentDispatch.backgroundPct}
                                 % run in background
                               </p>
@@ -1721,7 +1721,7 @@ export default function UploadPage() {
                       {parsed.harnessData.agentDispatch.customAgents.length >
                         0 && (
                         <div className="mt-3">
-                          <h4 className="mb-1 text-xs font-semibold text-slate-500">
+                          <h4 className="mb-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                             Custom Agents
                           </h4>
                           <div className="flex flex-wrap gap-1.5">
@@ -1791,7 +1791,7 @@ export default function UploadPage() {
                             <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
                               {server}
                             </span>
-                            <span className="text-xs text-slate-400">
+                            <span className="text-xs text-slate-400 dark:text-slate-500">
                               {calls.toLocaleString()} calls
                             </span>
                           </div>


### PR DESCRIPTION
## Changes

1. **H1 copy fix** — now reads exactly `Turn your Claude Code session data into your profile in one minute` (removed trailing period; was line-wrapped awkwardly).
2. **Emphasize "profile"** — wrapped in a `<span className="text-2xl">` so it pops one step larger than the surrounding `text-xl` headline (1.2x ratio), matching the existing Tailwind type scale. No color/weight changes.
3. **Actionable drop zone** — shared `MiniDropZone` component now uses the primary blue palette already used across the page (blue-600 CTAs, blue-300/700 primary card border):
   - Default: `border-blue-300 bg-blue-50/60` (dark: `border-blue-700 bg-blue-950/20`)
   - Hover: `border-blue-500 bg-blue-50` (dark: `border-blue-500 bg-blue-950/40`)
   - Drag-over: `border-blue-500 bg-blue-100` (dark: `border-blue-400 bg-blue-950/50`)
   - Upload icon bumped to `text-blue-500 dark:text-blue-400`, filename chip background switched to white for contrast on the tint, "Accepts .html files" now uses a muted blue. Both Enhanced and Standard drop zones get the treatment via the shared component. `filename` prop, drag handlers, and all existing behavior preserved.
4. **Dark mode audit** — swept the full page. Closed missing `dark:` variants on a handful of secondary labels inside the review-step preview: agent-dispatch section headers (`h4`), inactive plugin "off" pill text, plugin version/marketplace row, "% run in background" caption, and MCP "N calls" count. Everything else (hero, banners, comparison table, disclosures, sample-profile preview card, step indicator, sticky nav, publish CTAs, redaction summary bar) already had proper `dark:` pairs.

## Visual verification

Verified by static code read (dev server not started in worktree):
- H1 text and span-bumped "profile" word in markup
- Drop zone colors render in both light and dark class strings
- All edited lines have matching `dark:` variants

Skipped: browser render at mobile/desktop breakpoints, hover/drag-over animation feel, contrast check against actual rendered blue-50/60 background. Recommend a quick light/dark pass on `/upload` before merge.

## Dark mode issues found and fixed

- `text-slate-500` section headers in Agent Dispatch had no dark pair → added `dark:text-slate-400`
- Inactive plugin "off" pill: `bg-slate-800` with no dark text color → added `dark:text-slate-500`
- Plugin version/marketplace subtitle: added `dark:text-slate-500`
- Agent-dispatch "% run in background" and MCP calls counts: added `dark:text-slate-500`

No near-invisible text or stuck-light backgrounds found elsewhere.