### PR TITLE
fix(upload): point sample profile at live kabirdos/20260413-e3n48n report

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -90,7 +90,7 @@ const INSIGHTS_PATH = "~/.claude/usage-data/report.html";
 const HARNESS_PATH = "~/.claude/usage-data/insight-harness.html";
 
 const SAMPLE_PROFILE_USERNAME = "kabirdos";
-const SAMPLE_PROFILE_SLUG = "20260412-5x373x";
+const SAMPLE_PROFILE_SLUG = "20260413-e3n48n";
 const SAMPLE_PROFILE_HREF = buildReportUrl(
   SAMPLE_PROFILE_USERNAME,
   SAMPLE_PROFILE_SLUG,


### PR DESCRIPTION
Sample profile slug on the upload page was pointing at a stale slug from before the URL restructure migration. Updates to the live URL: https://insightharness.com/insights/kabirdos/20260413-e3n48n (verified 200).