### PR TITLE
feat(cards): lifetime tokens under username on all profile cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -622,8 +622,8 @@ function ProfileCard({
                 <div className="mt-1.5">
                   <div
                     className={clsx(
-                      "bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300",
-                      featured ? "text-4xl" : "text-2xl",
+                      "font-mono font-bold leading-none text-slate-900 dark:text-white",
+                      featured ? "text-lg" : "text-base",
                     )}
                   >
                     {formatTokens(lifetimeTokens)}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,7 @@ type SortOption = "newest" | "most_voted" | "trending";
 // computed wrong api-cost/wk numbers for mixed-model profiles.
 interface HarnessStatsSlice {
   totalTokens?: number;
+  lifetimeTokens?: number;
   durationHours?: number;
   sessionCount?: number;
   commitCount?: number;
@@ -560,6 +561,12 @@ function ProfileCard({
   const identityName = insight.author.displayName || insight.author.username;
   const hasHeatmap = tokenDaily.some((v) => v > 0);
 
+  const lifetimeTokensRaw = insight.harnessData?.stats?.lifetimeTokens;
+  const lifetimeTokens =
+    lifetimeTokensRaw && lifetimeTokensRaw > 0
+      ? lifetimeTokensRaw
+      : (effectiveTokens ?? 0);
+
   return (
     <Link
       href={`/insights/${insight.slug}`}
@@ -611,6 +618,21 @@ function ProfileCard({
                 @{insight.author.username}
                 {dateRange && <> · {dateRange}</>}
               </div>
+              {lifetimeTokens > 0 && (
+                <div className="mt-1.5">
+                  <div
+                    className={clsx(
+                      "bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300",
+                      featured ? "text-4xl" : "text-2xl",
+                    )}
+                  >
+                    {formatTokens(lifetimeTokens)}
+                  </div>
+                  <div className="mt-1 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">
+                    lifetime tokens
+                  </div>
+                </div>
+              )}
             </div>
           </div>
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -13,6 +13,7 @@ interface InsightSummary {
   sessionCount?: number | null;
   messageCount?: number | null;
   commitCount?: number | null;
+  totalTokens?: number | null;
   whatsWorkingPreview?: string | null;
   voteCount: number;
   commentCount: number;
@@ -118,6 +119,7 @@ export default function SearchPage() {
               sessionCount={insight.sessionCount}
               messageCount={insight.messageCount}
               commitCount={insight.commitCount}
+              totalTokens={insight.totalTokens}
               whatsWorkingPreview={insight.whatsWorkingPreview}
               voteCount={insight.voteCount}
               commentCount={insight.commentCount}

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -119,7 +119,7 @@ function ProfileCard({ report }: { report: TopReport }) {
           </span>
           {lifetimeTokens > 0 && (
             <div className="mt-1.5">
-              <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+              <div className="font-mono text-base font-semibold leading-none text-slate-900 dark:text-white">
                 {formatNumber(lifetimeTokens)}
               </div>
               <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -76,6 +76,11 @@ function ProfileCard({ report }: { report: TopReport }) {
     ? normalizeHarnessData(report.harnessData as HarnessData)
     : null;
   const sessions = report.sessionCount || hd?.stats?.sessionCount || 0;
+  const lifetimeTokensRaw = hd?.stats?.lifetimeTokens;
+  const lifetimeTokens =
+    lifetimeTokensRaw && lifetimeTokensRaw > 0
+      ? lifetimeTokensRaw
+      : (report.totalTokens ?? 0);
   const tokensWk = perWeek(report.totalTokens, report.dayCount);
   const sessionsWk = perWeek(sessions, report.dayCount);
   const commitsWk = perWeek(report.commitCount, report.dayCount);
@@ -112,6 +117,16 @@ function ProfileCard({ report }: { report: TopReport }) {
           <span className="text-xs text-slate-500 dark:text-slate-400">
             @{report.author.username}
           </span>
+          {lifetimeTokens > 0 && (
+            <div className="mt-1.5">
+              <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+                {formatNumber(lifetimeTokens)}
+              </div>
+              <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">
+                lifetime tokens
+              </div>
+            </div>
+          )}
         </div>
         <ShareButton
           url={

--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -26,6 +26,14 @@ interface InsightCardProps {
   voteCount: number;
   commentCount: number;
   sectionTags?: string[];
+  totalTokens?: number | null;
+  lifetimeTokens?: number | null;
+}
+
+function formatTokensCompact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return `${Math.round(n)}`;
 }
 
 function formatDate(dateStr: string) {
@@ -100,8 +108,12 @@ export default function InsightCard({
   voteCount,
   commentCount,
   sectionTags = [],
+  totalTokens,
+  lifetimeTokens,
 }: InsightCardProps) {
   const dateRange = formatDateRange(dateRangeStart, dateRangeEnd);
+  const effectiveLifetime =
+    lifetimeTokens && lifetimeTokens > 0 ? lifetimeTokens : (totalTokens ?? 0);
 
   return (
     <Link
@@ -130,6 +142,17 @@ export default function InsightCard({
           {formatDate(publishedAt)}
         </span>
       </div>
+
+      {effectiveLifetime > 0 && (
+        <div className="mt-2">
+          <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+            {formatTokensCompact(effectiveLifetime)}
+          </div>
+          <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">
+            lifetime tokens
+          </div>
+        </div>
+      )}
 
       {/* Title / Stats */}
       <h3 className="mt-3 text-base font-semibold text-slate-900 group-hover:text-blue-600 dark:text-slate-100 dark:group-hover:text-blue-400 line-clamp-2 break-all sm:break-normal">

--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -145,7 +145,7 @@ export default function InsightCard({
 
       {effectiveLifetime > 0 && (
         <div className="mt-2">
-          <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+          <div className="font-mono text-sm font-medium leading-none text-slate-900 dark:text-white">
             {formatTokensCompact(effectiveLifetime)}
           </div>
           <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">


### PR DESCRIPTION
## Summary

Adds a stacked lifetime-tokens display directly underneath the username on all three profile-card surfaces. Mono bold number with a blue-to-cyan gradient and an uppercase "lifetime tokens" label, scaled to each surface's density.

## Surfaces

- **Home `ProfileCard`** (`src/app/page.tsx`) — inserted into the identity column under `@username · dateRange`. `text-2xl` regular, `text-4xl` featured. Existing big `tokens / wk` on the right is preserved. Uses fallback chain: `harnessData.stats.lifetimeTokens > 0 ? lifetime : (totalTokens ?? harnessData.stats.totalTokens)`. Also extended local `HarnessStatsSlice` interface to include the optional `lifetimeTokens` field.
- **`/top` `ProfileCard`** (`src/app/top/page.tsx`) — inserted under `@username` in the identity column. `text-xl` (denser grid). Reads `lifetimeTokens` from normalized `harnessData` with `report.totalTokens` fallback. `tokens/wk` inline stat preserved.
- **`/search` `InsightCard`** (`src/components/InsightCard.tsx` + `src/app/search/page.tsx`) — added `totalTokens?: number | null` and `lifetimeTokens?: number | null` props, threaded `totalTokens` through `/search` page (already on the API response payload, no fetch change needed). Stacked block rendered after the author row, `text-xl`.

## Constraints

- No card restructure, just inserted the new block in the right slot on each surface.
- Dark-mode variants on gradient (`from-blue-400 to-cyan-300`) and label (`dark:text-slate-500`).
- Did not touch OG share cards or the profile detail page.

## Test plan

- [ ] Visual: home `/` light + dark, mobile + desktop — featured card hero number larger, regular cards smaller
- [ ] Visual: `/top` light + dark — lifetime number visible under @username, doesn't crowd ShareButton
- [ ] Visual: `/search` light + dark — number sits between author row and title
- [ ] Reports without `lifetimeTokens` fall back to `totalTokens`; reports with neither hide the block entirely