### PR TITLE
feat(analytics): capture profile_upload_started event

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
@@ -500,6 +500,10 @@ export default function UploadPage() {
   const [showCurlFallback, setShowCurlFallback] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const harnessFileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    posthog.capture("profile_upload_started");
+  }, []);
 
   const toggleSection = (key: string) => {
     setDisabledSections((prev) => ({ ...prev, [key]: !prev[key] }));

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
@@ -501,15 +501,12 @@ export default function UploadPage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const harnessFileInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    posthog.capture("profile_upload_started");
-  }, []);
-
   const toggleSection = (key: string) => {
     setDisabledSections((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
   const handleFile = async (f: File) => {
+    posthog.capture("profile_upload_started");
     setLoading(true);
     setError(null);
 


### PR DESCRIPTION
## Summary
- Fires `profile_upload_started` on upload page mount
- Enables a proper 4-step funnel: landed → signed in → upload started → published (previously no event existed between identify and publish)

## Test plan
- [ ] Visit /upload on preview deploy; confirm `profile_upload_started` appears in PostHog live events
- [ ] Event fires exactly once per page load