### PR TITLE
feat(posthog): reverse-proxy through /ingest to bypass ad-blockers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,5 @@ SENTRY_AUTH_TOKEN=""
 
 # PostHog (product analytics)
 NEXT_PUBLIC_POSTHOG_KEY=""
-NEXT_PUBLIC_POSTHOG_HOST="https://us.i.posthog.com"
+NEXT_PUBLIC_POSTHOG_HOST="/ingest"
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,26 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // PostHog reverse proxy — bypass ad-blockers by serving analytics
+  // through our own domain instead of *.posthog.com.
+  // https://posthog.com/docs/advanced/proxy/nextjs
+  skipTrailingSlashRedirect: true,
+  async rewrites() {
+    return [
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      {
+        source: "/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+    ];
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/src/components/PostHogProvider.tsx
+++ b/src/components/PostHogProvider.tsx
@@ -8,8 +8,8 @@ import { PostHogProvider as PHProvider } from "posthog-js/react";
 
 if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-    api_host:
-      process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "/ingest",
+    ui_host: "https://us.posthog.com",
     defaults: "2026-01-30",
     capture_pageview: false,
     capture_pageleave: true,


### PR DESCRIPTION
## Summary

PostHog's `us.i.posthog.com` is on every major ad-blocker list (uBlock, Brave, AdGuard) — most of our traffic was being silently dropped. This routes telemetry through our own domain.

- `next.config.ts` rewrites: `/ingest/static/*` → PostHog assets, `/ingest/*` → PostHog ingest
- `posthog-js` `api_host` now defaults to `/ingest`
- `ui_host: "https://us.posthog.com"` so the in-app toolbar and dashboard links still work
- `skipTrailingSlashRedirect: true` so `/ingest/decide` isn't 308-redirected (kills POST bodies)

## Tradeoff

Adds traffic to your Vercel functions (the rewrite goes through Next's edge, then proxies to PostHog). For a small site this is a rounding error; revisit if function invocation costs spike.

## Test plan

- [x] `npm run build` succeeds
- [ ] After deploy, network tab shows requests to `insightharness.com/ingest/*` (not `us.i.posthog.com`)
- [ ] Events still appear in PostHog Live with ad-blocker on
- [ ] `posthog.toolbar` link still works (uses `ui_host`)