### PR TITLE
fix(cards): tone down lifetime tokens — match display-name size, black text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -622,8 +622,8 @@ function ProfileCard({
                 <div className="mt-1.5">
                   <div
                     className={clsx(
-                      "bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300",
-                      featured ? "text-4xl" : "text-2xl",
+                      "font-mono font-bold leading-none text-slate-900 dark:text-white",
+                      featured ? "text-lg" : "text-base",
                     )}
                   >
                     {formatTokens(lifetimeTokens)}

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -119,7 +119,7 @@ function ProfileCard({ report }: { report: TopReport }) {
           </span>
           {lifetimeTokens > 0 && (
             <div className="mt-1.5">
-              <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+              <div className="font-mono text-base font-semibold leading-none text-slate-900 dark:text-white">
                 {formatNumber(lifetimeTokens)}
               </div>
               <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">

--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -145,7 +145,7 @@ export default function InsightCard({
 
       {effectiveLifetime > 0 && (
         <div className="mt-2">
-          <div className="bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono text-xl font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300">
+          <div className="font-mono text-sm font-medium leading-none text-slate-900 dark:text-white">
             {formatTokensCompact(effectiveLifetime)}
           </div>
           <div className="mt-0.5 text-[9px] font-bold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">


### PR DESCRIPTION
Follow-up tweak on top of #85. Tones down the stacked lifetime-tokens block under each username so it no longer competes visually with the display name.

## Before / after (number element classes)

**`src/app/page.tsx` (home ProfileCard)**
- before: `bg-gradient-to-r from-blue-600 to-cyan-500 bg-clip-text font-mono font-bold leading-none text-transparent dark:from-blue-400 dark:to-cyan-300` + `featured ? text-4xl : text-2xl`
- after: `font-mono font-bold leading-none text-slate-900 dark:text-white` + `featured ? text-lg : text-base`

**`src/app/top/page.tsx` (/top ProfileCard)**
- before: `bg-gradient-to-r ... text-xl font-bold ... text-transparent ...`
- after: `font-mono text-base font-semibold leading-none text-slate-900 dark:text-white`

**`src/components/InsightCard.tsx` (/search card)**
- before: `bg-gradient-to-r ... text-xl font-bold ... text-transparent ...`
- after: `font-mono text-sm font-medium leading-none text-slate-900 dark:text-white`

## Notes

- Color now matches each card's display name (`text-slate-900 dark:text-white`).
- Size matches each card's display-name size (lg/base on home, base on /top, sm on /search).
- Stacked position and the small uppercase `lifetime tokens` label below are unchanged.
- Mono kept; weight reduced where the smaller size warranted.

## Test plan

- [ ] Home `/` light + dark — number sits quietly under the name, no gradient
- [ ] `/top` light + dark — number reads as a secondary stat, not a hero
- [ ] `/search` light + dark — number doesn't out-shout the title