### PR TITLE
feat(profile): developer setup fields (uses.tech-style)

### DIFF
--- a/docs/plans/2026-04-13-profile-setup-fields-codex-review.md
+++ b/docs/plans/2026-04-13-profile-setup-fields-codex-review.md
@@ -1,0 +1,63 @@
+# Codex Review — Profile Setup Fields Plan
+
+Date: 2026-04-13
+Reviewer: codex CLI (gpt-5-codex)
+
+## Findings
+
+### Architecture & validation
+
+1. **Plan not in implementation branch.** Plan lives in main checkout only — copy/commit into the worktree before implementation so the branch contains the source of truth.
+
+2. **JSON blob on `User` is sound for v1.** Existing `User` model is profile scalars + relations with no setup table pressure (schema.prisma:12). Public profile fetch is already a single `User` query (route.ts:11). Normalized table would be premature.
+
+3. **Validation is too write-only.** `normalizeSetup(raw)` must run on BOTH the PUT path AND when reading from public/private endpoints. Otherwise malformed JSON from manual DB edits, old shape, or bad migration leaks raw unknown keys through the public endpoint once `setup: true` is added at `src/app/api/users/[username]/route.ts:13`.
+
+4. **Type missing recommended metadata.** Plan's `ProfileSetup` shape only includes user fields (plan:90). Bake in `version: 1` and `setupUpdatedAt` now if we agreed to them — but make BOTH server-owned. Do NOT accept client-provided `setupUpdatedAt`.
+
+5. **Prisma JSON null handling needs a note.** Plan says empty setup → NULL (plan:203). For Prisma `Json?`, plain `null` is ambiguous — use the generated Prisma null sentinel (`Prisma.JsonNull` / `Prisma.DbNull`) and cover with TS.
+
+6. **PUT accumulator type needs widening.** Current `updateData` in `src/app/api/users/me/route.ts:67` is typed `Record<string, string | null>`. Adding `setup` requires a wider type. The "no valid fields" check at line 97 must still allow "clear setup to null" as a valid update.
+
+### Auto-derivation
+
+7. **Source keys are real.** `models`, `mcpServers`, `harnessFiles`, `versions` all exist on `HarnessData` (insights.ts:225). `normalizeHarnessData` defaults `models` and `mcpServers` to `{}` (insights.ts:435).
+
+8. **Prefer `perModelTokens` for primaryModel.** `perModelTokens` already exists (insights.ts:249). If "primary model" means actual usage, **token share is a better signal than message count**.
+
+9. **OS heuristic privacy.** Project classifies local file paths as high-risk private data (review-step-design.md:18, :31). Helper must return ONLY `{ os: "macOS" }` — never the matched path, no logging, no serialization of evidence.
+
+10. **Derive from privacy-filtered harness data, not raw `harnessData`.** Public report responses already filter hidden harness fields server-side (filter-report-response.ts:50). The new `setup-suggestions` endpoint must select `hiddenHarnessSections` and run `stripHiddenHarnessData` BEFORE deriving — `harnessFiles` and `mcpServers` are both hideable (harness-section-visibility.ts:10).
+
+11. **MCP privacy understated.** Plan implies surfacing only key names = no PII (plan:287). Project research marks MCP server names as potentially project-specific (review-step-design.md:24, :87 — medium risk). Keep per-field confirmation; add UI copy: "Review names before publishing."
+
+12. **`packageManager` is a cheap missed derivation.** `HarnessData.cliTools` (insights.ts:237). If `pnpm`/`npm`/`yarn`/`bun`/`uv`/`pip`/`cargo`/`go` appears, suggest with same opt-in flow.
+
+### UI
+
+13. **In-page edit form is right for v1.** `ProfileEditForm` already in `src/app/[username]/page.tsx:139`, toggled inline at line 417. A separate /settings page only justified once non-public settings or much larger form.
+
+14. **Place `SetupCard` below header/bio, full-width.** Header is flex layout around avatar (page.tsx:401). Long machine/model/MCP values wrap more predictably in a full-width block before "Shared Reports" (page.tsx:480).
+
+15. **Public API filtering not needed if all setup fields are intentionally public** — but API normalization still required (see #3).
+
+16. **Add explicit UI states for suggestions.** Plan describes happy path only (plan:265). Missing: no harness reports, suggestions unavailable, loading, failed fetch, "already applied."
+
+### Migration & verification
+
+17. **Migration low-risk.** Model already uses several nullable `Json?` columns (schema.prisma:53). Use a full timestamped migration directory matching the existing `20260413003102_slug_per_user_unique` style — NOT the shorter `20260413_add_user_setup` shown in the plan (plan:123).
+
+18. **Verification commands wrong.** No `typecheck` or `test` scripts in `package.json:5`. Use `npx tsc --noEmit` and `npx vitest run` (or add scripts).
+
+## Defaults — Codex agrees with
+
+- JSON column on User
+- New `src/types/profile.ts`
+- Under-bio / full-width layout
+- Comma-separated MCP input for v1
+- `version: 1` baked into blob
+- No separate /settings page for v1
+
+## Conditional agreement
+
+- `setupUpdatedAt` in the blob: fine for display-only, but server-owned and updated only when normalized setup actually changes. If sorting/filtering by freshness becomes likely later, make it a real column instead.

--- a/docs/plans/2026-04-13-profile-setup-fields.md
+++ b/docs/plans/2026-04-13-profile-setup-fields.md
@@ -1,0 +1,440 @@
+# Developer Setup Fields for User Profiles
+
+**Date:** 2026-04-13
+**Status:** Plan — revised 2026-04-13 after codex review (see [`2026-04-13-profile-setup-fields-codex-review.md`](./2026-04-13-profile-setup-fields-codex-review.md))
+**Scope:** Add a public "what's your setup" section to user profiles (uses.tech-style).
+
+> **Revisions folded in from codex review:**
+>
+> - Validation runs on BOTH read and write paths (defense in depth)
+> - `version: 1` and server-owned `setupUpdatedAt` baked into the type
+> - `primaryModel` derives from `perModelTokens` (token share) not `models` (message count)
+> - `packageManager` added as a 4th auto-derived field (from `harnessData.cliTools`)
+> - OS heuristic returns only `{ os: "..." }`, never the matched path
+> - Auto-derive runs on `stripHiddenHarnessData(...)` output, never raw
+> - Migration uses full timestamp directory matching existing convention
+> - Verification commands fixed (`npx tsc --noEmit`, `npx vitest run` — no `typecheck` / `test` scripts exist in `package.json`)
+> - Suggestion UI states defined: loading / no-reports / unavailable / failed / already-applied
+> - Prisma null handling specified (`Prisma.JsonNull` vs `Prisma.DbNull`)
+
+## Goals
+
+- Enrich the public profile with optional, freeform "workstation" fields so it reads like a developer's uses-page, not just a stats dashboard.
+- Ship a small v1 quickly (8–12 fields) with high fill-in rate and autosuggest from uploaded harness data.
+- Keep storage dumb and display-only — no querying, no analytics on these fields.
+
+## Non-Goals (v1)
+
+- No public directory / search over setup fields.
+- No icon library for every tool (just a handful of curated ones).
+- No strict enums — tools churn, free text wins.
+
+---
+
+## 1. v1 Field List (11 fields)
+
+Grouped by category. Every field is optional.
+
+### Hardware (3)
+
+| Field      | Input                                                                | Why                                                                                                                                          |
+| ---------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `os`       | single-select autosuggest (macOS / Linux / Windows / WSL + freeform) | Everyone knows theirs. Can be **auto-derived** from `harnessData` cwd paths + `versions` strings (e.g. `/Users/` → macOS, `/home/` → Linux). |
+| `machine`  | free text                                                            | "M4 Max MBP 64GB", "Framework 13", "Desktop I built". High brag factor.                                                                      |
+| `keyboard` | free text                                                            | Keyboard tribalism is real. Instant "ooh same".                                                                                              |
+
+### Editor & Terminal (3)
+
+| Field      | Input                                                                                          | Why                |
+| ---------- | ---------------------------------------------------------------------------------------------- | ------------------ |
+| `editor`   | autosuggest (VS Code, Cursor, Zed, Neovim, JetBrains family, Windsurf, …)                      | Universal opinion. |
+| `terminal` | autosuggest (Ghostty, iTerm2, Warp, Alacritty, Kitty, WezTerm, Terminal.app, Windows Terminal) | Same.              |
+| `shell`    | autosuggest (zsh, bash, fish, nushell, PowerShell)                                             | Short, universal.  |
+
+### AI Coding Stack (3, mostly auto-derived)
+
+| Field          | Input                                                         | Why                                                                                                             |
+| -------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `primaryAgent` | autosuggest (Claude Code, Codex, Cursor Agent, Aider, Amp, …) | Defaults to "Claude Code" since they uploaded a harness report; still editable.                                 |
+| `primaryModel` | free text w/ suggestions                                      | **Auto-derived** from `harnessData.perModelTokens` (token share) with `harnessData.models` (count) as fallback. |
+| `mcpServers`   | multi-chip free text                                          | **Auto-derived** from `harnessData.mcpServers` keys. Huge "what's that?" factor.                                |
+
+### Workflow (2)
+
+| Field            | Input                                                           | Why                                                                                                             |
+| ---------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `packageManager` | autosuggest (pnpm, npm, yarn, bun, uv, pip, cargo, go, mise, …) | **Auto-derived** from `harnessData.cliTools` — match against the known package-manager set, pick highest-count. |
+| `dotfilesUrl`    | URL                                                             | Classic uses-page flex; trivial to validate (reuse `isValidUrl`).                                               |
+
+**Total: 11 fields.** Tight, high fill-in rate, **four auto-derivable** (primaryAgent, primaryModel, mcpServers, packageManager).
+
+---
+
+## 2. v2 Field List
+
+Punt these until v1 has fill-in-rate data:
+
+- **Hardware:** `display` (monitor setup), `mouse` (trackball/trackpad), `headphones`, `chair`, `drink`.
+- **Editor & Terminal:** `multiplexer` (tmux/Zellij), `editorFont`, `colorTheme`.
+- **AI:** `secondaryAgent`, `notableHarnessCustomizations` (auto-derived from hook definitions / plugin list — richer, more privacy review needed).
+- **Workflow:** `containers` (Docker/OrbStack/Podman), `gitClient` (CLI/Tower/Fork), `noteTaking` (Obsidian/Notion/…), `devBrowser`.
+- **Fun:** `dock` (what's pinned), free-form "random stuff on my desk".
+
+Justification for pushing: display/chair/headphones are fun but niche; multiplexer/font/theme are power-user-only; secondary-agent and notable-customizations require more auto-derivation logic to feel alive. Build the pattern first with v1, extend once.
+
+---
+
+## 3. Data Model
+
+### Current state (verified)
+
+`prisma/schema.prisma` line 12–31: `User` has `displayName`, `bio`, four URL fields. No setup-related columns. Uses PostgreSQL. Prisma migrations are applied via `prisma migrate deploy` (per project note).
+
+### Decision: single JSON column
+
+Add one nullable `Json` column to `User`:
+
+```
+setup Json?
+```
+
+Shape (TypeScript type, stored as loose JSON):
+
+```ts
+// src/types/profile.ts
+export const PROFILE_SETUP_VERSION = 1 as const;
+
+export interface ProfileSetup {
+  // Server-owned metadata (never accept from client; set/refresh in normalizeSetup):
+  version: typeof PROFILE_SETUP_VERSION;
+  setupUpdatedAt: string; // ISO-8601, refreshed only when normalized payload changes
+
+  // User fields (all optional, all freeform):
+  os?: string;
+  machine?: string;
+  keyboard?: string;
+  editor?: string;
+  terminal?: string;
+  shell?: string;
+  primaryAgent?: string;
+  primaryModel?: string;
+  mcpServers?: string[];
+  packageManager?: string;
+  dotfilesUrl?: string;
+}
+```
+
+`version` and `setupUpdatedAt` are **server-owned** — `normalizeSetup` always overwrites them. Client-supplied values for these two keys are ignored. `setupUpdatedAt` only refreshes when the normalized user-fields payload differs from what's already stored (avoid bumping the timestamp on no-op PUTs).
+
+**Why JSON, not a normalized `ProfileSetup` table:**
+
+- Display-only. No filtering, sorting, joining, or aggregation on these fields.
+- Schema will churn (v2 adds ~12 more fields, users will want custom ones eventually).
+- Type-safety lives in a TS type + a manual validator in the PUT handler, not in the DB.
+- One fewer join on the hot public profile fetch.
+
+**Trade-off acknowledged:** if we ever want "show me all devs using Ghostty", we'd need to backfill a table or use JSONB indexing. Accept that cost later.
+
+---
+
+## 4. Migration
+
+Follow project's "never reset" rule. Match the existing migration directory naming convention (full UTC timestamp, e.g. `20260413003102_slug_per_user_unique`) — **not** the shorter `20260413_add_user_setup` originally proposed.
+
+**File:** `prisma/migrations/<YYYYMMDDHHMMSS>_add_user_setup/migration.sql` (generate the timestamp with `date -u +%Y%m%d%H%M%S` at migration-create time).
+
+```sql
+ALTER TABLE "User" ADD COLUMN "setup" JSONB;
+```
+
+Then update `prisma/schema.prisma` to add `setup Json?` to the `User` model.
+
+**Verification:**
+
+```
+npx prisma validate
+npx prisma generate
+npx prisma migrate deploy   # against dev DB
+npx tsc --noEmit            # confirm Prisma client types compile
+```
+
+Note: `package.json` has no `typecheck` or `test` scripts — use `npx tsc --noEmit` and `npx vitest run` directly throughout this plan.
+
+---
+
+## 5. Edit UI
+
+### Current state (verified)
+
+The profile edit form lives **in-page** inside `src/app/[username]/page.tsx` as a `ProfileEditForm` component (lines 139–279). Toggled by an `editing` state (line 288). Saves via `PUT /api/users/me` (line 329). No separate settings page.
+
+### Plan
+
+Add a collapsible "Developer Setup" section to `ProfileEditForm` **below** the "Social Links" block (after line 253). Use a `<details>` element or a controlled `showSetup` toggle for consistency.
+
+Structure:
+
+```
+▸ Developer Setup (optional — shown publicly on your profile)
+   ─── Hardware ───
+     OS               [autosuggest input]
+     Machine          [text]
+     Keyboard         [text]
+   ─── Editor & Terminal ───
+     Editor/IDE       [autosuggest]
+     Terminal         [autosuggest]
+     Shell            [autosuggest]
+   ─── AI Stack ───
+     Primary agent    [autosuggest, default "Claude Code"]
+     Primary model    [text + suggestions]
+     MCP servers      [chip input]
+   ─── Workflow ───
+     Package manager  [autosuggest]
+     Dotfiles URL     [url]
+```
+
+**Autosuggest component:** use an `<input list="...">` + `<datalist>` — native, zero deps, free text allowed. Suggestion sources live in a new file `src/lib/profile-setup-suggestions.ts`:
+
+```ts
+export const OS_SUGGESTIONS = ["macOS", "Linux", "Windows", "WSL"];
+export const EDITOR_SUGGESTIONS = ["VS Code", "Cursor", "Zed", "Neovim", "JetBrains", "Windsurf", ...];
+// …
+```
+
+**MCP servers chip input:** comma-separated text → `string[]` on submit. Pre-filled from auto-derive (see §7).
+
+**Copy at top of section (privacy note):**
+
+> "These appear publicly on your profile. All fields optional — leave blank to hide."
+
+**State management:** extend `EditFormData` (currently at line 130) with a `setup: ProfileSetup` object. Serialize into the `PUT /api/users/me` body.
+
+### API changes
+
+**File:** `src/app/api/users/me/route.ts`
+
+- In `GET`, add `setup: true` to the Prisma `select` (line 30–40). **Run the result through `normalizeSetup` before returning** — defense in depth against malformed JSON from manual DB edits or stale shapes.
+- In `PUT`, accept `body.setup`, run through `normalizeSetup(raw, prevStored): ProfileSetup | null` (see helper below).
+- The current update accumulator is typed `Record<string, string | null>` (line 67) — widen to `Prisma.UserUpdateInput` (or a hand-typed superset) to allow the `Json | null` value. The "no valid fields" check (line 97) must accept "clear setup to null" as a valid update.
+- For Prisma JSON null handling: pass `Prisma.JsonNull` to clear the column (stores SQL `NULL`), not plain JS `null`. Pass `Prisma.DbNull` is wrong here. Document the choice inline.
+- Include `setup` in both the response `select` blocks (lines 30–40 and 107–117), normalized.
+
+**`normalizeSetup` helper:**
+
+New file: `src/lib/profile-setup-normalize.ts`. Pure function used on **every read and write path** (PUT body, GET response in `me` route, GET response in public `[username]` route, server-side render in setup card, derivation suggestion endpoint).
+
+Behavior:
+
+- Reject non-object input → returns `null`.
+- Strip unknown keys.
+- Trim all strings; coerce empty → undefined.
+- Validate `dotfilesUrl` via existing `isValidUrl` (drop on fail).
+- Cap each free-text field at 120 chars (truncate, don't reject).
+- Cap `mcpServers` array length at 20 and each string at 80 chars.
+- If every user field is undefined/empty after normalization → return `null` (clear blob).
+- Otherwise overwrite `version: PROFILE_SETUP_VERSION` and set `setupUpdatedAt`:
+  - If `prevStored` is provided AND the normalized user-field payload (excluding `setupUpdatedAt`) deep-equals `prevStored`'s user-field payload → preserve `prevStored.setupUpdatedAt` (no-op write).
+  - Otherwise set `setupUpdatedAt = new Date().toISOString()`.
+
+**File:** `src/app/api/users/[username]/route.ts` (public GET)
+
+- Add `setup: true` to Prisma select.
+- Normalize the result through `normalizeSetup` before returning. (Even though all fields are intentionally public, normalization prevents stale unknown keys leaking through if the type changes.)
+
+**Verification:**
+
+```
+npx tsc --noEmit
+npx vitest run profile-setup-normalize
+curl -X PUT -H 'content-type: application/json' \
+  -d '{"setup":{"editor":"Zed"}}' http://localhost:3000/api/users/me
+curl -X PUT -H 'content-type: application/json' \
+  -d '{"setup":null}' http://localhost:3000/api/users/me   # clears
+curl -s localhost:3000/api/users/me | jq '.data.setup'      # normalized
+```
+
+---
+
+## 6. Display UI
+
+### Current state (verified)
+
+Public profile rendering is in the same `src/app/[username]/page.tsx`, starting around line 398. `SocialLinks` (line 79–128) is the pattern to follow: render only non-empty links.
+
+### Plan: `SetupCard` component
+
+New file: `src/components/profile/SetupCard.tsx`.
+
+- Props: `setup: ProfileSetup | null`.
+- Short-circuit to `null` if the blob is null or every field is empty (prevents empty placeholder card).
+- Layout: **labeled rows, not icon grid**. Rationale:
+  - Fields are heterogeneous (URLs, chip lists, long strings like "M4 Max MBP 64GB"). Icon grid forces uniformity that doesn't fit.
+  - A two-column `dl` (label / value) scans fast and is trivial in Tailwind.
+  - Group headings: Hardware, Editor & Terminal, AI, Workflow. Only render a group if at least one field in it is present.
+  - Special rendering:
+    - `mcpServers`: render as chips.
+    - `dotfilesUrl`: render as external link with GitHub icon if host includes `github.com`, else generic globe.
+    - `os` / `editor` / `terminal`: optionally pair with a small lucide icon (Monitor, Code, TerminalSquare) but keep text-forward.
+
+**Mount point:** below the header/bio block (around `src/app/[username]/page.tsx:480`, before "Shared Reports"), full-width. The avatar+bio header is a flex layout (page.tsx:401) — long values like "M4 Max MBP 64GB" or chip lists wrap more predictably in a full-width block underneath than in a right rail.
+
+**Also update `src/app/api/users/[username]/route.ts`** (public GET) to include `setup` in its Prisma select, and `UserProfile` interface (line 38–64 of the page file) to add `setup?: ProfileSetup | null`.
+
+**Verification:**
+
+- Manually visit `/yourname` with an empty setup → no card renders.
+- Fill two fields via edit → only those two rows render, only their group heading renders.
+
+---
+
+## 7. Auto-Derivation Pass
+
+On the edit form's mount, pre-fill suggestions from the user's most recent uploaded report.
+
+### Source fields in `harnessData` (verified in `src/types/insights.ts` lines 225–250)
+
+- `harnessData.perModelTokens: Record<string, {input,output,cache_read,cache_create}>` → `primaryModel` = key with max `(input + output)`. **Falls back to** `harnessData.models` (count) if `perModelTokens` absent. Token share is a more honest "primary" signal than message count.
+- `harnessData.mcpServers: Record<string, number>` → `mcpServers` = array of keys, sorted by count desc, top N=8.
+- `harnessData.cliTools: Record<string, number>` → `packageManager` = first match in the known set `{pnpm, npm, yarn, bun, uv, pip, cargo, go, mise}`, picking the highest-count match if multiple.
+- **OS hint**: scan `harnessData.harnessFiles: string[]` + `harnessData.versions: string[]` for `/Users/` (macOS), `/home/` (Linux), `C:\` or `\\wsl$` (Windows/WSL). **The helper returns ONLY `{ os: "macOS" }` — never the matched path, never logs evidence, never serializes the source string.** Local file paths are classified as high-risk private data per `docs/research/review-step-design.md`.
+
+### Privacy filtering on the source side
+
+The derivation helper must operate on **privacy-filtered** harness data, not raw — `harnessFiles` and `mcpServers` are both hideable via `hiddenHarnessSections`. The suggestions endpoint must:
+
+1. Select `hiddenHarnessSections` alongside `harnessData` from the report.
+2. Run `stripHiddenHarnessData(harnessData, hiddenHarnessSections)` (existing helper in `src/lib/harness-section-visibility.ts`) to produce filtered data.
+3. Derive from the filtered output. If a section is hidden, the corresponding suggestion is simply absent — not an error.
+
+### Flow
+
+1. New API endpoint `GET /api/users/me/setup-suggestions` (new file: `src/app/api/users/me/setup-suggestions/route.ts`):
+   - Find `InsightReport` for the current user where `reportType = 'insight-harness'`, ordered by `createdAt desc`, take first.
+   - Pull `harnessData` JSON + `hiddenHarnessSections`. Normalize via `normalizeHarnessData`. Strip hidden sections via `stripHiddenHarnessData`.
+   - Derive `{ primaryAgent: "Claude Code", primaryModel?, mcpServers?, packageManager?, os? }` via `deriveSetupFromHarness(filtered)`.
+   - Return `{ status: "ok", suggestions: {...}, sourceReportId, sourceReportCreatedAt }` OR `{ status: "no-reports" }` (no insight-harness reports yet) OR `{ status: "no-suggestions" }` (report exists but every field came back empty).
+2. In `ProfileEditForm`, when the "Developer Setup" section is first expanded, fetch this endpoint. For each derived field that is currently empty in the form, render an inline `"Suggest: claude-sonnet-4-5 — use?"` chip that fills the field on click.
+   - For `mcpServers`: render the list with copy "Review names before publishing — server names can hint at private projects."
+   - **Do not auto-save; do not auto-fill inputs.** User confirms per field.
+3. If user already has `setup.primaryModel` set (etc.), don't suggest over it.
+
+### UI states for the suggestions panel
+
+| State                           | UI                                                                                 |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| loading                         | small spinner + "Looking at your latest harness report…"                           |
+| `status: "no-reports"`          | dimmed copy: "Upload a harness report to get setup suggestions." (link to /upload) |
+| `status: "no-suggestions"`      | dimmed copy: "No suggestions from your latest report." (no error tone)             |
+| `status: "ok"` with suggestions | inline "Suggest: X — use?" chips next to each empty field                          |
+| fetch failed                    | dimmed copy: "Couldn't load suggestions." (no error toast — non-critical)          |
+| field already filled            | suppress the chip for that field; if user clears the field later, re-show          |
+| chip clicked → field filled     | chip disappears; field updates dirty state for the form's save button              |
+
+### Helper file
+
+New: `src/lib/profile-setup-derive.ts` — pure function `deriveSetupFromHarness(harness: HarnessData): Partial<Pick<ProfileSetup, 'primaryAgent' | 'primaryModel' | 'mcpServers' | 'packageManager' | 'os'>>`. Unit-tested independently. Never returns paths or other evidence.
+
+**Verification:**
+
+```
+npx vitest run profile-setup-derive
+```
+
+Test cases:
+
+- empty harness → `{}`
+- harness with only `models` (no `perModelTokens`) → primaryModel from count fallback
+- harness with `perModelTokens` → primaryModel from token share (different from count winner)
+- harness with `mcpServers` → mcpServers array, top 8, sorted
+- harness with `cliTools` containing pnpm + npm → packageManager = highest-count match
+- Windows-path `harnessFiles` → os: "Windows", **no path returned in result**
+- Linux-path `versions` → os: "Linux"
+- harness with `mcpServers` filtered out by `stripHiddenHarnessData` → no mcpServers suggestion
+
+---
+
+## 8. Privacy
+
+- Copy at the top of the Setup section in the edit form: "These appear publicly on your profile. Leave blank to hide."
+- Above the MCP servers field specifically: "Review names before publishing — server names can hint at private projects."
+- `SetupCard` never renders empty fields or empty groups, so blanks are truly invisible (not just "N/A").
+- `dotfilesUrl` runs through the same `isValidUrl` check used for social URLs (rejects non-http(s)).
+- **OS heuristic helper returns ONLY the label** (`{ os: "macOS" }`), never the matched path, never logs evidence, never includes the source string in the response. Test asserts the helper output contains no `/Users`, `/home`, `C:\` strings.
+- Auto-derivation runs on `stripHiddenHarnessData(...)` output, so any user-hidden harness section (e.g. mcpServers, harnessFiles) is also absent from suggestions.
+- API normalization runs on **read** paths too — old/malformed JSON from manual DB edits or version drift can't leak unknown keys through public endpoints.
+
+**Decision:** `setup` does NOT get a separate `setupVisible: boolean` flag. Blank-field semantics cover the use case. Add later if users ask.
+
+---
+
+## 9. Phased Rollout
+
+### Phase A — Schema, types, normalize helper
+
+1. Add `src/types/profile.ts` with `ProfileSetup`, `PROFILE_SETUP_VERSION`, the user-fields subset type used by the derive helper.
+2. Add `src/lib/profile-setup-normalize.ts` with `normalizeSetup(raw, prevStored?)`.
+3. Edit `prisma/schema.prisma` to add `setup Json?` on `User`.
+4. Create migration `prisma/migrations/<UTC-timestamp>_add_user_setup/migration.sql` (`ALTER TABLE "User" ADD COLUMN "setup" JSONB;`).
+5. Update `src/app/api/users/me/route.ts`: include `setup` in both `select` blocks; widen `updateData` accumulator type; accept+validate in PUT via `normalizeSetup`; allow "clear to null" as a valid update; use `Prisma.JsonNull` when clearing; normalize on read before returning.
+6. Update `src/app/api/users/[username]/route.ts` GET to include `setup` in select and run through `normalizeSetup` before returning.
+
+**Verify:**
+
+```
+npx prisma validate && npx prisma generate && npx prisma migrate deploy
+npx tsc --noEmit
+npx vitest run profile-setup-normalize
+curl -s localhost:3000/api/users/me | jq .data.setup   # null on a fresh user
+curl -s -X PUT -H 'content-type: application/json' \
+     -d '{"setup":{"editor":"Zed"}}' localhost:3000/api/users/me
+curl -s -X PUT -H 'content-type: application/json' \
+     -d '{"setup":null}' localhost:3000/api/users/me   # clears to null
+```
+
+### Phase B — Display
+
+7. Create `src/components/profile/SetupCard.tsx`.
+8. Wire into `src/app/[username]/page.tsx`: add `setup` to `UserProfile` interface, render `<SetupCard setup={profile.setup} />` below header/bio, full-width, before "Shared Reports".
+
+**Verify:** visual check `/your-username` with manually-seeded setup via the API. Confirm empty groups don't render. Confirm that an old/malformed setup blob (manually inserted) returns normalized output, not raw.
+
+### Phase C — Edit UI
+
+9. Extend `EditFormData` in `src/app/[username]/page.tsx` with `setup` object. Add a collapsible "Developer Setup" section to `ProfileEditForm`.
+10. Create `src/lib/profile-setup-suggestions.ts` with autosuggest arrays and wire up `<datalist>`.
+11. Quick `Grep` check first: is there an existing autosuggest component pattern in `src/components` to reuse, or is `<datalist>` the project's first use? If a pattern exists, follow it.
+
+**Verify:** edit a field, save, reload — persists and displays. Edit and clear all fields, save — `setup` returns to null in the GET response.
+
+### Phase D — Auto-derivation
+
+12. Create `src/lib/profile-setup-derive.ts` + tests (covering all cases listed in §7).
+13. Create `src/app/api/users/me/setup-suggestions/route.ts` — runs `stripHiddenHarnessData` before deriving.
+14. Wire suggestion chips + state machine (loading / no-reports / no-suggestions / ok / failed / applied) into the edit form.
+
+**Verify:** upload a harness report, open edit form, confirm suggestions appear and fill on click. Hide `mcpServers` on a report, refresh suggestions, confirm mcpServers suggestion is absent. Test the no-reports state on a fresh user.
+
+---
+
+## 10. Resolved Decisions
+
+1. **Layout:** `SetupCard` mounts below the header/bio block, full-width, before "Shared Reports".
+2. **Type location:** new file `src/types/profile.ts`.
+3. **`setupUpdatedAt`:** baked into the JSON blob, **server-owned only** — never accept from client; only refresh when the normalized user-fields payload actually changes.
+4. **MCP input UI:** comma-separated text → `string[]` for v1. Proper chip input deferred.
+5. **Schema version:** `version: 1` baked into the blob and the type alias `PROFILE_SETUP_VERSION`.
+6. **Autosuggest:** check for an existing generic component in Phase C step 11. If absent, use native `<input list>` + `<datalist>` for v1.
+
+## 11. Outstanding Open Questions
+
+None blocking implementation. v2 questions (sortable freshness column, search/filter over setup, chip input, v1→v2 schema migration) are tracked under §2.
+
+---
+
+### Critical Files for Implementation
+
+- /Users/craigdossantos/Coding/insightful/prisma/schema.prisma
+- /Users/craigdossantos/Coding/insightful/src/app/api/users/me/route.ts
+- /Users/craigdossantos/Coding/insightful/src/app/[username]/page.tsx
+- /Users/craigdossantos/Coding/insightful/src/app/api/users/[username]/route.ts
+- /Users/craigdossantos/Coding/insightful/src/types/insights.ts (HarnessData reference for auto-derive)

--- a/docs/plans/2026-04-13-profile-setup-fields.md
+++ b/docs/plans/2026-04-13-profile-setup-fields.md
@@ -6,16 +6,17 @@
 
 > **Revisions folded in from codex review:**
 >
-> - Validation runs on BOTH read and write paths (defense in depth)
+> - Validation runs on BOTH read and write paths (defense in depth), with `normalizeSetup(stored, stored)` on reads to preserve the persisted `setupUpdatedAt`
 > - `version: 1` and server-owned `setupUpdatedAt` baked into the type
-> - `primaryModel` derives from `perModelTokens` (token share) not `models` (message count)
+> - `primaryModel` derives from `perModelTokens` (active tokens = input+output, deliberately excluding cache) with `models` count as fallback
 > - `packageManager` added as a 4th auto-derived field (from `harnessData.cliTools`)
 > - OS heuristic returns only `{ os: "..." }`, never the matched path
 > - Auto-derive runs on `stripHiddenHarnessData(...)` output, never raw
+> - MCP privacy copy ("Review names before publishing…") added to the edit form
 > - Migration uses full timestamp directory matching existing convention
 > - Verification commands fixed (`npx tsc --noEmit`, `npx vitest run` — no `typecheck` / `test` scripts exist in `package.json`)
-> - Suggestion UI states defined: loading / no-reports / unavailable / failed / already-applied
-> - Prisma null handling specified (`Prisma.JsonNull` vs `Prisma.DbNull`)
+> - Suggestion UI states defined: loading / no-reports / no-suggestions / ok / failed / already-applied
+> - Prisma null handling: use `Prisma.DbNull` to clear to SQL NULL (NOT `Prisma.JsonNull`, which stores a JSON null literal)
 
 ## Goals
 
@@ -213,11 +214,11 @@ export const EDITOR_SUGGESTIONS = ["VS Code", "Cursor", "Zed", "Neovim", "JetBra
 
 **File:** `src/app/api/users/me/route.ts`
 
-- In `GET`, add `setup: true` to the Prisma `select` (line 30–40). **Run the result through `normalizeSetup` before returning** — defense in depth against malformed JSON from manual DB edits or stale shapes.
-- In `PUT`, accept `body.setup`, run through `normalizeSetup(raw, prevStored): ProfileSetup | null` (see helper below).
+- In `GET`, add `setup: true` to the Prisma `select` (line 30–40). **Run the result through `normalizeSetup(stored, stored)` before returning** — defense in depth against malformed JSON from manual DB edits or stale shapes. Passing `stored` as `prevStored` ensures a well-formed stored blob preserves its persisted `setupUpdatedAt` on every read (no thrash).
+- In `PUT`, accept `body.setup`, run through `normalizeSetup(raw, prevStored): ProfileSetup | null` (see helper below). `prevStored` is the user's currently persisted `setup` read earlier in the handler.
 - The current update accumulator is typed `Record<string, string | null>` (line 67) — widen to `Prisma.UserUpdateInput` (or a hand-typed superset) to allow the `Json | null` value. The "no valid fields" check (line 97) must accept "clear setup to null" as a valid update.
-- For Prisma JSON null handling: pass `Prisma.JsonNull` to clear the column (stores SQL `NULL`), not plain JS `null`. Pass `Prisma.DbNull` is wrong here. Document the choice inline.
-- Include `setup` in both the response `select` blocks (lines 30–40 and 107–117), normalized.
+- **For Prisma JSON null handling: pass `Prisma.DbNull` to clear the column to SQL `NULL`. Do NOT use `Prisma.JsonNull` (that stores a JSON `null` literal, which is NOT what we want). Do NOT pass plain JS `null`.** Document the choice inline. [Prisma docs](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#using-null-values).
+- Include `setup` in both the response `select` blocks (lines 30–40 and 107–117), normalized with `prevStored = stored`.
 
 **`normalizeSetup` helper:**
 
@@ -239,7 +240,7 @@ Behavior:
 **File:** `src/app/api/users/[username]/route.ts` (public GET)
 
 - Add `setup: true` to Prisma select.
-- Normalize the result through `normalizeSetup` before returning. (Even though all fields are intentionally public, normalization prevents stale unknown keys leaking through if the type changes.)
+- Normalize via `normalizeSetup(stored, stored)` before returning (same pattern as the private GET — preserves the persisted `setupUpdatedAt`). Normalization prevents stale unknown keys leaking through if the type changes.
 
 **Verification:**
 
@@ -293,7 +294,7 @@ On the edit form's mount, pre-fill suggestions from the user's most recent uploa
 
 ### Source fields in `harnessData` (verified in `src/types/insights.ts` lines 225–250)
 
-- `harnessData.perModelTokens: Record<string, {input,output,cache_read,cache_create}>` → `primaryModel` = key with max `(input + output)`. **Falls back to** `harnessData.models` (count) if `perModelTokens` absent. Token share is a more honest "primary" signal than message count.
+- `harnessData.perModelTokens: Record<string, {input,output,cache_read,cache_create}>` → `primaryModel` = key with max **active tokens** (`input + output`, deliberately excluding cache reads/creates — cache traffic distorts the "primary" signal toward whichever model happened to inherit long cached context, which isn't what "primary model" should mean). **Falls back to** `harnessData.models` (message count) if `perModelTokens` absent.
 - `harnessData.mcpServers: Record<string, number>` → `mcpServers` = array of keys, sorted by count desc, top N=8.
 - `harnessData.cliTools: Record<string, number>` → `packageManager` = first match in the known set `{pnpm, npm, yarn, bun, uv, pip, cargo, go, mise}`, picking the highest-count match if multiple.
 - **OS hint**: scan `harnessData.harnessFiles: string[]` + `harnessData.versions: string[]` for `/Users/` (macOS), `/home/` (Linux), `C:\` or `\\wsl$` (Windows/WSL). **The helper returns ONLY `{ os: "macOS" }` — never the matched path, never logs evidence, never serializes the source string.** Local file paths are classified as high-risk private data per `docs/research/review-step-design.md`.

--- a/prisma/migrations/20260413201603_add_user_setup/migration.sql
+++ b/prisma/migrations/20260413201603_add_user_setup/migration.sql
@@ -1,0 +1,4 @@
+-- Add optional JSON blob to User for the "developer setup" profile fields
+-- (OS, editor, terminal, primary model, MCP servers, etc.). Display-only.
+-- See docs/plans/2026-04-13-profile-setup-fields.md.
+ALTER TABLE "User" ADD COLUMN "setup" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   twitterUrl  String?
   linkedinUrl String?
   websiteUrl  String?
+  setup       Json?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -238,6 +238,7 @@ function SetupInput({
   placeholder,
   inputClass,
   type = "text",
+  suggestion,
 }: {
   label: string;
   value: string;
@@ -247,7 +248,11 @@ function SetupInput({
   placeholder?: string;
   inputClass: string;
   type?: "text" | "url";
+  /** Auto-derived hint to show as a click-to-fill chip. Only renders when
+   *  the field is currently empty. */
+  suggestion?: string;
 }) {
+  const showChip = suggestion && !value.trim();
   return (
     <div>
       <label className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">
@@ -268,8 +273,35 @@ function SetupInput({
           ))}
         </datalist>
       ) : null}
+      {showChip ? (
+        <button
+          type="button"
+          onClick={() => onChange(suggestion)}
+          className="mt-1 inline-flex items-center gap-1 rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300"
+          title="Click to fill from your latest harness report"
+        >
+          <span>Suggest:</span>
+          <span className="font-mono">{suggestion}</span>
+        </button>
+      ) : null}
     </div>
   );
+}
+
+type SuggestionsState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ok"; suggestions: DerivedProfileSuggestions }
+  | { status: "no-reports" }
+  | { status: "no-suggestions" }
+  | { status: "failed" };
+
+interface DerivedProfileSuggestions {
+  primaryAgent?: string;
+  primaryModel?: string;
+  mcpServers?: string[];
+  packageManager?: string;
+  os?: string;
 }
 
 function ProfileEditForm({
@@ -297,9 +329,49 @@ function ProfileEditForm({
     // not exploring. Default-closed for empty-setup first-timers.
     return Boolean(profile.setup);
   });
+  const [suggestState, setSuggestState] = useState<SuggestionsState>({
+    status: "idle",
+  });
 
   const updateSetup = (patch: Partial<EditFormSetup>) =>
     setForm((f) => ({ ...f, setup: { ...f.setup, ...patch } }));
+
+  // Fetch auto-derived suggestions once the Developer Setup section is first
+  // expanded. Keeps us off the network until the user opts in, and prevents
+  // re-fetching on every toggle.
+  useEffect(() => {
+    if (!setupOpen) return;
+    if (suggestState.status !== "idle") return;
+
+    let cancelled = false;
+    setSuggestState({ status: "loading" });
+    fetch("/api/users/me/setup-suggestions")
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((json) => {
+        if (cancelled) return;
+        if (json.status === "ok") {
+          setSuggestState({ status: "ok", suggestions: json.suggestions });
+        } else if (json.status === "no-reports") {
+          setSuggestState({ status: "no-reports" });
+        } else {
+          setSuggestState({ status: "no-suggestions" });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSuggestState({ status: "failed" });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [setupOpen, suggestState.status]);
+
+  const suggestions =
+    suggestState.status === "ok" ? suggestState.suggestions : undefined;
+  const mcpSuggestion = suggestions?.mcpServers?.join(", ");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -417,6 +489,33 @@ function ProfileEditForm({
               to hide.
             </p>
 
+            {suggestState.status === "loading" && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                Looking at your latest harness report…
+              </p>
+            )}
+            {suggestState.status === "no-reports" && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                <Link
+                  href="/upload"
+                  className="underline hover:text-slate-600 dark:hover:text-slate-300"
+                >
+                  Upload a harness report
+                </Link>{" "}
+                to get setup suggestions.
+              </p>
+            )}
+            {suggestState.status === "no-suggestions" && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                No suggestions from your latest report.
+              </p>
+            )}
+            {suggestState.status === "failed" && (
+              <p className="text-xs text-slate-400 dark:text-slate-500">
+                Couldn&apos;t load suggestions.
+              </p>
+            )}
+
             <SetupGroup title="Hardware">
               <SetupInput
                 label="OS"
@@ -426,6 +525,7 @@ function ProfileEditForm({
                 options={OS_SUGGESTIONS}
                 placeholder="macOS"
                 inputClass={inputClass}
+                suggestion={suggestions?.os}
               />
               <SetupInput
                 label="Machine"
@@ -482,6 +582,7 @@ function ProfileEditForm({
                 options={PRIMARY_AGENT_SUGGESTIONS}
                 placeholder="Claude Code"
                 inputClass={inputClass}
+                suggestion={suggestions?.primaryAgent}
               />
               <SetupInput
                 label="Primary model"
@@ -491,6 +592,7 @@ function ProfileEditForm({
                 options={PRIMARY_MODEL_SUGGESTIONS}
                 placeholder="claude-sonnet-4"
                 inputClass={inputClass}
+                suggestion={suggestions?.primaryModel}
               />
               <div>
                 <label className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">
@@ -510,6 +612,17 @@ function ProfileEditForm({
                 <p className="mt-1 text-[11px] text-slate-400">
                   Comma-separated.
                 </p>
+                {mcpSuggestion && !form.setup.mcpServers.trim() ? (
+                  <button
+                    type="button"
+                    onClick={() => updateSetup({ mcpServers: mcpSuggestion })}
+                    className="mt-1 inline-flex items-center gap-1 rounded border border-blue-200 bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 transition-colors hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300"
+                    title="Click to fill from your latest harness report"
+                  >
+                    <span>Suggest:</span>
+                    <span className="font-mono">{mcpSuggestion}</span>
+                  </button>
+                ) : null}
               </div>
             </SetupGroup>
 
@@ -522,6 +635,7 @@ function ProfileEditForm({
                 options={PACKAGE_MANAGER_SUGGESTIONS}
                 placeholder="pnpm"
                 inputClass={inputClass}
+                suggestion={suggestions?.packageManager}
               />
               <SetupInput
                 label="Dotfiles URL"

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -17,7 +17,9 @@ import {
   Trash2,
 } from "lucide-react";
 import InsightCard from "@/components/InsightCard";
+import SetupCard from "@/components/profile/SetupCard";
 import { buildReportApiUrl, buildReportEditUrl } from "@/lib/urls";
+import type { ProfileSetup } from "@/types/profile";
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -44,6 +46,7 @@ interface UserProfile {
   twitterUrl?: string | null;
   linkedinUrl?: string | null;
   websiteUrl?: string | null;
+  setup?: ProfileSetup | null;
   createdAt: string;
   totalReports: number;
   totalVotes: number;
@@ -476,6 +479,9 @@ export default function UserProfilePage() {
           )}
         </div>
       </div>
+
+      {/* Developer Setup (only renders when non-empty) */}
+      <SetupCard setup={profile.setup} />
 
       {/* Reports */}
       <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">

--- a/src/app/[username]/page.tsx
+++ b/src/app/[username]/page.tsx
@@ -20,6 +20,15 @@ import InsightCard from "@/components/InsightCard";
 import SetupCard from "@/components/profile/SetupCard";
 import { buildReportApiUrl, buildReportEditUrl } from "@/lib/urls";
 import type { ProfileSetup } from "@/types/profile";
+import {
+  OS_SUGGESTIONS,
+  EDITOR_SUGGESTIONS,
+  TERMINAL_SUGGESTIONS,
+  SHELL_SUGGESTIONS,
+  PRIMARY_AGENT_SUGGESTIONS,
+  PRIMARY_MODEL_SUGGESTIONS,
+  PACKAGE_MANAGER_SUGGESTIONS,
+} from "@/lib/profile-setup-suggestions";
 
 function GithubIcon({ className }: { className?: string }) {
   return (
@@ -130,6 +139,21 @@ function SocialLinks({
   );
 }
 
+interface EditFormSetup {
+  os: string;
+  machine: string;
+  keyboard: string;
+  editor: string;
+  terminal: string;
+  shell: string;
+  primaryAgent: string;
+  primaryModel: string;
+  /** Comma-separated string in the form; split into string[] on submit. */
+  mcpServers: string;
+  packageManager: string;
+  dotfilesUrl: string;
+}
+
 interface EditFormData {
   displayName: string;
   bio: string;
@@ -137,6 +161,115 @@ interface EditFormData {
   twitterUrl: string;
   linkedinUrl: string;
   websiteUrl: string;
+  setup: EditFormSetup;
+}
+
+const EMPTY_SETUP_FORM: EditFormSetup = {
+  os: "",
+  machine: "",
+  keyboard: "",
+  editor: "",
+  terminal: "",
+  shell: "",
+  primaryAgent: "",
+  primaryModel: "",
+  mcpServers: "",
+  packageManager: "",
+  dotfilesUrl: "",
+};
+
+function setupToForm(setup: ProfileSetup | null | undefined): EditFormSetup {
+  if (!setup) return EMPTY_SETUP_FORM;
+  return {
+    os: setup.os ?? "",
+    machine: setup.machine ?? "",
+    keyboard: setup.keyboard ?? "",
+    editor: setup.editor ?? "",
+    terminal: setup.terminal ?? "",
+    shell: setup.shell ?? "",
+    primaryAgent: setup.primaryAgent ?? "",
+    primaryModel: setup.primaryModel ?? "",
+    mcpServers: setup.mcpServers?.join(", ") ?? "",
+    packageManager: setup.packageManager ?? "",
+    dotfilesUrl: setup.dotfilesUrl ?? "",
+  };
+}
+
+/** Convert the flat form state into the payload the PUT endpoint expects. */
+function formSetupToPayload(
+  form: EditFormSetup,
+): Record<string, string | string[]> {
+  const payload: Record<string, string | string[]> = {};
+  for (const [key, value] of Object.entries(form)) {
+    if (key === "mcpServers") continue;
+    if (value && value.trim()) payload[key] = value.trim();
+  }
+  const mcpList = form.mcpServers
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (mcpList.length > 0) payload.mcpServers = mcpList;
+  return payload;
+}
+
+function SetupGroup({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-500">
+        {title}
+      </h4>
+      <div className="space-y-2">{children}</div>
+    </div>
+  );
+}
+
+function SetupInput({
+  label,
+  value,
+  onChange,
+  listId,
+  options,
+  placeholder,
+  inputClass,
+  type = "text",
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  listId?: string;
+  options?: readonly string[];
+  placeholder?: string;
+  inputClass: string;
+  type?: "text" | "url";
+}) {
+  return (
+    <div>
+      <label className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">
+        {label}
+      </label>
+      <input
+        type={type}
+        list={listId}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className={inputClass}
+      />
+      {listId && options ? (
+        <datalist id={listId}>
+          {options.map((opt) => (
+            <option key={opt} value={opt} />
+          ))}
+        </datalist>
+      ) : null}
+    </div>
+  );
 }
 
 function ProfileEditForm({
@@ -155,9 +288,18 @@ function ProfileEditForm({
     twitterUrl: profile.twitterUrl ?? "",
     linkedinUrl: profile.linkedinUrl ?? "",
     websiteUrl: profile.websiteUrl ?? "",
+    setup: setupToForm(profile.setup),
   });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [setupOpen, setSetupOpen] = useState(() => {
+    // Default-open when the user already has setup content — they're editing,
+    // not exploring. Default-closed for empty-setup first-timers.
+    return Boolean(profile.setup);
+  });
+
+  const updateSetup = (patch: Partial<EditFormSetup>) =>
+    setForm((f) => ({ ...f, setup: { ...f.setup, ...patch } }));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -255,6 +397,145 @@ function ProfileEditForm({
         </div>
       </div>
 
+      <div className="border-t border-slate-200 pt-4 dark:border-slate-700">
+        <button
+          type="button"
+          onClick={() => setSetupOpen((v) => !v)}
+          className="flex w-full items-center justify-between text-left"
+        >
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Developer Setup
+          </h3>
+          <span className="text-xs text-slate-400">
+            {setupOpen ? "Hide" : "Show"}
+          </span>
+        </button>
+        {setupOpen && (
+          <div className="mt-3 space-y-4">
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Optional. All fields appear publicly on your profile — leave blank
+              to hide.
+            </p>
+
+            <SetupGroup title="Hardware">
+              <SetupInput
+                label="OS"
+                value={form.setup.os}
+                onChange={(os) => updateSetup({ os })}
+                listId="suggest-os"
+                options={OS_SUGGESTIONS}
+                placeholder="macOS"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Machine"
+                value={form.setup.machine}
+                onChange={(machine) => updateSetup({ machine })}
+                placeholder="M4 Max MBP, 64GB"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Keyboard"
+                value={form.setup.keyboard}
+                onChange={(keyboard) => updateSetup({ keyboard })}
+                placeholder="HHKB, split ergo, stock…"
+                inputClass={inputClass}
+              />
+            </SetupGroup>
+
+            <SetupGroup title="Editor & Terminal">
+              <SetupInput
+                label="Editor / IDE"
+                value={form.setup.editor}
+                onChange={(editor) => updateSetup({ editor })}
+                listId="suggest-editor"
+                options={EDITOR_SUGGESTIONS}
+                placeholder="VS Code"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Terminal"
+                value={form.setup.terminal}
+                onChange={(terminal) => updateSetup({ terminal })}
+                listId="suggest-terminal"
+                options={TERMINAL_SUGGESTIONS}
+                placeholder="Ghostty"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Shell"
+                value={form.setup.shell}
+                onChange={(shell) => updateSetup({ shell })}
+                listId="suggest-shell"
+                options={SHELL_SUGGESTIONS}
+                placeholder="zsh"
+                inputClass={inputClass}
+              />
+            </SetupGroup>
+
+            <SetupGroup title="AI Stack">
+              <SetupInput
+                label="Primary agent"
+                value={form.setup.primaryAgent}
+                onChange={(primaryAgent) => updateSetup({ primaryAgent })}
+                listId="suggest-primary-agent"
+                options={PRIMARY_AGENT_SUGGESTIONS}
+                placeholder="Claude Code"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Primary model"
+                value={form.setup.primaryModel}
+                onChange={(primaryModel) => updateSetup({ primaryModel })}
+                listId="suggest-primary-model"
+                options={PRIMARY_MODEL_SUGGESTIONS}
+                placeholder="claude-sonnet-4"
+                inputClass={inputClass}
+              />
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-500 dark:text-slate-400">
+                  MCP servers
+                  <span className="ml-2 font-normal text-slate-400">
+                    Review names before publishing — server names can hint at
+                    private projects.
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  value={form.setup.mcpServers}
+                  onChange={(e) => updateSetup({ mcpServers: e.target.value })}
+                  placeholder="serena, playwright, supabase"
+                  className={inputClass}
+                />
+                <p className="mt-1 text-[11px] text-slate-400">
+                  Comma-separated.
+                </p>
+              </div>
+            </SetupGroup>
+
+            <SetupGroup title="Workflow">
+              <SetupInput
+                label="Package manager"
+                value={form.setup.packageManager}
+                onChange={(packageManager) => updateSetup({ packageManager })}
+                listId="suggest-package-manager"
+                options={PACKAGE_MANAGER_SUGGESTIONS}
+                placeholder="pnpm"
+                inputClass={inputClass}
+              />
+              <SetupInput
+                label="Dotfiles URL"
+                value={form.setup.dotfilesUrl}
+                onChange={(dotfilesUrl) => updateSetup({ dotfilesUrl })}
+                placeholder="https://github.com/you/dotfiles"
+                type="url"
+                inputClass={inputClass}
+              />
+            </SetupGroup>
+          </div>
+        )}
+      </div>
+
       {error && (
         <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
       )}
@@ -330,10 +611,23 @@ export default function UserProfilePage() {
   }, [username]);
 
   const handleSave = async (data: EditFormData) => {
+    const setupPayload = formSetupToPayload(data.setup);
+    const body = {
+      displayName: data.displayName,
+      bio: data.bio,
+      githubUrl: data.githubUrl,
+      twitterUrl: data.twitterUrl,
+      linkedinUrl: data.linkedinUrl,
+      websiteUrl: data.websiteUrl,
+      // Explicit null clears the column; otherwise the normalized object is
+      // sent as-is and the server handles shape validation.
+      setup: Object.keys(setupPayload).length > 0 ? setupPayload : null,
+    };
+
     const res = await fetch("/api/users/me", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(data),
+      body: JSON.stringify(body),
     });
 
     if (!res.ok) {
@@ -354,6 +648,7 @@ export default function UserProfilePage() {
             twitterUrl: updated.twitterUrl,
             linkedinUrl: updated.linkedinUrl,
             websiteUrl: updated.websiteUrl,
+            setup: updated.setup ?? null,
           }
         : prev,
     );

--- a/src/app/api/users/[username]/route.ts
+++ b/src/app/api/users/[username]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { normalizeSetup } from "@/lib/profile-setup-normalize";
 
 export async function GET(
   request: Request,
@@ -20,6 +21,7 @@ export async function GET(
         twitterUrl: true,
         linkedinUrl: true,
         websiteUrl: true,
+        setup: true,
         createdAt: true,
         reports: {
           orderBy: { publishedAt: "desc" },
@@ -89,6 +91,9 @@ export async function GET(
         twitterUrl: user.twitterUrl,
         linkedinUrl: user.linkedinUrl,
         websiteUrl: user.websiteUrl,
+        // Pass `setup` as both raw + prevStored so a well-formed stored blob
+        // preserves its persisted `setupUpdatedAt` across reads (plan §5).
+        setup: normalizeSetup(user.setup, user.setup),
         createdAt: user.createdAt,
         totalReports: user.reports.length,
         totalVotes,

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { normalizeSetup } from "@/lib/profile-setup-normalize";
 
 const URL_FIELDS = [
   "githubUrl",
@@ -8,6 +10,19 @@ const URL_FIELDS = [
   "linkedinUrl",
   "websiteUrl",
 ] as const;
+
+const USER_SELECT = {
+  id: true,
+  username: true,
+  displayName: true,
+  avatarUrl: true,
+  bio: true,
+  githubUrl: true,
+  twitterUrl: true,
+  linkedinUrl: true,
+  websiteUrl: true,
+  setup: true,
+} as const;
 
 function isValidUrl(value: string): boolean {
   try {
@@ -27,24 +42,18 @@ export async function GET() {
 
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
-      select: {
-        id: true,
-        username: true,
-        displayName: true,
-        avatarUrl: true,
-        bio: true,
-        githubUrl: true,
-        twitterUrl: true,
-        linkedinUrl: true,
-        websiteUrl: true,
-      },
+      select: USER_SELECT,
     });
 
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    return NextResponse.json({ data: user });
+    // Pass `setup` as both `raw` and `prevStored` so a well-formed stored
+    // blob preserves its persisted `setupUpdatedAt` on every read (plan §5).
+    return NextResponse.json({
+      data: { ...user, setup: normalizeSetup(user.setup, user.setup) },
+    });
   } catch (error) {
     console.error("GET /api/users/me error:", error);
     return NextResponse.json(
@@ -64,7 +73,9 @@ export async function PUT(request: Request) {
     const body = await request.json();
     const { displayName, bio } = body;
 
-    const updateData: Record<string, string | null> = {};
+    // Widened from `Record<string, string | null>` so `setup` (Json | DbNull)
+    // can land in the same accumulator.
+    const updateData: Prisma.UserUpdateInput = {};
 
     if (displayName !== undefined) {
       updateData.displayName =
@@ -94,7 +105,27 @@ export async function PUT(request: Request) {
       }
     }
 
-    if (Object.keys(updateData).length === 0) {
+    // Accept `setup` as an object (fields to set), explicit `null` (clear), or
+    // omitted (leave alone). normalizeSetup collapses empty-user-fields to
+    // null too. Prisma null handling: use `Prisma.DbNull` to store SQL NULL.
+    // `Prisma.JsonNull` would persist a JSON null literal, which is NOT what
+    // we want. See plan §5 and
+    // https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/working-with-json-fields#using-null-values
+    let setupProvided = false;
+    if (body.setup !== undefined) {
+      setupProvided = true;
+      const prevStored = await prisma.user.findUnique({
+        where: { id: session.user.id },
+        select: { setup: true },
+      });
+      const normalized = normalizeSetup(body.setup, prevStored?.setup ?? null);
+      updateData.setup =
+        normalized === null
+          ? Prisma.DbNull
+          : (normalized as unknown as Prisma.InputJsonValue);
+    }
+
+    if (Object.keys(updateData).length === 0 && !setupProvided) {
       return NextResponse.json(
         { error: "No valid fields to update" },
         { status: 400 },
@@ -104,20 +135,12 @@ export async function PUT(request: Request) {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: updateData,
-      select: {
-        id: true,
-        username: true,
-        displayName: true,
-        avatarUrl: true,
-        bio: true,
-        githubUrl: true,
-        twitterUrl: true,
-        linkedinUrl: true,
-        websiteUrl: true,
-      },
+      select: USER_SELECT,
     });
 
-    return NextResponse.json({ data: user });
+    return NextResponse.json({
+      data: { ...user, setup: normalizeSetup(user.setup, user.setup) },
+    });
   } catch (error) {
     console.error("PUT /api/users/me error:", error);
     return NextResponse.json(

--- a/src/app/api/users/me/setup-suggestions/route.ts
+++ b/src/app/api/users/me/setup-suggestions/route.ts
@@ -1,0 +1,97 @@
+// GET /api/users/me/setup-suggestions
+//
+// Returns profile-setup field suggestions derived from the signed-in user's
+// most recent insight-harness report. The derive helper operates on
+// stripHiddenHarnessData output, so a user who has hidden (e.g.) mcpServers
+// on their report will not get mcpServers suggestions — honoring the
+// existing privacy model.
+//
+// primaryAgent is added here (not in derive) as the endpoint's static
+// default: every insight-harness report implies Claude Code as the primary
+// agent. Keeping it out of derive means an empty/stripped report can honestly
+// return { status: "no-suggestions" }.
+//
+// See docs/plans/2026-04-13-profile-setup-fields.md §7.
+
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { normalizeHarnessData } from "@/types/insights";
+import { stripHiddenHarnessData } from "@/lib/harness-section-visibility";
+import { deriveSetupFromHarness } from "@/lib/profile-setup-derive";
+import type { DerivedSetupFields } from "@/types/profile";
+
+type SuggestionsResponse =
+  | {
+      status: "ok";
+      suggestions: DerivedSetupFields;
+      sourceReportId: string;
+      sourceReportCreatedAt: string;
+    }
+  | { status: "no-reports" }
+  | { status: "no-suggestions" };
+
+export async function GET(): Promise<
+  NextResponse<SuggestionsResponse | { error: string }>
+> {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const report = await prisma.insightReport.findFirst({
+      where: { authorId: session.user.id, reportType: "insight-harness" },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        createdAt: true,
+        harnessData: true,
+        hiddenHarnessSections: true,
+      },
+    });
+
+    if (!report) {
+      return NextResponse.json({ status: "no-reports" });
+    }
+
+    const harness = normalizeHarnessData(report.harnessData);
+    if (!harness) {
+      // Report exists but its harnessData is malformed / legacy — treat as
+      // no-suggestions rather than error. This path is rare but defensible.
+      return NextResponse.json({ status: "no-suggestions" });
+    }
+
+    const filtered = stripHiddenHarnessData(
+      harness,
+      report.hiddenHarnessSections ?? [],
+    );
+    const derived = deriveSetupFromHarness(filtered);
+
+    const hasData = Object.keys(derived).length > 0;
+    if (!hasData) {
+      return NextResponse.json({ status: "no-suggestions" });
+    }
+
+    // Report exists AND has signal: primaryAgent is safe to suggest alongside
+    // derived fields. The UI suppresses any suggestion whose field is
+    // already filled by the user.
+    const suggestions: DerivedSetupFields = {
+      primaryAgent: "Claude Code",
+      ...derived,
+    };
+
+    return NextResponse.json({
+      status: "ok",
+      suggestions,
+      sourceReportId: report.id,
+      sourceReportCreatedAt: report.createdAt.toISOString(),
+    });
+  } catch (error) {
+    console.error("GET /api/users/me/setup-suggestions error:", error);
+    return NextResponse.json(
+      { error: "Failed to compute suggestions" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/profile/SetupCard.tsx
+++ b/src/components/profile/SetupCard.tsx
@@ -1,0 +1,207 @@
+// Renders a user's "developer setup" fields on their public profile.
+// Short-circuits to null when the blob has no user-visible content.
+// See docs/plans/2026-04-13-profile-setup-fields.md §6.
+
+import Link from "next/link";
+import {
+  Monitor,
+  Cpu,
+  Keyboard,
+  Code,
+  TerminalSquare,
+  Sparkles,
+  Package,
+  Globe,
+} from "lucide-react";
+
+function GithubGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+import type { ProfileSetup } from "@/types/profile";
+
+interface SetupCardProps {
+  setup: ProfileSetup | null | undefined;
+}
+
+type IconComponent = typeof Monitor;
+
+interface SetupRow {
+  key: keyof ProfileSetup;
+  label: string;
+  icon?: IconComponent;
+  value: string | string[] | undefined;
+}
+
+interface SetupGroup {
+  title: string;
+  rows: SetupRow[];
+}
+
+function buildGroups(setup: ProfileSetup): SetupGroup[] {
+  return [
+    {
+      title: "Hardware",
+      rows: [
+        { key: "os", label: "OS", icon: Monitor, value: setup.os },
+        { key: "machine", label: "Machine", icon: Cpu, value: setup.machine },
+        {
+          key: "keyboard",
+          label: "Keyboard",
+          icon: Keyboard,
+          value: setup.keyboard,
+        },
+      ],
+    },
+    {
+      title: "Editor & Terminal",
+      rows: [
+        { key: "editor", label: "Editor", icon: Code, value: setup.editor },
+        {
+          key: "terminal",
+          label: "Terminal",
+          icon: TerminalSquare,
+          value: setup.terminal,
+        },
+        { key: "shell", label: "Shell", value: setup.shell },
+      ],
+    },
+    {
+      title: "AI Stack",
+      rows: [
+        {
+          key: "primaryAgent",
+          label: "Primary agent",
+          icon: Sparkles,
+          value: setup.primaryAgent,
+        },
+        {
+          key: "primaryModel",
+          label: "Primary model",
+          value: setup.primaryModel,
+        },
+        {
+          key: "mcpServers",
+          label: "MCP servers",
+          value: setup.mcpServers,
+        },
+      ],
+    },
+    {
+      title: "Workflow",
+      rows: [
+        {
+          key: "packageManager",
+          label: "Package manager",
+          icon: Package,
+          value: setup.packageManager,
+        },
+        {
+          key: "dotfilesUrl",
+          label: "Dotfiles",
+          value: setup.dotfilesUrl,
+        },
+      ],
+    },
+  ];
+}
+
+function hasValue(v: string | string[] | undefined): boolean {
+  if (!v) return false;
+  if (Array.isArray(v)) return v.length > 0;
+  return v.trim().length > 0;
+}
+
+function renderValue(row: SetupRow) {
+  const { key, value } = row;
+  if (key === "mcpServers" && Array.isArray(value)) {
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {value.map((name) => (
+          <span
+            key={name}
+            className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800/60 dark:text-slate-300"
+          >
+            {name}
+          </span>
+        ))}
+      </div>
+    );
+  }
+  if (key === "dotfilesUrl" && typeof value === "string") {
+    const isGithub = value.includes("github.com");
+    return (
+      <Link
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 text-sm text-blue-600 hover:underline dark:text-blue-400"
+      >
+        {isGithub ? (
+          <GithubGlyph className="h-3.5 w-3.5" />
+        ) : (
+          <Globe className="h-3.5 w-3.5" />
+        )}
+        <span className="font-mono text-xs">
+          {value.replace(/^https?:\/\//, "")}
+        </span>
+      </Link>
+    );
+  }
+  return <span className="text-slate-800 dark:text-slate-200">{value}</span>;
+}
+
+export default function SetupCard({ setup }: SetupCardProps) {
+  if (!setup) return null;
+
+  const groups = buildGroups(setup)
+    .map((g) => ({ ...g, rows: g.rows.filter((r) => hasValue(r.value)) }))
+    .filter((g) => g.rows.length > 0);
+
+  if (groups.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Developer setup"
+      className="mb-8 rounded-lg border border-slate-200 bg-white px-5 py-4 dark:border-slate-700 dark:bg-slate-900/40"
+    >
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        Setup
+      </h2>
+      <div className="grid gap-x-8 gap-y-4 sm:grid-cols-2">
+        {groups.map((group) => (
+          <div key={group.title}>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              {group.title}
+            </h3>
+            <dl className="space-y-1.5">
+              {group.rows.map((row) => {
+                const Icon = row.icon;
+                return (
+                  <div
+                    key={row.key}
+                    className="grid grid-cols-[110px_1fr] items-start gap-3 text-sm"
+                  >
+                    <dt className="flex items-center gap-1.5 text-slate-500 dark:text-slate-400">
+                      {Icon ? <Icon className="h-3.5 w-3.5" /> : null}
+                      <span>{row.label}</span>
+                    </dt>
+                    <dd className="min-w-0">{renderValue(row)}</dd>
+                  </div>
+                );
+              })}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/__tests__/profile-setup-derive.test.ts
+++ b/src/lib/__tests__/profile-setup-derive.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import { deriveSetupFromHarness } from "../profile-setup-derive";
+import { stripHiddenHarnessData } from "../harness-section-visibility";
+import type { HarnessData } from "@/types/insights";
+
+function harness(partial: Partial<HarnessData>): HarnessData {
+  // Minimal-but-realistic HarnessData stub. Every field the derive helper
+  // reads is supplied through `partial`; unused fields get safe defaults.
+  return {
+    stats: {
+      totalTokens: 0,
+      sessionCount: 0,
+      messageCount: 0,
+      durationHours: 0,
+      avgSessionMinutes: 0,
+      commitCount: 0,
+      prCount: 0,
+    } as unknown as HarnessData["stats"],
+    autonomy: { label: "balanced" } as unknown as HarnessData["autonomy"],
+    featurePills: [],
+    toolUsage: {},
+    skillInventory: [],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      dominant: "write",
+    } as unknown as HarnessData["fileOpStyle"],
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      branchPrefixes: {},
+      totalBranches: 0,
+    } as unknown as HarnessData["gitPatterns"],
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "",
+    skillVersion: null,
+    ...partial,
+  };
+}
+
+describe("deriveSetupFromHarness", () => {
+  it("returns only primaryAgent for an empty harness", () => {
+    const out = deriveSetupFromHarness(harness({}));
+    expect(out).toEqual({ primaryAgent: "Claude Code" });
+  });
+
+  it("falls back to models (message count) when perModelTokens is absent", () => {
+    const out = deriveSetupFromHarness(
+      harness({ models: { "claude-sonnet-4": 100, "claude-opus-4": 30 } }),
+    );
+    expect(out.primaryModel).toBe("claude-sonnet-4");
+  });
+
+  it("prefers perModelTokens active tokens (input+output) over message count", () => {
+    // Opus wins by message count, but Sonnet does vastly more active work.
+    const out = deriveSetupFromHarness(
+      harness({
+        models: { "claude-opus-4": 100, "claude-sonnet-4": 50 },
+        perModelTokens: {
+          "claude-opus-4": {
+            input: 1_000,
+            output: 1_000,
+            cache_read: 0,
+            cache_create: 0,
+          },
+          "claude-sonnet-4": {
+            input: 10_000,
+            output: 10_000,
+            cache_read: 9_000_000, // a lot of cache — must be ignored
+            cache_create: 0,
+          },
+        },
+      }),
+    );
+    expect(out.primaryModel).toBe("claude-sonnet-4");
+  });
+
+  it("emits top-N mcpServers sorted by count desc", () => {
+    const mcpServers: Record<string, number> = {};
+    for (let i = 0; i < 12; i++) mcpServers[`server-${i}`] = 100 - i;
+    const out = deriveSetupFromHarness(harness({ mcpServers }));
+    expect(out.mcpServers?.length).toBe(8);
+    expect(out.mcpServers?.[0]).toBe("server-0");
+    expect(out.mcpServers?.[7]).toBe("server-7");
+  });
+
+  it("picks highest-count package manager from cliTools", () => {
+    const out = deriveSetupFromHarness(
+      harness({ cliTools: { pnpm: 200, npm: 50, git: 5_000, ls: 1_000 } }),
+    );
+    expect(out.packageManager).toBe("pnpm");
+  });
+
+  it("returns no packageManager when cliTools has none matching", () => {
+    const out = deriveSetupFromHarness(
+      harness({ cliTools: { git: 5_000, curl: 100, rg: 800 } }),
+    );
+    expect(out.packageManager).toBeUndefined();
+  });
+
+  it("detects Windows from harnessFiles paths WITHOUT returning the path", () => {
+    const winPath = "C:\\Users\\alice\\AppData\\Roaming\\something";
+    const out = deriveSetupFromHarness(harness({ harnessFiles: [winPath] }));
+    expect(out.os).toBe("Windows");
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("C:");
+    expect(serialized).not.toContain("alice");
+    expect(serialized).not.toContain("AppData");
+  });
+
+  it("detects Linux from versions strings", () => {
+    const out = deriveSetupFromHarness(
+      harness({ versions: ["node-22.1.0-linux-x64"] }),
+    );
+    expect(out.os).toBe("Linux");
+  });
+
+  it("detects macOS from harnessFiles user path", () => {
+    const out = deriveSetupFromHarness(
+      harness({ harnessFiles: ["/Users/craig/.claude/skills/foo"] }),
+    );
+    expect(out.os).toBe("macOS");
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("/Users");
+    expect(serialized).not.toContain("craig");
+  });
+
+  it("returns no os when no path-like evidence is present", () => {
+    const out = deriveSetupFromHarness(
+      harness({ harnessFiles: ["relative/path/without/marker.md"] }),
+    );
+    expect(out.os).toBeUndefined();
+  });
+
+  it("respects stripHiddenHarnessData: hidden mcpServers yields no suggestion", () => {
+    const full = harness({
+      mcpServers: { serena: 5, playwright: 2 },
+      cliTools: { pnpm: 10 },
+    });
+    const filtered = stripHiddenHarnessData(full, ["mcpServers"]);
+    const out = deriveSetupFromHarness(filtered);
+    expect(out.mcpServers).toBeUndefined();
+    // packageManager still derives (cliTools not hidden)
+    expect(out.packageManager).toBe("pnpm");
+  });
+
+  it("respects stripHiddenHarnessData: hidden cliTools yields no packageManager", () => {
+    const full = harness({
+      cliTools: { pnpm: 10 },
+      mcpServers: { serena: 5 },
+    });
+    const filtered = stripHiddenHarnessData(full, ["cliTools"]);
+    const out = deriveSetupFromHarness(filtered);
+    expect(out.packageManager).toBeUndefined();
+    expect(out.mcpServers).toEqual(["serena"]);
+  });
+});

--- a/src/lib/__tests__/profile-setup-derive.test.ts
+++ b/src/lib/__tests__/profile-setup-derive.test.ts
@@ -47,9 +47,9 @@ function harness(partial: Partial<HarnessData>): HarnessData {
 }
 
 describe("deriveSetupFromHarness", () => {
-  it("returns only primaryAgent for an empty harness", () => {
+  it("returns {} for an empty harness (primaryAgent is the endpoint's job)", () => {
     const out = deriveSetupFromHarness(harness({}));
-    expect(out).toEqual({ primaryAgent: "Claude Code" });
+    expect(out).toEqual({});
   });
 
   it("falls back to models (message count) when perModelTokens is absent", () => {
@@ -161,5 +161,25 @@ describe("deriveSetupFromHarness", () => {
     const out = deriveSetupFromHarness(filtered);
     expect(out.packageManager).toBeUndefined();
     expect(out.mcpServers).toEqual(["serena"]);
+  });
+
+  it("respects stripHiddenHarnessData: hidden harnessFiles suppresses os (macOS evidence)", () => {
+    const full = harness({
+      harnessFiles: ["/Users/craig/.claude/skills/foo"],
+    });
+    // Pre-filter: we can detect os from the paths.
+    expect(deriveSetupFromHarness(full).os).toBe("macOS");
+    // Post-filter: the evidence source is gone, so no os emission.
+    const filtered = stripHiddenHarnessData(full, ["harnessFiles"]);
+    expect(deriveSetupFromHarness(filtered).os).toBeUndefined();
+  });
+
+  it("respects stripHiddenHarnessData: hidden versions suppresses os when versions is the only evidence", () => {
+    const full = harness({
+      versions: ["node-22.1.0-linux-x64"],
+    });
+    expect(deriveSetupFromHarness(full).os).toBe("Linux");
+    const filtered = stripHiddenHarnessData(full, ["versions"]);
+    expect(deriveSetupFromHarness(filtered).os).toBeUndefined();
   });
 });

--- a/src/lib/__tests__/profile-setup-normalize.test.ts
+++ b/src/lib/__tests__/profile-setup-normalize.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { normalizeSetup } from "../profile-setup-normalize";
+import { PROFILE_SETUP_VERSION } from "@/types/profile";
+
+const FIXED_NOW = "2026-04-13T12:00:00.000Z";
+const OLDER_NOW = "2026-01-01T00:00:00.000Z";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(FIXED_NOW));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("normalizeSetup", () => {
+  it("returns null for non-object input", () => {
+    expect(normalizeSetup(null)).toBeNull();
+    expect(normalizeSetup(undefined)).toBeNull();
+    expect(normalizeSetup("hello")).toBeNull();
+    expect(normalizeSetup(42)).toBeNull();
+    expect(normalizeSetup([])).toBeNull();
+  });
+
+  it("returns null when every user field is empty", () => {
+    expect(normalizeSetup({})).toBeNull();
+    expect(normalizeSetup({ os: "   " })).toBeNull();
+    expect(normalizeSetup({ mcpServers: [] })).toBeNull();
+    expect(normalizeSetup({ editor: "" })).toBeNull();
+  });
+
+  it("strips unknown keys", () => {
+    const out = normalizeSetup({ editor: "Zed", malicious: "x", __proto__: 1 });
+    expect(out?.editor).toBe("Zed");
+    // @ts-expect-error — asserting absence of unknown key
+    expect(out?.malicious).toBeUndefined();
+  });
+
+  it("trims strings and coerces empty to undefined", () => {
+    const out = normalizeSetup({
+      editor: "  Zed  ",
+      terminal: "",
+      shell: "   ",
+      keyboard: "HHKB",
+    });
+    expect(out?.editor).toBe("Zed");
+    expect(out?.terminal).toBeUndefined();
+    expect(out?.shell).toBeUndefined();
+    expect(out?.keyboard).toBe("HHKB");
+  });
+
+  it("truncates free-text fields at 120 chars", () => {
+    const long = "x".repeat(200);
+    const out = normalizeSetup({ machine: long });
+    expect(out?.machine?.length).toBe(120);
+  });
+
+  it("validates dotfilesUrl and drops invalid values", () => {
+    expect(
+      normalizeSetup({ dotfilesUrl: "https://github.com/me/dotfiles" })
+        ?.dotfilesUrl,
+    ).toBe("https://github.com/me/dotfiles");
+    expect(normalizeSetup({ dotfilesUrl: "not a url" })).toBeNull();
+    expect(normalizeSetup({ dotfilesUrl: "javascript:alert(1)" })).toBeNull();
+    expect(normalizeSetup({ dotfilesUrl: "ftp://example.com" })).toBeNull();
+  });
+
+  it("caps mcpServers at 20 items and each string at 80 chars", () => {
+    const long = "y".repeat(100);
+    const many = Array.from({ length: 50 }, (_, i) => `srv-${i}`);
+    const out = normalizeSetup({ mcpServers: [...many, long] });
+    expect(out?.mcpServers?.length).toBe(20);
+    const allWithinLimit = out?.mcpServers?.every((s) => s.length <= 80);
+    expect(allWithinLimit).toBe(true);
+  });
+
+  it("drops non-string and empty entries from mcpServers", () => {
+    const out = normalizeSetup({
+      mcpServers: ["a", "", "  ", 42, null, "b"],
+    });
+    expect(out?.mcpServers).toEqual(["a", "b"]);
+  });
+
+  it("returns null if mcpServers is the only field and is empty after cleaning", () => {
+    expect(normalizeSetup({ mcpServers: ["", null, "  "] })).toBeNull();
+  });
+
+  it("always overwrites version + setupUpdatedAt (server-owned)", () => {
+    const out = normalizeSetup({
+      editor: "Zed",
+      version: 999, // client attempt
+      setupUpdatedAt: "1999-01-01T00:00:00.000Z", // client attempt
+    });
+    expect(out?.version).toBe(PROFILE_SETUP_VERSION);
+    expect(out?.setupUpdatedAt).toBe(FIXED_NOW);
+  });
+
+  it("preserves prevStored.setupUpdatedAt when user fields are unchanged", () => {
+    const prev = {
+      version: PROFILE_SETUP_VERSION,
+      setupUpdatedAt: OLDER_NOW,
+      editor: "Zed",
+      shell: "zsh",
+    };
+    const out = normalizeSetup({ editor: "Zed", shell: "zsh" }, prev);
+    expect(out?.setupUpdatedAt).toBe(OLDER_NOW);
+  });
+
+  it("refreshes setupUpdatedAt when a user field changes", () => {
+    const prev = {
+      version: PROFILE_SETUP_VERSION,
+      setupUpdatedAt: OLDER_NOW,
+      editor: "Zed",
+    };
+    const out = normalizeSetup({ editor: "Cursor" }, prev);
+    expect(out?.setupUpdatedAt).toBe(FIXED_NOW);
+  });
+
+  it("refreshes setupUpdatedAt when mcpServers order changes", () => {
+    const prev = {
+      version: PROFILE_SETUP_VERSION,
+      setupUpdatedAt: OLDER_NOW,
+      mcpServers: ["a", "b"],
+    };
+    const out = normalizeSetup({ mcpServers: ["b", "a"] }, prev);
+    expect(out?.setupUpdatedAt).toBe(FIXED_NOW);
+  });
+
+  it("mints a new setupUpdatedAt when prevStored is absent", () => {
+    const out = normalizeSetup({ editor: "Zed" });
+    expect(out?.setupUpdatedAt).toBe(FIXED_NOW);
+  });
+
+  it("mints a new setupUpdatedAt when prevStored is malformed", () => {
+    const out = normalizeSetup({ editor: "Zed" }, "garbage");
+    expect(out?.setupUpdatedAt).toBe(FIXED_NOW);
+  });
+
+  it("round-trips a stored blob without churning the timestamp (read-path pattern)", () => {
+    // Simulates the `normalizeSetup(stored, stored)` call on read paths.
+    const stored = {
+      version: PROFILE_SETUP_VERSION,
+      setupUpdatedAt: OLDER_NOW,
+      editor: "Zed",
+      shell: "zsh",
+      mcpServers: ["serena"],
+    };
+    const first = normalizeSetup(stored, stored);
+    expect(first?.setupUpdatedAt).toBe(OLDER_NOW);
+    // Re-normalize the result against itself — still stable.
+    const second = normalizeSetup(first, first);
+    expect(second?.setupUpdatedAt).toBe(OLDER_NOW);
+  });
+
+  it("normalizes even when prev is well-formed but raw is malformed (returns null)", () => {
+    const prev = {
+      version: PROFILE_SETUP_VERSION,
+      setupUpdatedAt: OLDER_NOW,
+      editor: "Zed",
+    };
+    expect(normalizeSetup(null, prev)).toBeNull();
+    expect(normalizeSetup({}, prev)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/profile-setup-normalize.test.ts
+++ b/src/lib/__tests__/profile-setup-normalize.test.ts
@@ -82,6 +82,14 @@ describe("normalizeSetup", () => {
     expect(out?.mcpServers).toEqual(["a", "b"]);
   });
 
+  it("dedupes mcpServers while preserving first-occurrence spelling", () => {
+    const out = normalizeSetup({
+      mcpServers: ["serena", "Serena", "serena", "playwright", "serena"],
+    });
+    // Case-sensitive dedupe — treats 'serena' and 'Serena' as distinct.
+    expect(out?.mcpServers).toEqual(["serena", "Serena", "playwright"]);
+  });
+
   it("returns null if mcpServers is the only field and is empty after cleaning", () => {
     expect(normalizeSetup({ mcpServers: ["", null, "  "] })).toBeNull();
   });

--- a/src/lib/profile-setup-derive.ts
+++ b/src/lib/profile-setup-derive.ts
@@ -1,0 +1,125 @@
+// Pure function that derives safe-to-show profile setup suggestions from a
+// (privacy-filtered) HarnessData blob. Never returns paths or other
+// evidence — only labels. See docs/plans/2026-04-13-profile-setup-fields.md §7.
+
+import type { HarnessData } from "@/types/insights";
+import type { DerivedSetupFields } from "@/types/profile";
+
+const PACKAGE_MANAGER_KEYS = new Set([
+  "pnpm",
+  "npm",
+  "yarn",
+  "bun",
+  "uv",
+  "pip",
+  "poetry",
+  "cargo",
+  "go",
+  "mise",
+  "asdf",
+]);
+
+const MCP_TOP_N = 8;
+
+function pickMaxKey<T>(
+  record: Record<string, T> | undefined | null,
+  score: (value: T) => number,
+): string | undefined {
+  if (!record) return undefined;
+  let best: string | undefined;
+  let bestScore = -Infinity;
+  for (const [key, value] of Object.entries(record)) {
+    const s = score(value);
+    if (s > bestScore) {
+      bestScore = s;
+      best = key;
+    }
+  }
+  return bestScore > 0 ? best : undefined;
+}
+
+function derivePrimaryModel(harness: HarnessData): string | undefined {
+  // Prefer active-token share (input+output) from perModelTokens. Cache
+  // traffic is deliberately excluded because cached context inflates the
+  // "primary" signal toward whichever model inherited the long cache.
+  if (harness.perModelTokens) {
+    const fromTokens = pickMaxKey(
+      harness.perModelTokens,
+      (v) => (v?.input ?? 0) + (v?.output ?? 0),
+    );
+    if (fromTokens) return fromTokens;
+  }
+  return pickMaxKey(harness.models, (count) => count);
+}
+
+function deriveMcpServers(harness: HarnessData): string[] | undefined {
+  const entries = Object.entries(harness.mcpServers ?? {});
+  if (entries.length === 0) return undefined;
+  const sorted = entries
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, MCP_TOP_N)
+    .map(([key]) => key);
+  return sorted.length > 0 ? sorted : undefined;
+}
+
+function derivePackageManager(harness: HarnessData): string | undefined {
+  const entries = Object.entries(harness.cliTools ?? {}).filter(([key]) =>
+    PACKAGE_MANAGER_KEYS.has(key.toLowerCase()),
+  );
+  if (entries.length === 0) return undefined;
+  entries.sort((a, b) => b[1] - a[1]);
+  return entries[0][0];
+}
+
+// ── OS heuristic ────────────────────────────────────────────────────────
+// Returns ONLY a label. Never echoes, logs, or serializes the matched path
+// or source string. The callers rely on this invariant — test coverage in
+// profile-setup-derive.test.ts enforces it.
+
+function classifyOsFromString(str: string): string | undefined {
+  if (str.includes("/Users/")) return "macOS";
+  if (str.includes("/home/")) return "Linux";
+  if (/[A-Za-z]:\\/.test(str)) return "Windows";
+  if (str.includes("\\\\wsl$")) return "WSL (Windows)";
+  if (/-darwin(?:\b|$)/i.test(str)) return "macOS";
+  if (/-linux(?:\b|$)/i.test(str)) return "Linux";
+  if (/-windows(?:\b|$)/i.test(str)) return "Windows";
+  return undefined;
+}
+
+function deriveOs(harness: HarnessData): string | undefined {
+  const sources: string[] = [];
+  if (Array.isArray(harness.harnessFiles))
+    sources.push(...harness.harnessFiles);
+  if (Array.isArray(harness.versions)) sources.push(...harness.versions);
+  for (const s of sources) {
+    if (typeof s !== "string") continue;
+    const label = classifyOsFromString(s);
+    if (label) return label;
+  }
+  return undefined;
+}
+
+export function deriveSetupFromHarness(
+  harness: HarnessData,
+): DerivedSetupFields {
+  const out: DerivedSetupFields = {
+    // Every uploaded insight-harness report implies the user runs Claude Code.
+    // The form only shows the suggestion when primaryAgent is still empty.
+    primaryAgent: "Claude Code",
+  };
+
+  const primaryModel = derivePrimaryModel(harness);
+  if (primaryModel) out.primaryModel = primaryModel;
+
+  const mcpServers = deriveMcpServers(harness);
+  if (mcpServers) out.mcpServers = mcpServers;
+
+  const packageManager = derivePackageManager(harness);
+  if (packageManager) out.packageManager = packageManager;
+
+  const os = deriveOs(harness);
+  if (os) out.os = os;
+
+  return out;
+}

--- a/src/lib/profile-setup-derive.ts
+++ b/src/lib/profile-setup-derive.ts
@@ -100,14 +100,17 @@ function deriveOs(harness: HarnessData): string | undefined {
   return undefined;
 }
 
+/**
+ * Derive suggestions purely from data found in the harness blob. The
+ * helper is intentionally data-only — a "Claude Code" primaryAgent default
+ * is the endpoint's responsibility, decided after status classification, so
+ * an empty harness can honestly return `{}` and produce a `no-suggestions`
+ * state upstream.
+ */
 export function deriveSetupFromHarness(
   harness: HarnessData,
 ): DerivedSetupFields {
-  const out: DerivedSetupFields = {
-    // Every uploaded insight-harness report implies the user runs Claude Code.
-    // The form only shows the suggestion when primaryAgent is still empty.
-    primaryAgent: "Claude Code",
-  };
+  const out: DerivedSetupFields = {};
 
   const primaryModel = derivePrimaryModel(harness);
   if (primaryModel) out.primaryModel = primaryModel;

--- a/src/lib/profile-setup-normalize.ts
+++ b/src/lib/profile-setup-normalize.ts
@@ -1,0 +1,170 @@
+// Runs on every read and write path for User.setup. Defense in depth against
+// malformed JSON from manual DB edits or stale shapes, and single point of
+// truth for server-owned metadata (version, setupUpdatedAt).
+//
+// Contract (see docs/plans/2026-04-13-profile-setup-fields.md §5):
+//   - Reject non-object input → null.
+//   - Strip unknown keys.
+//   - Trim strings; empty → undefined. Truncate to FREE_TEXT_MAX.
+//   - dotfilesUrl must pass isValidUrl; dropped on fail.
+//   - mcpServers: cap array length, cap each string, drop empties.
+//   - Empty user-fields payload → null (caller should store DbNull).
+//   - Otherwise: version is overwritten; setupUpdatedAt is refreshed only if
+//     the normalized user-fields payload differs from prevStored's.
+
+import {
+  PROFILE_SETUP_LIMITS,
+  PROFILE_SETUP_USER_KEYS,
+  PROFILE_SETUP_VERSION,
+  type ProfileSetup,
+  type ProfileSetupUserFields,
+  type ProfileSetupUserKey,
+} from "@/types/profile";
+
+const STRING_FIELDS: readonly ProfileSetupUserKey[] = [
+  "os",
+  "machine",
+  "keyboard",
+  "editor",
+  "terminal",
+  "shell",
+  "primaryAgent",
+  "primaryModel",
+  "packageManager",
+  "dotfilesUrl",
+] as const;
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeString(
+  raw: unknown,
+  max: number = PROFILE_SETUP_LIMITS.FREE_TEXT_MAX,
+): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+function normalizeMcpServers(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const cleaned: string[] = [];
+  for (const item of raw) {
+    if (typeof item !== "string") continue;
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    cleaned.push(
+      trimmed.length > PROFILE_SETUP_LIMITS.MCP_ITEM_MAX
+        ? trimmed.slice(0, PROFILE_SETUP_LIMITS.MCP_ITEM_MAX)
+        : trimmed,
+    );
+    if (cleaned.length >= PROFILE_SETUP_LIMITS.MCP_ARRAY_MAX) break;
+  }
+  return cleaned.length > 0 ? cleaned : undefined;
+}
+
+function extractUserFields(raw: unknown): ProfileSetupUserFields {
+  if (!raw || typeof raw !== "object") return {};
+  const obj = raw as Record<string, unknown>;
+  // Build into a plain record then cast once — every STRING_FIELDS key maps
+  // to `string | undefined` in ProfileSetupUserFields, so the cast is safe.
+  const stringOut: Partial<Record<(typeof STRING_FIELDS)[number], string>> = {};
+
+  for (const key of STRING_FIELDS) {
+    const value = normalizeString(obj[key]);
+    if (value !== undefined) {
+      if (key === "dotfilesUrl" && !isValidUrl(value)) continue;
+      stringOut[key] = value;
+    }
+  }
+
+  // `stringOut` only carries the string-valued keys. Cast through `unknown`
+  // and let the explicit `mcpServers` branch below populate the array field.
+  const out = { ...stringOut } as ProfileSetupUserFields;
+  const mcp = normalizeMcpServers(obj.mcpServers);
+  if (mcp) out.mcpServers = mcp;
+
+  return out;
+}
+
+function userFieldsEqual(
+  a: ProfileSetupUserFields,
+  b: ProfileSetupUserFields,
+): boolean {
+  for (const key of PROFILE_SETUP_USER_KEYS) {
+    const av = a[key];
+    const bv = b[key];
+    if (key === "mcpServers") {
+      const al = Array.isArray(av) ? av : [];
+      const bl = Array.isArray(bv) ? bv : [];
+      if (al.length !== bl.length) return false;
+      for (let i = 0; i < al.length; i++) {
+        if (al[i] !== bl[i]) return false;
+      }
+    } else if (av !== bv) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isUserFieldsEmpty(fields: ProfileSetupUserFields): boolean {
+  for (const key of PROFILE_SETUP_USER_KEYS) {
+    const v = fields[key];
+    if (v === undefined) continue;
+    if (Array.isArray(v) && v.length === 0) continue;
+    if (typeof v === "string" && !v) continue;
+    return false;
+  }
+  return true;
+}
+
+function toPrevUserFields(prev: unknown): ProfileSetupUserFields | null {
+  if (!prev || typeof prev !== "object") return null;
+  // prevStored comes from the DB and may itself be malformed; re-extract
+  // through the same normalizer so comparison is apples-to-apples.
+  return extractUserFields(prev);
+}
+
+/**
+ * Normalize a raw setup blob for safe storage and safe response.
+ *
+ * @param raw        Possibly-untrusted input (client body or stored blob).
+ * @param prevStored Currently persisted blob. When provided and the
+ *                   normalized user-fields payload matches the previous
+ *                   payload, the persisted `setupUpdatedAt` is preserved so
+ *                   round-trips through reads don't churn the timestamp.
+ */
+export function normalizeSetup(
+  raw: unknown,
+  prevStored?: unknown,
+): ProfileSetup | null {
+  const fields = extractUserFields(raw);
+  if (isUserFieldsEmpty(fields)) return null;
+
+  const prevFields = toPrevUserFields(prevStored);
+  const prevTimestamp =
+    prevStored && typeof prevStored === "object"
+      ? (prevStored as Record<string, unknown>).setupUpdatedAt
+      : undefined;
+
+  const setupUpdatedAt =
+    prevFields &&
+    typeof prevTimestamp === "string" &&
+    userFieldsEqual(fields, prevFields)
+      ? prevTimestamp
+      : new Date().toISOString();
+
+  return {
+    version: PROFILE_SETUP_VERSION,
+    setupUpdatedAt,
+    ...fields,
+  };
+}

--- a/src/lib/profile-setup-normalize.ts
+++ b/src/lib/profile-setup-normalize.ts
@@ -56,15 +56,21 @@ function normalizeString(
 function normalizeMcpServers(raw: unknown): string[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const cleaned: string[] = [];
+  const seen = new Set<string>();
   for (const item of raw) {
     if (typeof item !== "string") continue;
     const trimmed = item.trim();
     if (!trimmed) continue;
-    cleaned.push(
+    const capped =
       trimmed.length > PROFILE_SETUP_LIMITS.MCP_ITEM_MAX
         ? trimmed.slice(0, PROFILE_SETUP_LIMITS.MCP_ITEM_MAX)
-        : trimmed,
-    );
+        : trimmed;
+    // Dedupe case-sensitively — preserves user's intended spelling on first
+    // occurrence and prevents duplicate React keys downstream (SetupCard
+    // chips, auto-derive suggestions).
+    if (seen.has(capped)) continue;
+    seen.add(capped);
+    cleaned.push(capped);
     if (cleaned.length >= PROFILE_SETUP_LIMITS.MCP_ARRAY_MAX) break;
   }
   return cleaned.length > 0 ? cleaned : undefined;

--- a/src/lib/profile-setup-suggestions.ts
+++ b/src/lib/profile-setup-suggestions.ts
@@ -1,0 +1,93 @@
+// Autosuggest lists for the profile setup edit form. Consumed by
+// <datalist> elements so users can pick common values or type freely.
+// Ordering reflects rough popularity / recency to make the dropdown useful
+// at a glance. Not a strict enum — all fields accept arbitrary free text.
+
+export const OS_SUGGESTIONS = [
+  "macOS",
+  "Linux",
+  "Windows",
+  "WSL (Windows)",
+  "NixOS",
+  "Arch Linux",
+  "Ubuntu",
+  "Fedora",
+  "Debian",
+];
+
+export const EDITOR_SUGGESTIONS = [
+  "VS Code",
+  "Cursor",
+  "Zed",
+  "Neovim",
+  "Vim",
+  "Emacs",
+  "JetBrains (IntelliJ)",
+  "JetBrains (WebStorm)",
+  "JetBrains (PyCharm)",
+  "JetBrains (GoLand)",
+  "Windsurf",
+  "Sublime Text",
+  "Xcode",
+  "Visual Studio",
+];
+
+export const TERMINAL_SUGGESTIONS = [
+  "Ghostty",
+  "iTerm2",
+  "Warp",
+  "Alacritty",
+  "Kitty",
+  "WezTerm",
+  "Terminal.app",
+  "Windows Terminal",
+  "Hyper",
+  "Tabby",
+];
+
+export const SHELL_SUGGESTIONS = [
+  "zsh",
+  "bash",
+  "fish",
+  "nushell",
+  "PowerShell",
+];
+
+export const PRIMARY_AGENT_SUGGESTIONS = [
+  "Claude Code",
+  "Codex",
+  "Cursor Agent",
+  "Aider",
+  "Amp",
+  "Cline",
+  "Continue",
+  "GitHub Copilot Workspace",
+];
+
+export const PRIMARY_MODEL_SUGGESTIONS = [
+  "claude-opus-4",
+  "claude-sonnet-4",
+  "claude-haiku-4",
+  "claude-opus-3.5",
+  "claude-sonnet-3.5",
+  "gpt-5",
+  "gpt-4.1",
+  "o3",
+  "o4-mini",
+  "gemini-2.5-pro",
+  "gemini-2.5-flash",
+];
+
+export const PACKAGE_MANAGER_SUGGESTIONS = [
+  "pnpm",
+  "npm",
+  "yarn",
+  "bun",
+  "uv",
+  "pip",
+  "poetry",
+  "cargo",
+  "go modules",
+  "mise",
+  "asdf",
+];

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,67 @@
+// Profile "developer setup" fields — uses.tech-style workstation info
+// rendered on public profiles. Stored as a single Json blob on User.setup.
+// See docs/plans/2026-04-13-profile-setup-fields.md.
+
+export const PROFILE_SETUP_VERSION = 1 as const;
+
+/** Keys users can set directly via the edit form. */
+export const PROFILE_SETUP_USER_KEYS = [
+  "os",
+  "machine",
+  "keyboard",
+  "editor",
+  "terminal",
+  "shell",
+  "primaryAgent",
+  "primaryModel",
+  "mcpServers",
+  "packageManager",
+  "dotfilesUrl",
+] as const;
+
+export type ProfileSetupUserKey = (typeof PROFILE_SETUP_USER_KEYS)[number];
+
+export interface ProfileSetupUserFields {
+  os?: string;
+  machine?: string;
+  keyboard?: string;
+  editor?: string;
+  terminal?: string;
+  shell?: string;
+  primaryAgent?: string;
+  primaryModel?: string;
+  mcpServers?: string[];
+  packageManager?: string;
+  dotfilesUrl?: string;
+}
+
+export interface ProfileSetup extends ProfileSetupUserFields {
+  // Server-owned metadata. Never accept from client; normalizeSetup always
+  // overwrites these. setupUpdatedAt is refreshed only when the normalized
+  // user-fields payload differs from what's already stored.
+  version: typeof PROFILE_SETUP_VERSION;
+  setupUpdatedAt: string; // ISO-8601
+}
+
+/**
+ * Subset the derive helper can emit. Ordering mirrors Phase D source-field
+ * precedence in the plan.
+ */
+export type DerivedSetupFields = Partial<
+  Pick<
+    ProfileSetupUserFields,
+    "primaryAgent" | "primaryModel" | "mcpServers" | "packageManager" | "os"
+  >
+>;
+
+export type ProfileSetupLimits = {
+  FREE_TEXT_MAX: 120;
+  MCP_ARRAY_MAX: 20;
+  MCP_ITEM_MAX: 80;
+};
+
+export const PROFILE_SETUP_LIMITS: ProfileSetupLimits = {
+  FREE_TEXT_MAX: 120,
+  MCP_ARRAY_MAX: 20,
+  MCP_ITEM_MAX: 80,
+};


### PR DESCRIPTION
Closes #90

## What

Adds optional "developer setup" fields (uses.tech-style) to user profiles — OS, machine, keyboard, editor, terminal, shell, primary agent/model, MCP servers, package manager, dotfiles URL. Storage is a single nullable `User.setup` JSON column. All fields optional, all public, blank-field-invisible.

## Why

Makes profiles feel like developer personality pages rather than just stats dashboards. Four of the eleven v1 fields are auto-derivable from the user's uploaded harness report, so the friction to fill them in is low.

## How

Four phases, one commit per phase plus a codex-fix amendment:

**A.** Schema + types + `normalizeSetup` helper. Defense-in-depth: the helper runs on **both** read and write paths with `normalizeSetup(stored, stored)` on reads so the persisted `setupUpdatedAt` survives GETs. PUT accumulator widened to `Prisma.UserUpdateInput`. `setup: null` bypasses the "no valid fields" short-circuit. Clear-to-NULL uses `Prisma.DbNull` (NOT `JsonNull`, which would persist a JSON null literal).

**B.** `SetupCard` public display — only renders populated groups, chip list for MCP servers, github/globe icon for dotfiles URL.

**C.** Edit UI — collapsible section in the existing in-page `ProfileEditForm`, native `<datalist>` autosuggest, comma-separated MCP input, privacy copy "Review names before publishing…" above the MCP field.

**D.** Auto-derivation. `GET /api/users/me/setup-suggestions` runs `stripHiddenHarnessData` before deriving, so user-hidden harness sections are absent from suggestions. `primaryModel` uses `perModelTokens` active tokens (input+output, deliberately excluding cache — cache distorts the "primary" signal). OS heuristic returns label only — never the matched path, never evidence. Per-field "Suggest: X" chips in the edit form with 5 UI states (loading / no-reports / no-suggestions / ok / failed).

## Plan + review history

- Plan: [`docs/plans/2026-04-13-profile-setup-fields.md`](../blob/feat/profile-setup-fields/docs/plans/2026-04-13-profile-setup-fields.md)
- Codex review: [`docs/plans/2026-04-13-profile-setup-fields-codex-review.md`](../blob/feat/profile-setup-fields/docs/plans/2026-04-13-profile-setup-fields-codex-review.md)

Plan went through two codex passes; implementation went through one more codex pass, which flagged 3 issues that are fixed in `d70c066`:

- `deriveSetupFromHarness` stopped seeding `primaryAgent` so an empty harness honestly returns `{}` — lets the endpoint return `no-suggestions` rather than false-positive `ok`.
- `normalizeSetup` dedupes `mcpServers` (prevents duplicate React keys in chips).
- Privacy regression tests for OS suppression when `harnessFiles` or `versions` are hidden.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on all new/changed files — clean
- `npx vitest run` — 409 tests pass (+32 new across 2 suites)

## Test plan

- [ ] Fresh user with no harness reports: edit profile → open Developer Setup → see "Upload a harness report…" hint.
- [ ] User with a harness report: open Developer Setup → spinner → suggestion chips appear on empty fields.
- [ ] Click a suggestion chip → field fills, chip disappears, save button dirties.
- [ ] Type in a field manually → suggestion chip disappears (suppressed on filled fields).
- [ ] Fill several fields, save → SetupCard renders below bio with only populated rows/groups.
- [ ] Clear all setup fields, save → SetupCard disappears (empty blob → `DbNull`).
- [ ] `mcpServers: "serena, serena, playwright"` → saved as `["serena", "playwright"]`.
- [ ] Hide `mcpServers` on the harness report → refresh edit form → MCP suggestion gone.
- [ ] Public profile visit: `SetupCard` renders for users with setup, no placeholder card for users without.

## Post-Deploy Monitoring & Validation

- **Migration:** `20260413201603_add_user_setup/migration.sql` runs via `prisma migrate deploy` in the Vercel build step. Monitor the first post-deploy build log for successful migration application. Rollback: the migration is a pure nullable `ALTER TABLE … ADD COLUMN`; revertable with `ALTER TABLE "User" DROP COLUMN "setup"`.
- **Healthy signals:** Users with no `setup` get `setup: null` in both `/api/users/me` and `/api/users/:username` responses. Users who fill fields see the `SetupCard` render on their public profile. No new 500s in `/api/users/me*` routes.
- **Failure signals:** 500 spike on `/api/users/me/setup-suggestions`, "Prisma schema is out of sync" build errors, SetupCard rendering raw/unnormalized data.
- **Validation window:** 24h after deploy. No special SQL to run — the new column is opt-in via UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)