### PR TITLE
fix(upload): unify plugin install commands

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1049,7 +1049,10 @@ export default function UploadPage() {
                   </span>
                 </span>
               </div>
-              <CommandBlock command="claude plugin marketplace add kabirdos/insight-harness" />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Run these two commands inside Claude Code:
+              </p>
+              <CommandBlock command="/plugin marketplace add kabirdos/insight-harness" />
               <CommandBlock command="/plugin install insight-harness@kabirdos-insight-harness" />
               <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                 Auto-updates when new versions ship. Inspect the source at{" "}


### PR DESCRIPTION
## Before
Step 1 mixed a shell command with a slash command:
- `claude plugin marketplace add kabirdos/insight-harness` (shell)
- `/plugin install insight-harness@kabirdos-insight-harness` (Claude Code)

## After
Both are slash commands run inside Claude Code, with a clarifying label:

> Run these two commands inside Claude Code:

- `/plugin marketplace add kabirdos/insight-harness`
- `/plugin install insight-harness@kabirdos-insight-harness`

The collapsible "Prefer curl or no plugin support?" fallback is unchanged.