### PR TITLE
feat(skills): dedicated Skills tab with deep-dive accordion

### DIFF
--- a/docs/mockups/skills-section-redesign.html
+++ b/docs/mockups/skills-section-redesign.html
@@ -1,0 +1,3247 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skills Section Redesign</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          "Inter",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        background: #f5f5f0;
+        color: #0f172a;
+      }
+
+      /* ── Sticky Nav ── */
+      .mockup-nav {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: #1e1e1e;
+        color: #fff;
+        padding: 10px 16px;
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        align-items: center;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      }
+      .mockup-nav .title {
+        font-size: 14px;
+        font-weight: 600;
+        margin-right: 12px;
+        white-space: nowrap;
+      }
+      .mockup-nav a {
+        color: #a8c8ff;
+        text-decoration: none;
+        font-size: 12px;
+        padding: 3px 8px;
+        border-radius: 4px;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+      }
+      .mockup-nav a:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+      .mockup-nav .copy-all-btn {
+        margin-left: auto;
+        background: #2563eb;
+        color: #fff;
+        border: none;
+        padding: 6px 14px;
+        border-radius: 6px;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      .mockup-nav .copy-all-btn.copied {
+        background: #16a34a;
+      }
+
+      /* ── Sections ── */
+      .mockup-section {
+        max-width: 900px;
+        margin: 40px auto;
+        padding: 0 16px;
+      }
+      .section-label {
+        background: #1e1e1e;
+        color: #fff;
+        display: inline-block;
+        padding: 4px 12px;
+        border-radius: 4px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        margin-bottom: 12px;
+      }
+      .section-desc {
+        font-size: 13px;
+        color: #64748b;
+        margin-bottom: 20px;
+        line-height: 1.5;
+      }
+      .section-divider {
+        height: 1px;
+        background: #ddd;
+        margin: 48px 0;
+      }
+
+      .version-container {
+        position: relative;
+      }
+      .version {
+        display: none;
+      }
+      .version.active {
+        display: block;
+      }
+
+      .feedback-area {
+        margin-top: 16px;
+        background: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 8px;
+        padding: 12px;
+      }
+      .feedback-area label {
+        display: block;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #888;
+        margin-bottom: 6px;
+      }
+      .feedback-area textarea {
+        width: 100%;
+        min-height: 80px;
+        border: 1px solid #e5e5e5;
+        border-radius: 6px;
+        padding: 10px;
+        font-family: inherit;
+        font-size: 14px;
+        line-height: 1.5;
+        resize: vertical;
+      }
+      .feedback-area textarea:focus {
+        outline: none;
+        border-color: #2563eb;
+        box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+      }
+      .char-count {
+        font-size: 11px;
+        color: #aaa;
+        text-align: right;
+        margin-top: 4px;
+      }
+
+      .design-note {
+        background: #fffbeb;
+        border: 1px solid #fcd34d;
+        border-radius: 8px;
+        padding: 10px 14px;
+        margin: 12px 0 20px;
+        font-size: 12px;
+        color: #92400e;
+        line-height: 1.5;
+      }
+      .design-note.info {
+        background: #f0fdf4;
+        border-color: #86efac;
+        color: #166534;
+      }
+      .design-note.warn {
+        background: #fef2f2;
+        border-color: #fca5a5;
+        color: #991b1b;
+      }
+
+      /* ── Fake app chrome — mimics the real page ── */
+      .app-shell {
+        background: #ffffff;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 20px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+      }
+      .app-shell h2.section-title {
+        font-size: 20px;
+        font-weight: 600;
+        color: #0f172a;
+        margin-bottom: 16px;
+      }
+
+      /* Fake profile tab bar */
+      .profile-tabs {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        overflow: hidden;
+        background: #fff;
+        margin-bottom: 20px;
+      }
+      .profile-tabs.four-tabs {
+        grid-template-columns: repeat(4, 1fr);
+      }
+      .profile-tab {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 18px;
+        border-right: 1px solid #f1f5f9;
+        background: #fff;
+        cursor: pointer;
+        position: relative;
+      }
+      .profile-tab:last-child {
+        border-right: none;
+      }
+      .profile-tab.active {
+        background: #eef2ff;
+      }
+      .profile-tab.active::after {
+        content: "";
+        position: absolute;
+        inset: auto 0 0 0;
+        height: 3px;
+        background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+      }
+      .tab-badge {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 18px;
+        background: #dbeafe;
+        color: #2563eb;
+        font-weight: 700;
+        flex-shrink: 0;
+      }
+      .profile-tab.active .tab-badge {
+        background: #2563eb;
+        color: #fff;
+      }
+      .profile-tab.indigo .tab-badge {
+        background: #e0e7ff;
+        color: #4f46e5;
+      }
+      .profile-tab.indigo.active .tab-badge {
+        background: #4f46e5;
+        color: #fff;
+      }
+      .profile-tab.purple .tab-badge {
+        background: #f3e8ff;
+        color: #9333ea;
+      }
+      .profile-tab.purple.active .tab-badge {
+        background: #9333ea;
+        color: #fff;
+      }
+      .profile-tab.emerald .tab-badge {
+        background: #d1fae5;
+        color: #059669;
+      }
+      .profile-tab.emerald.active .tab-badge {
+        background: #059669;
+        color: #fff;
+      }
+      .tab-info .tab-label {
+        font-size: 15px;
+        font-weight: 600;
+        color: #0f172a;
+      }
+      .profile-tab:not(.active) .tab-info .tab-label {
+        color: #475569;
+        font-weight: 500;
+      }
+      .tab-info .tab-meta {
+        font-size: 11px;
+        color: #94a3b8;
+        margin-top: 2px;
+      }
+
+      /* ── "Featured Skills" current card ── */
+      .featured-card-current {
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 16px;
+        background: #fafafa;
+      }
+      .featured-card-current h3 {
+        font-size: 15px;
+        font-weight: 700;
+        margin-bottom: 4px;
+      }
+      .featured-card-current .subtitle {
+        font-size: 12px;
+        color: #64748b;
+        margin-bottom: 12px;
+      }
+      .featured-card-current .readme-wall {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 16px;
+        font-size: 13px;
+        color: #334155;
+        line-height: 1.5;
+        max-height: 500px;
+        overflow: hidden;
+        position: relative;
+      }
+      .featured-card-current .readme-wall::after {
+        content: "… and 400+ more lines ↓";
+        position: absolute;
+        inset: auto 0 0 0;
+        background: linear-gradient(transparent, rgba(255, 255, 255, 0.95) 50%);
+        padding: 40px 16px 16px;
+        text-align: center;
+        font-size: 11px;
+        color: #94a3b8;
+        font-style: italic;
+      }
+
+      /* ── Accordion ToC — OPTION B/C ── */
+      .skill-accordion {
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        background: #fff;
+        overflow: hidden;
+      }
+      .skill-accordion-item {
+        border-bottom: 1px solid #f1f5f9;
+      }
+      .skill-accordion-item:last-child {
+        border-bottom: none;
+      }
+      .skill-accordion-header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 14px 16px;
+        cursor: pointer;
+        background: #fff;
+        user-select: none;
+        transition: background 0.15s;
+      }
+      .skill-accordion-header:hover {
+        background: #f8fafc;
+      }
+      .skill-accordion-item.open .skill-accordion-header {
+        background: #f1f5ff;
+      }
+      .skill-chev {
+        width: 20px;
+        height: 20px;
+        flex-shrink: 0;
+        transition: transform 0.2s;
+        color: #64748b;
+      }
+      .skill-accordion-item.open .skill-chev {
+        transform: rotate(90deg);
+        color: #2563eb;
+      }
+      .skill-accordion-name {
+        font-size: 14px;
+        font-weight: 600;
+        color: #0f172a;
+        flex-shrink: 0;
+      }
+      .skill-accordion-desc {
+        font-size: 12px;
+        color: #64748b;
+        flex: 1;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .skill-accordion-item.open .skill-accordion-desc {
+        white-space: normal;
+      }
+      .skill-badge-source {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 3px 7px;
+        border-radius: 4px;
+        flex-shrink: 0;
+      }
+      .skill-badge-source.custom {
+        background: #ecfdf5;
+        color: #047857;
+      }
+      .skill-badge-source.plugin {
+        background: #f3e8ff;
+        color: #7e22ce;
+      }
+      .skill-accordion-body {
+        display: none;
+        padding: 4px 20px 24px 48px;
+        background: #fafbff;
+        border-top: 1px solid #f1f5f9;
+      }
+      .skill-accordion-item.open .skill-accordion-body {
+        display: block;
+      }
+
+      /* ── Polished readme typography (matches HTML report feel) ── */
+      .readme-polished {
+        font-size: 14px;
+        line-height: 1.65;
+        color: #1e293b;
+      }
+      .readme-polished .hero-img {
+        width: 100%;
+        border-radius: 10px;
+        margin: 8px 0 16px;
+        border: 1px solid #e2e8f0;
+      }
+      .readme-polished h1,
+      .readme-polished h2,
+      .readme-polished h3 {
+        font-weight: 700;
+        color: #0f172a;
+        letter-spacing: -0.01em;
+        margin: 24px 0 10px;
+      }
+      .readme-polished h1 {
+        font-size: 22px;
+      }
+      .readme-polished h2 {
+        font-size: 17px;
+        border-bottom: 1px solid #e2e8f0;
+        padding-bottom: 6px;
+      }
+      .readme-polished h3 {
+        font-size: 15px;
+      }
+      .readme-polished p {
+        margin: 10px 0;
+      }
+      .readme-polished code {
+        background: #f1f5f9;
+        color: #be185d;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 12.5px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      }
+      .readme-polished pre {
+        background: #0f172a;
+        color: #e2e8f0;
+        border-radius: 8px;
+        padding: 14px 16px;
+        overflow-x: auto;
+        font-size: 12.5px;
+        margin: 12px 0;
+      }
+      .readme-polished pre code {
+        background: transparent;
+        color: inherit;
+        padding: 0;
+      }
+      .readme-polished ul,
+      .readme-polished ol {
+        padding-left: 22px;
+        margin: 10px 0;
+      }
+      .readme-polished li {
+        margin: 4px 0;
+      }
+      .readme-polished blockquote {
+        border-left: 3px solid #3b82f6;
+        background: #eff6ff;
+        padding: 8px 14px;
+        color: #1e40af;
+        border-radius: 0 6px 6px 0;
+        margin: 12px 0;
+      }
+      .readme-polished table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        margin: 12px 0;
+      }
+      .readme-polished th,
+      .readme-polished td {
+        text-align: left;
+        padding: 8px 10px;
+        border: 1px solid #e2e8f0;
+      }
+      .readme-polished th {
+        background: #f8fafc;
+        font-weight: 600;
+      }
+
+      /* ── Skills & Commands compact grid (redesigned) ── */
+      .sc-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 10px;
+      }
+      .sc-card {
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: 10px 12px;
+        background: #fff;
+        cursor: pointer;
+      }
+      .sc-card:hover {
+        border-color: #93c5fd;
+        background: #fafbff;
+      }
+      .sc-card.custom {
+        border-color: #a7f3d0;
+        background: #f0fdf4;
+      }
+      .sc-card-head {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        justify-content: space-between;
+      }
+      .sc-card-name {
+        font-size: 13px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .sc-card-calls {
+        font-size: 10px;
+        font-weight: 700;
+        padding: 2px 6px;
+        background: #ede9fe;
+        color: #6d28d9;
+        border-radius: 999px;
+      }
+      .sc-card-source {
+        display: inline-block;
+        margin-top: 4px;
+        font-size: 9px;
+        font-weight: 700;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        border: 1px solid #e2e8f0;
+        padding: 1px 5px;
+        border-radius: 4px;
+      }
+      .sc-card-desc {
+        font-size: 11.5px;
+        color: #475569;
+        margin-top: 6px;
+        line-height: 1.45;
+      }
+      .sc-card.compact .sc-card-desc {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .sc-card.expanded .sc-card-desc {
+        overflow: visible;
+        display: block;
+      }
+      .sc-chev-inline {
+        font-size: 10px;
+        color: #94a3b8;
+        margin-left: 4px;
+      }
+
+      /* ── Option-specific highlight strip ── */
+      .option-strip {
+        display: inline-block;
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        padding: 3px 10px;
+        border-radius: 999px;
+        margin-bottom: 10px;
+      }
+      .option-strip.a {
+        background: #fee2e2;
+        color: #991b1b;
+      }
+      .option-strip.b {
+        background: #dbeafe;
+        color: #1d4ed8;
+      }
+      .option-strip.c {
+        background: #f3e8ff;
+        color: #6b21a8;
+      }
+      .option-strip.d {
+        background: #dcfce7;
+        color: #166534;
+      }
+
+      .sub-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin: 24px 0 10px;
+      }
+      .sub-header h3 {
+        font-size: 16px;
+        font-weight: 700;
+        color: #0f172a;
+      }
+      .sub-header .count-pill {
+        font-size: 11px;
+        background: #f1f5f9;
+        color: #475569;
+        padding: 3px 10px;
+        border-radius: 999px;
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <nav class="mockup-nav">
+      <span class="title">Skills Section Redesign</span>
+      <a href="#current">Current</a>
+      <a href="#option-b">Option B</a>
+      <a href="#option-c">Option C</a>
+      <a href="#option-d">Option D</a>
+      <button class="copy-all-btn" onclick="copyAllFeedback()">
+        Copy All Feedback
+      </button>
+    </nav>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- SECTION 1 — CURRENT STATE -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="current" id="current">
+      <span class="option-strip a">Option A · Problem Statement</span>
+      <span class="section-label">Current state</span>
+      <p class="section-desc">
+        What the Dashboard tab looks like today — "Featured Skills" expands all
+        README content inline, producing a wall of text. "Skills & Commands"
+        below shows cards with a broken/unused expand affordance and many plugin
+        entries ship with no description.
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <!-- Today's 3-tab bar -->
+            <div class="profile-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts · setup</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+            </div>
+
+            <h2 class="section-title">Featured Skills</h2>
+            <div class="featured-card-current">
+              <h3>skill-showcase</h3>
+              <div class="subtitle">custom · last used 2 days ago</div>
+              <div class="readme-wall">
+                <strong># skill-showcase</strong>
+                <br /><br />
+                Build a single-file public HTML showcase of a collection of
+                Claude Code skills — table of contents, grouped categories,
+                per-skill README with hero image, custom-vs-plugin labeling, and
+                PII scrubbing.
+                <br /><br />
+                ## Overview This skill takes a directory of Claude Code skills
+                and produces a portable HTML file suitable for sharing.
+                Includes: table of contents, grouped categories, per-skill
+                README rendering with inlined hero image, custom-vs-plugin
+                source labeling, and a privacy pass that scrubs identifiers,
+                paths, and other PII from skill descriptions and README content.
+                <br /><br />
+                ## Usage ```bash skill-showcase --skills-dir ~/.claude/skills
+                --output ~/showcase.html ```
+                <br /><br />
+                ## Options - `--skills-dir` — path to directory containing skill
+                folders - `--output` — output file path (default:
+                ./showcase.html) - `--title` — page title (default: "My Claude
+                Skills") - `--include-categories` — comma-separated list of
+                categories to include - `--exclude-private` — skip skills marked
+                as private...
+              </div>
+            </div>
+
+            <div
+              style="
+                margin-top: 20px;
+                border: 1px solid #e2e8f0;
+                border-radius: 12px;
+                padding: 16px;
+                background: #fff;
+              "
+            >
+              <h3
+                style="font-size: 15px; font-weight: 700; margin-bottom: 12px"
+              >
+                Skills & Commands
+              </h3>
+              <div class="sc-grid">
+                <div class="sc-card custom compact">
+                  <div class="sc-card-head">
+                    <span class="sc-card-name">ux-mockup</span>
+                    <span class="sc-card-calls">14</span>
+                  </div>
+                  <span class="sc-card-source">custom</span>
+                  <p class="sc-card-desc">
+                    Create interactive HTML mockups for UX design review with
+                    built-in feedback… <span class="sc-chev-inline">▾</span>
+                  </p>
+                </div>
+                <div class="sc-card compact">
+                  <div class="sc-card-head">
+                    <span class="sc-card-name"
+                      >compound-engineering:ce-work</span
+                    >
+                    <span class="sc-card-calls">9</span>
+                  </div>
+                  <span class="sc-card-source"
+                    >plugin:compound-engineering</span
+                  >
+                  <p
+                    class="sc-card-desc"
+                    style="color: #cbd5e1; font-style: italic"
+                  >
+                    no description <span class="sc-chev-inline">▾</span>
+                  </p>
+                </div>
+                <div class="sc-card compact">
+                  <div class="sc-card-head">
+                    <span class="sc-card-name">superpowers:brainstorming</span>
+                    <span class="sc-card-calls">6</span>
+                  </div>
+                  <span class="sc-card-source">plugin:superpowers</span>
+                  <p class="sc-card-desc">
+                    You MUST use this before any creative work - creating
+                    features, building… <span class="sc-chev-inline">▾</span>
+                  </p>
+                </div>
+                <div class="sc-card compact">
+                  <div class="sc-card-head">
+                    <span class="sc-card-name">frontend-design</span>
+                    <span class="sc-card-calls">4</span>
+                  </div>
+                  <span class="sc-card-source">custom</span>
+                  <p
+                    class="sc-card-desc"
+                    style="color: #cbd5e1; font-style: italic"
+                  >
+                    no description <span class="sc-chev-inline">▾</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note warn">
+            <strong>Problems flagged:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>
+                Featured-Skills readme dumps every skill expanded → page is
+                forever long
+              </li>
+              <li>
+                README content is a wall of text — no section styling, no
+                readable typography
+              </li>
+              <li>
+                "Featured Skills" label is ambiguous (vs. "skills I featured a
+                write-up on")
+              </li>
+              <li>
+                Skills & Commands cards: many have no description, even when one
+                exists in metadata
+              </li>
+              <li>
+                Down-arrow chevron on S&C cards doesn't work — click does
+                nothing
+              </li>
+              <li>
+                S&C descriptions truncate at 2 lines with no way to expand
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-current">Feedback on problem framing</label>
+        <textarea
+          id="fb-current"
+          placeholder="Did I capture everything? Anything missing from the list above?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION B — Stay on Dashboard, accordion only -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-b" id="option-b">
+      <span class="option-strip b">Option B · Minimal — stay on Dashboard</span>
+      <span class="section-label">Option B — Accordion on Dashboard</span>
+      <p class="section-desc">
+        Keep everything on the Dashboard tab. Rename "Featured Skills" →
+        <em>Featured skill write-ups</em>. Collapse every write-up by default,
+        one-at-a-time expansion. Fix Skills & Commands so descriptions always
+        render and actually expand. Smallest-diff path.
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <div class="profile-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts · setup</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header">
+              <h3>Featured skill write-ups</h3>
+              <span class="count-pill">3 write-ups</span>
+            </div>
+            <p style="font-size: 12px; color: #64748b; margin-bottom: 10px">
+              Skills this developer published a detailed write-up for. Click a
+              row to read.
+            </p>
+
+            <div class="skill-accordion" data-acc>
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">skill-showcase</span>
+                  <span class="skill-accordion-desc"
+                    >Build a single-file public HTML showcase of a collection of
+                    Claude Code skills — table of contents, grouped categories,
+                    per-skill README with hero image…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished">
+                    <h2>Overview</h2>
+                    <p>
+                      Generates a portable, self-contained HTML file from a
+                      directory of Claude Code skills. No server, no build step
+                      — just one file you can host anywhere.
+                    </p>
+                    <h2>Usage</h2>
+                    <pre><code>skill-showcase --skills-dir ~/.claude/skills --output ~/showcase.html</code></pre>
+                    <h3>Options</h3>
+                    <ul>
+                      <li>
+                        <code>--skills-dir</code> — directory containing skill
+                        folders
+                      </li>
+                      <li><code>--output</code> — output HTML path</li>
+                      <li>
+                        <code>--exclude-private</code> — skip skills marked
+                        private
+                      </li>
+                    </ul>
+                    <blockquote>
+                      Ships with a built-in PII scrubber that masks paths,
+                      emails, and identifiers before rendering.
+                    </blockquote>
+                  </div>
+                </div>
+              </div>
+
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">ux-mockup</span>
+                  <span class="skill-accordion-desc"
+                    >Create interactive HTML mockups for UX design review with
+                    built-in feedback collection, version history, viewport
+                    toggle…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished">
+                    <p>
+                      Collapsed until expanded. Lazy-rendered if readme is
+                      large.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">frontend-design</span>
+                  <span class="skill-accordion-desc"
+                    >Build web interfaces with genuine design quality, not AI
+                    slop. Landing pages, web apps, dashboards, admin
+                    panels…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished">
+                    <p>Collapsed until expanded.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header" style="margin-top: 32px">
+              <h3>All skills &amp; commands</h3>
+              <span class="count-pill">Active 18 · Unused 42</span>
+            </div>
+            <p style="font-size: 12px; color: #64748b; margin-bottom: 10px">
+              Every skill and slash command installed in this harness. Click a
+              card to read its description.
+            </p>
+            <div class="sc-grid">
+              <div class="sc-card custom compact" data-click-expand>
+                <div class="sc-card-head">
+                  <span class="sc-card-name">ux-mockup</span>
+                  <span class="sc-card-calls">14</span>
+                </div>
+                <span class="sc-card-source">custom</span>
+                <p class="sc-card-desc">
+                  Create interactive HTML mockups for UX design review with
+                  built-in feedback collection, version history, viewport
+                  toggle…
+                </p>
+              </div>
+              <div class="sc-card compact" data-click-expand>
+                <div class="sc-card-head">
+                  <span class="sc-card-name">compound-engineering:ce-work</span>
+                  <span class="sc-card-calls">9</span>
+                </div>
+                <span class="sc-card-source">plugin:compound-engineering</span>
+                <p class="sc-card-desc">
+                  Execute work efficiently while maintaining quality and
+                  finishing features.
+                </p>
+              </div>
+              <div class="sc-card compact" data-click-expand>
+                <div class="sc-card-head">
+                  <span class="sc-card-name">superpowers:brainstorming</span>
+                  <span class="sc-card-calls">6</span>
+                </div>
+                <span class="sc-card-source">plugin:superpowers</span>
+                <p class="sc-card-desc">
+                  You MUST use this before any creative work — creating
+                  features, building components, adding functionality, or
+                  modifying behavior.
+                </p>
+              </div>
+              <div class="sc-card compact" data-click-expand>
+                <div class="sc-card-head">
+                  <span class="sc-card-name">frontend-design</span>
+                  <span class="sc-card-calls">4</span>
+                </div>
+                <span class="sc-card-source">custom</span>
+                <p class="sc-card-desc">
+                  Build web interfaces with genuine design quality, not AI slop.
+                  Landing pages, web apps, dashboards…
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>What changed vs current:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>
+                Renamed "Featured Skills" → "Featured skill write-ups" +
+                subtitle explains it
+              </li>
+              <li>
+                Every write-up collapsed by default; single-row ToC; click to
+                expand inline
+              </li>
+              <li>
+                README renders with typography (h2/h3/code/pre/blockquote), not
+                wall-of-text
+              </li>
+              <li>
+                "Skills & Commands" → "All skills & commands"; cards now
+                click-to-expand full description
+              </li>
+              <li>
+                Plugin skills that have descriptions in metadata actually render
+                them now
+              </li>
+              <li>
+                Skills with truly no description hide the description line
+                instead of showing "no description"
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-b">Feedback on Option B</label>
+        <textarea
+          id="fb-option-b"
+          placeholder="Is Dashboard-only the right call? Accordion behavior? Rename OK?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION C — Dedicated Skills tab (4th) -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-c" id="option-c">
+      <span class="option-strip c">Option C · Dedicated Skills tab</span>
+      <span class="section-label">Option C — New "Skills" tab</span>
+      <p class="section-desc">
+        Promote skills to their own top-level tab. Dashboard stays about
+        metrics; Skills tab holds both the write-ups and the full inventory.
+        Order suggestion: Dashboard · <strong>Skills</strong> · Write-up ·
+        Claude Insights (skills come before the AI-authored tabs since they're
+        factual, not generated).
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <div class="profile-tabs four-tabs">
+              <div class="profile-tab">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts</div>
+                </div>
+              </div>
+              <div class="profile-tab emerald active">
+                <div class="tab-badge">⬢</div>
+                <div class="tab-info">
+                  <div class="tab-label">Skills</div>
+                  <div class="tab-meta">inventory · write-ups</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Skills tab content: two stacked accordions -->
+            <div class="sub-header">
+              <h3>Featured skill write-ups</h3>
+              <span class="count-pill">3 write-ups · 1 open</span>
+            </div>
+            <p style="font-size: 12px; color: #64748b; margin-bottom: 10px">
+              Click to expand. Heroes and full READMEs render inline.
+            </p>
+
+            <div class="skill-accordion" data-acc>
+              <div class="skill-accordion-item open">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">skill-showcase</span>
+                  <span class="skill-accordion-desc"
+                    >Build a single-file public HTML showcase of a collection of
+                    Claude Code skills…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished">
+                    <svg
+                      class="hero-img"
+                      viewBox="0 0 800 200"
+                      xmlns="http://www.w3.org/2000/svg"
+                      style="
+                        background: linear-gradient(135deg, #1e293b, #4f46e5);
+                        height: auto;
+                      "
+                    >
+                      <text
+                        x="50%"
+                        y="55%"
+                        font-size="28"
+                        font-weight="700"
+                        fill="#fff"
+                        text-anchor="middle"
+                        font-family="Inter"
+                      >
+                        skill-showcase hero
+                      </text>
+                    </svg>
+                    <h2>Overview</h2>
+                    <p>
+                      Turn a folder of Claude skills into one self-contained
+                      HTML file. Works offline. Ships PII-scrubbed by default.
+                    </p>
+                    <h2>Usage</h2>
+                    <pre><code>skill-showcase --skills-dir ~/.claude/skills --output ~/showcase.html</code></pre>
+                    <h2>Options</h2>
+                    <table>
+                      <thead>
+                        <tr>
+                          <th>Flag</th>
+                          <th>Purpose</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td><code>--skills-dir</code></td>
+                          <td>Directory of skill folders</td>
+                        </tr>
+                        <tr>
+                          <td><code>--output</code></td>
+                          <td>Output HTML path</td>
+                        </tr>
+                        <tr>
+                          <td><code>--exclude-private</code></td>
+                          <td>Skip private skills</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <blockquote>
+                      Includes a built-in scrubber that masks paths, emails, and
+                      identifiers.
+                    </blockquote>
+                  </div>
+                </div>
+              </div>
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">ux-mockup</span>
+                  <span class="skill-accordion-desc"
+                    >Create interactive HTML mockups for UX design review…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished"><p>Expand to read.</p></div>
+                </div>
+              </div>
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">frontend-design</span>
+                  <span class="skill-accordion-desc"
+                    >Build web interfaces with genuine design quality, not AI
+                    slop…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished"><p>Expand to read.</p></div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header" style="margin-top: 32px">
+              <h3>All skills &amp; commands</h3>
+              <span class="count-pill">Active 18 · Unused 42</span>
+            </div>
+            <div class="sc-grid">
+              <div class="sc-card custom compact">
+                <div class="sc-card-head">
+                  <span class="sc-card-name">ux-mockup</span
+                  ><span class="sc-card-calls">14</span>
+                </div>
+                <span class="sc-card-source">custom</span>
+                <p class="sc-card-desc">
+                  Create interactive HTML mockups for UX design review with
+                  feedback collection…
+                </p>
+              </div>
+              <div class="sc-card compact">
+                <div class="sc-card-head">
+                  <span class="sc-card-name">ce-work</span
+                  ><span class="sc-card-calls">9</span>
+                </div>
+                <span class="sc-card-source">plugin:compound-engineering</span>
+                <p class="sc-card-desc">
+                  Execute work efficiently while maintaining quality and
+                  finishing features.
+                </p>
+              </div>
+              <div class="sc-card compact">
+                <div class="sc-card-head">
+                  <span class="sc-card-name">brainstorming</span
+                  ><span class="sc-card-calls">6</span>
+                </div>
+                <span class="sc-card-source">plugin:superpowers</span>
+                <p class="sc-card-desc">
+                  Use before any creative work — explores intent, requirements,
+                  design before implementation.
+                </p>
+              </div>
+              <div class="sc-card compact">
+                <div class="sc-card-head">
+                  <span class="sc-card-name">frontend-design</span
+                  ><span class="sc-card-calls">4</span>
+                </div>
+                <span class="sc-card-source">custom</span>
+                <p class="sc-card-desc">
+                  Build web interfaces with genuine design quality, not AI slop.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>What changed vs B:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>
+                Skills promoted to own tab — Dashboard stays focused on metrics
+              </li>
+              <li>
+                Position: between Dashboard and Write-up (factual content before
+                AI-authored)
+              </li>
+              <li>
+                Emerald color — distinct from blue/indigo/purple, signals "raw
+                inventory"
+              </li>
+              <li>
+                Default state shows one write-up open so visitors see what
+                write-ups <em>are</em>
+              </li>
+              <li>
+                Deep link support: <code>#skill-showcase</code> routes to Skills
+                tab + opens that accordion item
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-c">Feedback on Option C</label>
+        <textarea
+          id="fb-option-c"
+          placeholder="New tab — yes or no? Tab order? Name? Color?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION D — Polished readme typography (focus view) -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-d" id="option-d">
+      <span class="option-strip d">Option D · Readme typography</span>
+      <span class="section-label">Option D — Polished readme rendering</span>
+      <p class="section-desc">
+        Regardless of where the skills live (B or C), the actual README content
+        needs the HTML-report treatment — real headings, code blocks, tables,
+        blockquotes, hero image at top. This is what one expanded write-up
+        should feel like when open.
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <div class="readme-polished">
+              <svg
+                class="hero-img"
+                viewBox="0 0 800 220"
+                xmlns="http://www.w3.org/2000/svg"
+                style="
+                  background: linear-gradient(
+                    135deg,
+                    #0f172a,
+                    #3b82f6 70%,
+                    #8b5cf6
+                  );
+                  height: auto;
+                "
+              >
+                <text
+                  x="50%"
+                  y="52%"
+                  font-size="32"
+                  font-weight="800"
+                  fill="#fff"
+                  text-anchor="middle"
+                  font-family="Inter"
+                >
+                  skill-showcase
+                </text>
+                <text
+                  x="50%"
+                  y="72%"
+                  font-size="14"
+                  fill="#cbd5e1"
+                  text-anchor="middle"
+                  font-family="Inter"
+                >
+                  Portable HTML for a folder of skills
+                </text>
+              </svg>
+              <h1>skill-showcase</h1>
+              <p>
+                <em
+                  >Build a single-file public HTML showcase of a collection of
+                  Claude Code skills — table of contents, grouped categories,
+                  per-skill README with hero image, custom-vs-plugin labeling,
+                  and PII scrubbing.</em
+                >
+              </p>
+
+              <h2>Overview</h2>
+              <p>
+                Takes a directory of skills and produces
+                <strong>one portable HTML file</strong> you can host anywhere.
+                No build step. No runtime dependencies. Designed for sharing
+                your Claude Code setup publicly without leaking identifiers.
+              </p>
+
+              <h2>Quick start</h2>
+              <pre><code>skill-showcase \
+  --skills-dir ~/.claude/skills \
+  --output ~/showcase.html</code></pre>
+
+              <h2>Flags</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Flag</th>
+                    <th>Default</th>
+                    <th>Purpose</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>--skills-dir</code></td>
+                    <td><code>~/.claude/skills</code></td>
+                    <td>Directory containing skill folders</td>
+                  </tr>
+                  <tr>
+                    <td><code>--output</code></td>
+                    <td><code>./showcase.html</code></td>
+                    <td>Output HTML path</td>
+                  </tr>
+                  <tr>
+                    <td><code>--title</code></td>
+                    <td>"My Claude Skills"</td>
+                    <td>Page title</td>
+                  </tr>
+                  <tr>
+                    <td><code>--exclude-private</code></td>
+                    <td><code>false</code></td>
+                    <td>Skip skills marked private</td>
+                  </tr>
+                </tbody>
+              </table>
+
+              <h2>Privacy</h2>
+              <blockquote>
+                Ships with a built-in scrubber that masks filesystem paths,
+                email addresses, API keys, and usernames before rendering. Safe
+                to publish.
+              </blockquote>
+
+              <h3>What gets scrubbed</h3>
+              <ul>
+                <li>
+                  Absolute paths under <code>/Users/*</code>,
+                  <code>/home/*</code>
+                </li>
+                <li>Email addresses and phone numbers</li>
+                <li>Anything matching known API-key prefixes</li>
+                <li>Git remote URLs with credentials</li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>Ingredients:</strong>
+            Inter font · h1 22px / h2 17px with rule / h3 15px · inline
+            <code>code</code> pink-on-slate · fenced <code>pre</code> dark slate
+            · styled tables and blockquotes · hero image at 10px radius. All
+            already safe via existing <code>rehype-sanitize</code> schema — this
+            is CSS-only.
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-d">Feedback on readme typography</label>
+        <textarea
+          id="fb-option-d"
+          placeholder="Typography feel right? Too much? Not enough?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION E — Dashboard teaser strip (horizontal cards) -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-e" id="option-e">
+      <span class="option-strip c">Option E · Dashboard teaser strip</span>
+      <span class="section-label"
+        >Option E — Write-up cards on Dashboard → open Skills tab</span
+      >
+      <p class="section-desc">
+        Keep Skills as a dedicated tab (Option C confirmed). On the Dashboard,
+        render write-ups as a horizontal strip of visual cards with hero
+        thumbnails, name, one-line description, and an unmistakable
+        <em>"Read write-up →"</em> CTA. Each card opens the Skills tab and
+        scrolls to that skill. Compact on Dashboard, unavoidable.
+      </p>
+
+      <div class="version-container">
+        <div class="version" data-version="1">
+          <div class="app-shell">
+            <div class="profile-tabs four-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts</div>
+                </div>
+              </div>
+              <div class="profile-tab emerald">
+                <div class="tab-badge">⬢</div>
+                <div class="tab-info">
+                  <div class="tab-label">Skills</div>
+                  <div class="tab-meta">inventory · write-ups</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header">
+              <h3>
+                Skill write-ups
+                <span
+                  style="
+                    font-size: 11px;
+                    color: #059669;
+                    font-weight: 700;
+                    padding: 2px 8px;
+                    background: #d1fae5;
+                    border-radius: 999px;
+                    margin-left: 6px;
+                  "
+                  >3 published</span
+                >
+              </h3>
+              <a
+                href="#option-e"
+                style="
+                  font-size: 12px;
+                  color: #2563eb;
+                  text-decoration: none;
+                  font-weight: 600;
+                "
+                >See all in Skills tab →</a
+              >
+            </div>
+            <p style="font-size: 12px; color: #64748b; margin-bottom: 14px">
+              Curated write-ups this developer published. Tap any card to read
+              in the Skills tab.
+            </p>
+
+            <div
+              style="
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+                gap: 12px;
+              "
+            >
+              <!-- Teaser card 1 -->
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                  position: relative;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #0f172a, #4f46e5);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    skill-showcase
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >skill-showcase</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Build a portable single-file HTML showcase of your Claude
+                    Code skills.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read write-up <span>→</span>
+                  </div>
+                </div>
+              </a>
+
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #7c2d12, #ea580c);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    ux-mockup
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >ux-mockup</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Interactive HTML mockups for UX review with feedback
+                    collection + viewport toggle.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read write-up <span>→</span>
+                  </div>
+                </div>
+              </a>
+
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #164e63, #06b6d4);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    frontend-design
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >frontend-design</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Build web interfaces with genuine design quality, not AI
+                    slop.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read write-up <span>→</span>
+                  </div>
+                </div>
+              </a>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>Why this works:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>Hero images act as visual anchors — impossible to miss</li>
+              <li>"Read write-up →" CTA is explicit language, no guessing</li>
+              <li>
+                Whole card hover lifts — signals clickability before you read
+                the CTA
+              </li>
+              <li>
+                "See all in Skills tab →" header link = alternate entry point
+              </li>
+              <li>
+                Clicking a card triggers tab switch + scroll; mental model:
+                "open this"
+              </li>
+              <li>
+                Dashboard stays short — 3 cards in a grid, not 3 full READMEs
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="version active" data-version="2">
+          <div class="app-shell">
+            <div class="profile-tabs four-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts</div>
+                </div>
+              </div>
+              <div class="profile-tab emerald">
+                <div class="tab-badge">⬢</div>
+                <div class="tab-info">
+                  <div class="tab-label">Skills</div>
+                  <div class="tab-meta">inventory · deep dives</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                  <div class="tab-meta">by Claude</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header">
+              <h3>
+                Skill deep dives
+                <span
+                  style="
+                    font-size: 11px;
+                    color: #059669;
+                    font-weight: 700;
+                    padding: 2px 8px;
+                    background: #d1fae5;
+                    border-radius: 999px;
+                    margin-left: 6px;
+                  "
+                  >3 published</span
+                >
+              </h3>
+              <a
+                href="#option-e"
+                style="
+                  font-size: 12px;
+                  color: #2563eb;
+                  text-decoration: none;
+                  font-weight: 600;
+                "
+                >See all 3 in Skills tab →</a
+              >
+            </div>
+            <p style="font-size: 12px; color: #64748b; margin-bottom: 14px">
+              In-depth explanations this developer published for specific
+              skills. Tap a card to read.
+            </p>
+
+            <div
+              style="
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+                gap: 12px;
+              "
+            >
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #0f172a, #4f46e5);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    skill-showcase
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >skill-showcase</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Build a portable single-file HTML showcase of your Claude
+                    Code skills.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read deep dive <span>→</span>
+                  </div>
+                </div>
+              </a>
+
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #7c2d12, #ea580c);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    ux-mockup
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >ux-mockup</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Interactive HTML mockups for UX review with feedback
+                    collection + viewport toggle.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read deep dive <span>→</span>
+                  </div>
+                </div>
+              </a>
+
+              <a
+                href="#"
+                style="
+                  display: block;
+                  text-decoration: none;
+                  color: inherit;
+                  border: 1px solid #e2e8f0;
+                  border-radius: 12px;
+                  overflow: hidden;
+                  background: #fff;
+                  transition: all 0.15s;
+                "
+                onmouseover="
+                  this.style.borderColor = '#10b981';
+                  this.style.boxShadow = '0 4px 12px rgba(16,185,129,0.15)';
+                  this.style.transform = 'translateY(-2px)';
+                "
+                onmouseout="
+                  this.style.borderColor = '#e2e8f0';
+                  this.style.boxShadow = 'none';
+                  this.style.transform = 'none';
+                "
+              >
+                <svg
+                  viewBox="0 0 400 120"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    width: 100%;
+                    display: block;
+                    background: linear-gradient(135deg, #164e63, #06b6d4);
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="20"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    frontend-design
+                  </text>
+                </svg>
+                <div style="padding: 12px 14px">
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 6px;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    <span
+                      style="font-size: 14px; font-weight: 700; color: #0f172a"
+                      >frontend-design</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <p
+                    style="
+                      font-size: 12px;
+                      color: #475569;
+                      line-height: 1.45;
+                      margin-bottom: 10px;
+                      display: -webkit-box;
+                      -webkit-line-clamp: 2;
+                      -webkit-box-orient: vertical;
+                      overflow: hidden;
+                    "
+                  >
+                    Build web interfaces with genuine design quality, not AI
+                    slop.
+                  </p>
+                  <div
+                    style="
+                      display: flex;
+                      align-items: center;
+                      gap: 4px;
+                      font-size: 12px;
+                      font-weight: 700;
+                      color: #059669;
+                    "
+                  >
+                    Read deep dive <span>→</span>
+                  </div>
+                </div>
+              </a>
+            </div>
+
+            <!-- Naming variants shown inline for comparison -->
+            <div
+              style="
+                margin-top: 28px;
+                border: 1px dashed #cbd5e1;
+                border-radius: 12px;
+                padding: 16px;
+                background: #fafafa;
+              "
+            >
+              <div
+                style="
+                  font-size: 10px;
+                  font-weight: 800;
+                  text-transform: uppercase;
+                  letter-spacing: 0.1em;
+                  color: #64748b;
+                  margin-bottom: 12px;
+                "
+              >
+                Header naming — pick one
+              </div>
+              <div
+                style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px"
+              >
+                <div
+                  style="
+                    background: #fff;
+                    border: 2px solid #10b981;
+                    border-radius: 8px;
+                    padding: 10px 12px;
+                  "
+                >
+                  <div
+                    style="font-size: 15px; font-weight: 700; color: #0f172a"
+                  >
+                    Skill deep dives
+                    <span
+                      style="
+                        font-size: 10px;
+                        color: #059669;
+                        font-weight: 700;
+                        padding: 2px 6px;
+                        background: #d1fae5;
+                        border-radius: 999px;
+                      "
+                      >3 published</span
+                    >
+                  </div>
+                  <div
+                    style="
+                      font-size: 11px;
+                      color: #059669;
+                      margin-top: 4px;
+                      font-weight: 600;
+                    "
+                  >
+                    ✓ Claude's pick — signals depth, no "write-up" overlap with
+                    Claude tab
+                  </div>
+                </div>
+                <div
+                  style="
+                    background: #fff;
+                    border: 1px solid #e2e8f0;
+                    border-radius: 8px;
+                    padding: 10px 12px;
+                  "
+                >
+                  <div
+                    style="font-size: 15px; font-weight: 700; color: #0f172a"
+                  >
+                    Skill showcase
+                    <span
+                      style="
+                        font-size: 10px;
+                        color: #64748b;
+                        font-weight: 700;
+                        padding: 2px 6px;
+                        background: #f1f5f9;
+                        border-radius: 999px;
+                      "
+                      >3 featured</span
+                    >
+                  </div>
+                  <div style="font-size: 11px; color: #64748b; margin-top: 4px">
+                    Matches existing code naming — neutral, brand-aligned with
+                    insightharness
+                  </div>
+                </div>
+                <div
+                  style="
+                    background: #fff;
+                    border: 1px solid #e2e8f0;
+                    border-radius: 8px;
+                    padding: 10px 12px;
+                  "
+                >
+                  <div
+                    style="font-size: 15px; font-weight: 700; color: #0f172a"
+                  >
+                    Skill spotlights
+                    <span
+                      style="
+                        font-size: 10px;
+                        color: #64748b;
+                        font-weight: 700;
+                        padding: 2px 6px;
+                        background: #f1f5f9;
+                        border-radius: 999px;
+                      "
+                      >3 highlighted</span
+                    >
+                  </div>
+                  <div style="font-size: 11px; color: #64748b; margin-top: 4px">
+                    Curation signal — "these are the ones I'm drawing attention
+                    to"
+                  </div>
+                </div>
+                <div
+                  style="
+                    background: #fff;
+                    border: 1px solid #e2e8f0;
+                    border-radius: 8px;
+                    padding: 10px 12px;
+                  "
+                >
+                  <div
+                    style="font-size: 15px; font-weight: 700; color: #0f172a"
+                  >
+                    Skill explainers
+                    <span
+                      style="
+                        font-size: 10px;
+                        color: #64748b;
+                        font-weight: 700;
+                        padding: 2px 6px;
+                        background: #f1f5f9;
+                        border-radius: 999px;
+                      "
+                      >3 available</span
+                    >
+                  </div>
+                  <div style="font-size: 11px; color: #64748b; margin-top: 4px">
+                    Utilitarian — sounds like docs/tutorials
+                  </div>
+                </div>
+              </div>
+              <div style="margin-top: 10px; font-size: 11px; color: #64748b">
+                CTA on each card would match: "Read deep dive →" / "Read
+                showcase →" / "Read spotlight →" / "Read explainer →"
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>v2 changes vs v1:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>Header link now shows count: "See all 3 in Skills tab →"</li>
+              <li>
+                Renamed "Skill write-ups" → "Skill deep dives" (avoids Write-up
+                tab collision)
+              </li>
+              <li>CTA on each card: "Read write-up" → "Read deep dive"</li>
+              <li>
+                Skills tab meta text also updated: "inventory · deep dives"
+              </li>
+              <li>
+                Count pill reads "3 published" — matches author intent of
+                "things I chose to publish"
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-e">Feedback on Option E</label>
+        <textarea
+          id="fb-option-e"
+          placeholder="Does the hero thumbnail card + 'Read write-up →' CTA solve the discoverability concern?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION F — Inline-first write-up + rest as ToC -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-f" id="option-f">
+      <span class="option-strip c">Option F · Inline preview + ToC</span>
+      <span class="section-label"
+        >Option F — First write-up inline, rest link to Skills tab</span
+      >
+      <p class="section-desc">
+        Show ONE write-up inline on the Dashboard (the most-used or most-recent
+        one) with the full polished typography from Option D. Under it, list the
+        remaining write-ups as a compact ToC that links to the Skills tab.
+        Reader sees <em>what a write-up is</em> without needing to switch tabs —
+        but the page stays bounded to one readme, not three.
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <div class="profile-tabs four-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts</div>
+                </div>
+              </div>
+              <div class="profile-tab emerald">
+                <div class="tab-badge">⬢</div>
+                <div class="tab-info">
+                  <div class="tab-label">Skills</div>
+                  <div class="tab-meta">inventory · write-ups</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                </div>
+              </div>
+            </div>
+
+            <div class="sub-header">
+              <h3>Featured write-up</h3>
+              <a
+                href="#"
+                style="
+                  font-size: 12px;
+                  color: #2563eb;
+                  text-decoration: none;
+                  font-weight: 600;
+                "
+                >See all 3 in Skills tab →</a
+              >
+            </div>
+
+            <div
+              style="
+                border: 1px solid #e2e8f0;
+                border-radius: 12px;
+                padding: 20px;
+                background: #fff;
+              "
+            >
+              <div class="readme-polished">
+                <svg
+                  class="hero-img"
+                  viewBox="0 0 800 160"
+                  xmlns="http://www.w3.org/2000/svg"
+                  style="
+                    background: linear-gradient(135deg, #0f172a, #4f46e5);
+                    height: auto;
+                  "
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="26"
+                    font-weight="800"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    skill-showcase
+                  </text>
+                </svg>
+                <h1 style="margin-top: 6px">skill-showcase</h1>
+                <p>
+                  <em
+                    >Build a single-file public HTML showcase of a collection of
+                    Claude Code skills.</em
+                  >
+                </p>
+                <h2>Overview</h2>
+                <p>
+                  Turns a folder of skills into one portable HTML file. No build
+                  step. Ships PII-scrubbed by default.
+                </p>
+                <h2>Quick start</h2>
+                <pre><code>skill-showcase --skills-dir ~/.claude/skills --output ~/showcase.html</code></pre>
+              </div>
+            </div>
+
+            <div class="sub-header" style="margin-top: 28px">
+              <h3>More write-ups</h3>
+              <span class="count-pill">2 more</span>
+            </div>
+            <div
+              style="
+                border: 1px solid #e2e8f0;
+                border-radius: 12px;
+                background: #fff;
+                overflow: hidden;
+              "
+            >
+              <a
+                href="#"
+                style="
+                  display: flex;
+                  align-items: center;
+                  gap: 12px;
+                  padding: 14px 16px;
+                  text-decoration: none;
+                  color: inherit;
+                  border-bottom: 1px solid #f1f5f9;
+                "
+              >
+                <svg
+                  viewBox="0 0 48 48"
+                  style="
+                    width: 40px;
+                    height: 40px;
+                    border-radius: 6px;
+                    flex-shrink: 0;
+                    background: linear-gradient(135deg, #7c2d12, #ea580c);
+                  "
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="10"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    UX
+                  </text>
+                </svg>
+                <div style="flex: 1; min-width: 0">
+                  <div
+                    style="font-size: 14px; font-weight: 600; color: #0f172a"
+                  >
+                    ux-mockup
+                  </div>
+                  <div
+                    style="
+                      font-size: 12px;
+                      color: #64748b;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    "
+                  >
+                    Interactive HTML mockups for UX design review…
+                  </div>
+                </div>
+                <span class="skill-badge-source custom">custom</span>
+                <span style="font-size: 12px; color: #2563eb; font-weight: 600"
+                  >Read →</span
+                >
+              </a>
+              <a
+                href="#"
+                style="
+                  display: flex;
+                  align-items: center;
+                  gap: 12px;
+                  padding: 14px 16px;
+                  text-decoration: none;
+                  color: inherit;
+                "
+              >
+                <svg
+                  viewBox="0 0 48 48"
+                  style="
+                    width: 40px;
+                    height: 40px;
+                    border-radius: 6px;
+                    flex-shrink: 0;
+                    background: linear-gradient(135deg, #164e63, #06b6d4);
+                  "
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <text
+                    x="50%"
+                    y="58%"
+                    font-size="10"
+                    font-weight="700"
+                    fill="#fff"
+                    text-anchor="middle"
+                    font-family="Inter"
+                  >
+                    FE
+                  </text>
+                </svg>
+                <div style="flex: 1; min-width: 0">
+                  <div
+                    style="font-size: 14px; font-weight: 600; color: #0f172a"
+                  >
+                    frontend-design
+                  </div>
+                  <div
+                    style="
+                      font-size: 12px;
+                      color: #64748b;
+                      overflow: hidden;
+                      text-overflow: ellipsis;
+                      white-space: nowrap;
+                    "
+                  >
+                    Build web interfaces with genuine design quality, not AI
+                    slop…
+                  </div>
+                </div>
+                <span class="skill-badge-source custom">custom</span>
+                <span style="font-size: 12px; color: #2563eb; font-weight: 600"
+                  >Read →</span
+                >
+              </a>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>Trade-off:</strong> visitors see real content without
+            leaving Dashboard (no "jump to another tab" discomfort), but the
+            page is longer than E. Good when you have 3+ write-ups; less good
+            when you have 10. Which is picked as "Featured"? Author-selected or
+            highest-used.
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-f">Feedback on Option F</label>
+        <textarea
+          id="fb-option-f"
+          placeholder="Is showing one inline the right compromise? Who picks the featured one?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION G — Slide-over drawer (no tab switch) -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-g" id="option-g">
+      <span class="option-strip c">Option G · Slide-over drawer</span>
+      <span class="section-label"
+        >Option G — Click card → slide-over drawer on Dashboard</span
+      >
+      <p class="section-desc">
+        Same teaser cards as Option E, but instead of switching to the Skills
+        tab, clicking one slides a drawer in from the right with the full
+        write-up. User never leaves Dashboard. Drawer has an "Open in Skills
+        tab" link for full-page view. Resolves the "feels unorthodox to jump
+        tabs" concern.
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell" style="position: relative; overflow: hidden">
+            <div class="profile-tabs four-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                </div>
+              </div>
+              <div class="profile-tab emerald">
+                <div class="tab-badge">⬢</div>
+                <div class="tab-info"><div class="tab-label">Skills</div></div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                </div>
+              </div>
+            </div>
+
+            <div style="position: relative; min-height: 500px">
+              <!-- Dimmed dashboard behind -->
+              <div style="opacity: 0.45; pointer-events: none">
+                <div class="sub-header"><h3>Skill write-ups</h3></div>
+                <div
+                  style="
+                    display: grid;
+                    grid-template-columns: repeat(3, 1fr);
+                    gap: 12px;
+                  "
+                >
+                  <div
+                    style="
+                      border: 1px solid #e2e8f0;
+                      border-radius: 12px;
+                      overflow: hidden;
+                      background: #fff;
+                    "
+                  >
+                    <div
+                      style="
+                        height: 80px;
+                        background: linear-gradient(135deg, #0f172a, #4f46e5);
+                      "
+                    ></div>
+                    <div style="padding: 10px">
+                      <div style="font-size: 13px; font-weight: 700">
+                        skill-showcase
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    style="
+                      border: 1px solid #e2e8f0;
+                      border-radius: 12px;
+                      overflow: hidden;
+                      background: #fff;
+                    "
+                  >
+                    <div
+                      style="
+                        height: 80px;
+                        background: linear-gradient(135deg, #7c2d12, #ea580c);
+                      "
+                    ></div>
+                    <div style="padding: 10px">
+                      <div style="font-size: 13px; font-weight: 700">
+                        ux-mockup
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    style="
+                      border: 1px solid #e2e8f0;
+                      border-radius: 12px;
+                      overflow: hidden;
+                      background: #fff;
+                    "
+                  >
+                    <div
+                      style="
+                        height: 80px;
+                        background: linear-gradient(135deg, #164e63, #06b6d4);
+                      "
+                    ></div>
+                    <div style="padding: 10px">
+                      <div style="font-size: 13px; font-weight: 700">
+                        frontend-design
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Slide-over drawer -->
+              <div
+                style="
+                  position: absolute;
+                  top: 0;
+                  right: -20px;
+                  width: 60%;
+                  max-width: 560px;
+                  background: #fff;
+                  border-left: 1px solid #e2e8f0;
+                  box-shadow: -10px 0 30px rgba(15, 23, 42, 0.15);
+                  border-radius: 12px 0 0 12px;
+                  height: 100%;
+                  overflow-y: auto;
+                "
+              >
+                <div
+                  style="
+                    position: sticky;
+                    top: 0;
+                    background: #fff;
+                    border-bottom: 1px solid #f1f5f9;
+                    padding: 12px 18px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                  "
+                >
+                  <div style="display: flex; align-items: center; gap: 8px">
+                    <span style="font-size: 15px; font-weight: 700"
+                      >skill-showcase</span
+                    >
+                    <span class="skill-badge-source custom">custom</span>
+                  </div>
+                  <div style="display: flex; align-items: center; gap: 10px">
+                    <a
+                      href="#"
+                      style="
+                        font-size: 12px;
+                        color: #2563eb;
+                        text-decoration: none;
+                        font-weight: 600;
+                      "
+                      >Open in Skills tab ↗</a
+                    >
+                    <button
+                      style="
+                        background: none;
+                        border: none;
+                        font-size: 20px;
+                        cursor: pointer;
+                        color: #64748b;
+                        line-height: 1;
+                      "
+                    >
+                      ×
+                    </button>
+                  </div>
+                </div>
+                <div style="padding: 18px">
+                  <div class="readme-polished">
+                    <svg
+                      class="hero-img"
+                      viewBox="0 0 800 140"
+                      xmlns="http://www.w3.org/2000/svg"
+                      style="
+                        background: linear-gradient(135deg, #0f172a, #4f46e5);
+                        height: auto;
+                      "
+                    >
+                      <text
+                        x="50%"
+                        y="58%"
+                        font-size="24"
+                        font-weight="800"
+                        fill="#fff"
+                        text-anchor="middle"
+                        font-family="Inter"
+                      >
+                        skill-showcase
+                      </text>
+                    </svg>
+                    <h2>Overview</h2>
+                    <p>
+                      Turn a folder of Claude skills into one self-contained
+                      HTML file. Works offline. Ships PII-scrubbed.
+                    </p>
+                    <h2>Quick start</h2>
+                    <pre><code>skill-showcase --skills-dir ~/.claude/skills</code></pre>
+                    <h2>Flags</h2>
+                    <ul>
+                      <li><code>--output</code> — destination path</li>
+                      <li>
+                        <code>--exclude-private</code> — skip private skills
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note info">
+            <strong>Why this works / doesn't:</strong>
+            <ul style="margin: 6px 0 0 18px">
+              <li>
+                ✅ No unexpected tab switch — user stays where they clicked
+              </li>
+              <li>
+                ✅ Still offers Skills tab for deep browsing ("Open in Skills
+                tab ↗")
+              </li>
+              <li>
+                ✅ Shareable deep-link:
+                <code>?skill=skill-showcase</code> auto-opens drawer
+              </li>
+              <li>
+                ⚠️ Drawer on mobile becomes full-screen sheet — needs extra
+                design pass
+              </li>
+              <li>
+                ⚠️ Two places showing the same content (drawer + Skills tab) =
+                risk of feeling redundant
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-g">Feedback on Option G</label>
+        <textarea
+          id="fb-option-g"
+          placeholder="Drawer vs tab switch — which feels more natural?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div class="section-divider"></div>
+
+    <!-- ══════════════════════════════════════ -->
+    <!-- OPTION H — No separate tab, Dashboard-only with visual prominence -->
+    <!-- ══════════════════════════════════════ -->
+    <div class="mockup-section" data-section-id="option-h" id="option-h">
+      <span class="option-strip b">Option H · Counter-option: no new tab</span>
+      <span class="section-label"
+        >Option H — Skip the tab, go visual on Dashboard</span
+      >
+      <p class="section-desc">
+        Counterpoint to C/E/F/G: maybe a new tab <em>is</em> overkill. Make the
+        Dashboard write-up section visually unmissable (full-bleed hero strip
+        with thumbnails) but keep all content in-place via accordion. Page is
+        longer, but discoverability is guaranteed and there's no tab-switch
+        friction. Test case for "is the extra tab actually earning its weight?"
+      </p>
+
+      <div class="version-container">
+        <div class="version active" data-version="1">
+          <div class="app-shell">
+            <div class="profile-tabs">
+              <div class="profile-tab active">
+                <div class="tab-badge">▦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Dashboard</div>
+                  <div class="tab-meta">metrics · charts · skills</div>
+                </div>
+              </div>
+              <div class="profile-tab indigo">
+                <div class="tab-badge">✎</div>
+                <div class="tab-info">
+                  <div class="tab-label">Write-up</div>
+                </div>
+              </div>
+              <div class="profile-tab purple">
+                <div class="tab-badge">✦</div>
+                <div class="tab-info">
+                  <div class="tab-label">Claude Insights</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Big visual banner — impossible to miss -->
+            <div
+              style="
+                border: 2px solid transparent;
+                background:
+                  linear-gradient(#fff, #fff) padding-box,
+                  linear-gradient(135deg, #10b981, #3b82f6) border-box;
+                border-radius: 14px;
+                padding: 18px;
+                margin-bottom: 20px;
+              "
+            >
+              <div
+                style="
+                  display: flex;
+                  align-items: center;
+                  justify-content: space-between;
+                  margin-bottom: 14px;
+                "
+              >
+                <div>
+                  <div
+                    style="
+                      font-size: 11px;
+                      font-weight: 800;
+                      text-transform: uppercase;
+                      letter-spacing: 0.1em;
+                      color: #059669;
+                      margin-bottom: 4px;
+                    "
+                  >
+                    ✦ Featured write-ups
+                  </div>
+                  <h3 style="font-size: 17px; font-weight: 700">
+                    3 skills published by this developer
+                  </h3>
+                </div>
+              </div>
+              <div
+                style="
+                  display: grid;
+                  grid-template-columns: repeat(3, 1fr);
+                  gap: 10px;
+                "
+              >
+                <button
+                  style="
+                    border: 1px solid #e2e8f0;
+                    border-radius: 10px;
+                    overflow: hidden;
+                    background: #fff;
+                    cursor: pointer;
+                    padding: 0;
+                    text-align: left;
+                  "
+                >
+                  <svg
+                    viewBox="0 0 400 80"
+                    style="
+                      width: 100%;
+                      display: block;
+                      background: linear-gradient(135deg, #0f172a, #4f46e5);
+                    "
+                  >
+                    <text
+                      x="50%"
+                      y="60%"
+                      font-size="16"
+                      font-weight="700"
+                      fill="#fff"
+                      text-anchor="middle"
+                      font-family="Inter"
+                    >
+                      skill-showcase
+                    </text>
+                  </svg>
+                  <div style="padding: 8px 10px">
+                    <div style="font-size: 12px; font-weight: 700">
+                      skill-showcase
+                    </div>
+                  </div>
+                </button>
+                <button
+                  style="
+                    border: 1px solid #e2e8f0;
+                    border-radius: 10px;
+                    overflow: hidden;
+                    background: #fff;
+                    cursor: pointer;
+                    padding: 0;
+                    text-align: left;
+                  "
+                >
+                  <svg
+                    viewBox="0 0 400 80"
+                    style="
+                      width: 100%;
+                      display: block;
+                      background: linear-gradient(135deg, #7c2d12, #ea580c);
+                    "
+                  >
+                    <text
+                      x="50%"
+                      y="60%"
+                      font-size="16"
+                      font-weight="700"
+                      fill="#fff"
+                      text-anchor="middle"
+                      font-family="Inter"
+                    >
+                      ux-mockup
+                    </text>
+                  </svg>
+                  <div style="padding: 8px 10px">
+                    <div style="font-size: 12px; font-weight: 700">
+                      ux-mockup
+                    </div>
+                  </div>
+                </button>
+                <button
+                  style="
+                    border: 1px solid #e2e8f0;
+                    border-radius: 10px;
+                    overflow: hidden;
+                    background: #fff;
+                    cursor: pointer;
+                    padding: 0;
+                    text-align: left;
+                  "
+                >
+                  <svg
+                    viewBox="0 0 400 80"
+                    style="
+                      width: 100%;
+                      display: block;
+                      background: linear-gradient(135deg, #164e63, #06b6d4);
+                    "
+                  >
+                    <text
+                      x="50%"
+                      y="60%"
+                      font-size="16"
+                      font-weight="700"
+                      fill="#fff"
+                      text-anchor="middle"
+                      font-family="Inter"
+                    >
+                      frontend-design
+                    </text>
+                  </svg>
+                  <div style="padding: 8px 10px">
+                    <div style="font-size: 12px; font-weight: 700">
+                      frontend-design
+                    </div>
+                  </div>
+                </button>
+              </div>
+              <p style="font-size: 12px; color: #64748b; margin-top: 12px">
+                Click a thumbnail to jump to its write-up below ↓
+              </p>
+            </div>
+
+            <div class="skill-accordion">
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">skill-showcase</span>
+                  <span class="skill-accordion-desc"
+                    >Build a single-file public HTML showcase…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished"><p>Expand to read.</p></div>
+                </div>
+              </div>
+              <div class="skill-accordion-item">
+                <div class="skill-accordion-header" data-acc-toggle>
+                  <svg
+                    class="skill-chev"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M7 5l6 5-6 5V5z" />
+                  </svg>
+                  <span class="skill-accordion-name">ux-mockup</span>
+                  <span class="skill-accordion-desc"
+                    >Interactive HTML mockups for UX review…</span
+                  >
+                  <span class="skill-badge-source custom">custom</span>
+                </div>
+                <div class="skill-accordion-body">
+                  <div class="readme-polished"><p>Expand to read.</p></div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="design-note">
+            <strong>Trade-off:</strong> discoverability is 100% but the page is
+            now the longest of any option. Works if you trust users to
+            scroll-then-click-to-expand. Doesn't scale past ~5 write-ups. Good
+            stress-test: do we actually need the Skills tab, or is this enough?
+          </div>
+        </div>
+      </div>
+
+      <div class="feedback-area">
+        <label for="fb-option-h">Feedback on Option H</label>
+        <textarea
+          id="fb-option-h"
+          placeholder="Does this make the tab unnecessary, or does it prove you still want the tab?"
+        ></textarea>
+        <div class="char-count"></div>
+      </div>
+    </div>
+
+    <div style="height: 80px"></div>
+
+    <script>
+      // Accordion toggle: click row to open/close
+      document.querySelectorAll("[data-acc-toggle]").forEach((hdr) => {
+        hdr.addEventListener("click", () => {
+          const item = hdr.closest(".skill-accordion-item");
+          item.classList.toggle("open");
+        });
+      });
+
+      // S&C card click-to-expand
+      document.querySelectorAll("[data-click-expand]").forEach((card) => {
+        card.addEventListener("click", () => {
+          card.classList.toggle("expanded");
+          card.classList.toggle("compact");
+        });
+      });
+
+      function copyAllFeedback() {
+        const feedback = {};
+        document.querySelectorAll(".mockup-section").forEach((section) => {
+          const id = section.dataset.sectionId;
+          const textarea = section.querySelector("textarea");
+          if (textarea && textarea.value.trim()) {
+            feedback[id] = { feedback: textarea.value.trim() };
+          }
+        });
+        if (Object.keys(feedback).length === 0) {
+          alert("No feedback entered yet.");
+          return;
+        }
+        const json = JSON.stringify(
+          {
+            mockup: document.title,
+            timestamp: new Date().toISOString(),
+            sections: feedback,
+          },
+          null,
+          2,
+        );
+        navigator.clipboard.writeText(json).then(() => {
+          const btn = document.querySelector(".copy-all-btn");
+          btn.textContent = "Copied!";
+          btn.classList.add("copied");
+          setTimeout(() => {
+            btn.textContent = "Copy All Feedback";
+            btn.classList.remove("copied");
+          }, 2000);
+        });
+      }
+
+      document.querySelectorAll(".feedback-area textarea").forEach((ta) => {
+        const counter = ta.parentElement.querySelector(".char-count");
+        if (!counter) return;
+        ta.addEventListener("input", () => {
+          counter.textContent = ta.value.length
+            ? `${ta.value.length} chars`
+            : "";
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12498,6 +12498,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
+      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
+      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
+      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
+      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
+      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
+      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
+      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,3 +97,150 @@ body {
   font-size: 16px !important;
   font-weight: 600 !important;
 }
+
+/* Skill README rendering — polished typography for the Skills tab
+   "deep dive" accordion bodies. ReactMarkdown emits plain HTML tags,
+   so we style them directly via this scoped class rather than relying
+   on @tailwindcss/typography (not installed in this project). Dark
+   mode variants use the .dark parent selector convention already
+   established for this codebase. */
+.skill-readme {
+  font-size: 14px;
+  line-height: 1.65;
+  color: #1e293b;
+}
+.dark .skill-readme {
+  color: #e2e8f0;
+}
+.skill-readme > :first-child {
+  margin-top: 0;
+}
+.skill-readme h1,
+.skill-readme h2,
+.skill-readme h3,
+.skill-readme h4 {
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: -0.01em;
+  margin: 22px 0 10px;
+  line-height: 1.25;
+}
+.dark .skill-readme h1,
+.dark .skill-readme h2,
+.dark .skill-readme h3,
+.dark .skill-readme h4 {
+  color: #f1f5f9;
+}
+.skill-readme h1 {
+  font-size: 22px;
+}
+.skill-readme h2 {
+  font-size: 17px;
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 6px;
+}
+.dark .skill-readme h2 {
+  border-bottom-color: #334155;
+}
+.skill-readme h3 {
+  font-size: 15px;
+}
+.skill-readme h4 {
+  font-size: 14px;
+}
+.skill-readme p {
+  margin: 10px 0;
+}
+.skill-readme a {
+  color: #2563eb;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.dark .skill-readme a {
+  color: #60a5fa;
+}
+.skill-readme code {
+  background: #f1f5f9;
+  color: #be185d;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+}
+.dark .skill-readme code {
+  background: #1e293b;
+  color: #f472b6;
+}
+.skill-readme pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 14px 16px;
+  overflow-x: auto;
+  font-size: 12.5px;
+  line-height: 1.55;
+  margin: 14px 0;
+}
+.skill-readme pre code {
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  font-size: inherit;
+}
+.skill-readme ul,
+.skill-readme ol {
+  padding-left: 22px;
+  margin: 10px 0;
+}
+.skill-readme li {
+  margin: 4px 0;
+}
+.skill-readme blockquote {
+  border-left: 3px solid #3b82f6;
+  background: #eff6ff;
+  padding: 8px 14px;
+  color: #1e40af;
+  border-radius: 0 6px 6px 0;
+  margin: 14px 0;
+}
+.dark .skill-readme blockquote {
+  background: rgba(30, 58, 138, 0.25);
+  color: #bfdbfe;
+}
+.skill-readme table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin: 14px 0;
+}
+.skill-readme th,
+.skill-readme td {
+  text-align: left;
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+}
+.skill-readme th {
+  background: #f8fafc;
+  font-weight: 600;
+}
+.dark .skill-readme th,
+.dark .skill-readme td {
+  border-color: #334155;
+}
+.dark .skill-readme th {
+  background: #1e293b;
+}
+.skill-readme hr {
+  border: none;
+  border-top: 1px solid #e2e8f0;
+  margin: 20px 0;
+}
+.dark .skill-readme hr {
+  border-top-color: #334155;
+}
+.skill-readme img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+  margin: 12px 0;
+}

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -223,11 +223,30 @@ export default function InsightDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<ProfileTab>("dashboard");
+  // Set when the Dashboard's teaser card is clicked: we switch to the Skills
+  // tab AND tell SkillsShowcaseSection which accordion item to auto-open.
+  // Cleared on any manual tab change so a later direct tab-click doesn't
+  // re-open the previously requested item.
+  const [pendingSkillAnchor, setPendingSkillAnchor] = useState<string | null>(
+    null,
+  );
 
   // Scroll to top of tab content when switching tabs so readers don't
   // land mid-way through the previous panel's scroll position.
   const handleTabChange = (tab: ProfileTab) => {
     setActiveTab(tab);
+    setPendingSkillAnchor(null);
+    if (typeof window !== "undefined") {
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
+  // Teaser-card callback — routes Dashboard clicks to the Skills tab and
+  // remembers which deep-dive to open. An empty anchor means "just show the
+  // tab" (triggered by the "See all N →" header link).
+  const handleNavigateToSkill = (anchorId: string) => {
+    setActiveTab("skills");
+    setPendingSkillAnchor(anchorId || null);
     if (typeof window !== "undefined") {
       window.scrollTo({ top: 0, behavior: "smooth" });
     }
@@ -436,9 +455,11 @@ export default function InsightDetailPage() {
                   />
                 )}
 
-              {/* Skills Teaser — top-5 shareable skills with showcase content.
-                  Renders nothing when no skill carries showcase data, so reports
-                  generated without --include-skills aren't affected. */}
+              {/* Skills Teaser — hero-thumbnail cards for the top shareable
+                  skills. Clicking one switches to the Skills tab and opens
+                  that deep-dive. Renders nothing when no skill carries
+                  showcase data, so reports generated without --include-skills
+                  aren't affected. */}
               {!isSectionHidden(hiddenSet, "skillInventory") &&
                 report.harnessData.skillInventory.length > 0 && (
                   <SkillsTeaserCard
@@ -448,34 +469,7 @@ export default function InsightDetailPage() {
                       "skillInventory",
                       (s) => s.name,
                     )}
-                  />
-                )}
-
-              {/* Skills Card Grid */}
-              {!isSectionHidden(hiddenSet, "skillInventory") &&
-                report.harnessData.skillInventory.length > 0 && (
-                  <SkillCardGrid
-                    skillInventory={filterList(
-                      report.harnessData.skillInventory,
-                      hiddenSet,
-                      "skillInventory",
-                      (s) => s.name,
-                    )}
-                  />
-                )}
-
-              {/* Full Skills Showcase — README + hero per skill, grouped by
-                  category. Rendered through SkillReadme + getSafeHeroDataUri
-                  so any unsafe markdown URL or hero data URI is stripped. */}
-              {!isSectionHidden(hiddenSet, "skillInventory") &&
-                report.harnessData.skillInventory.length > 0 && (
-                  <SkillsShowcaseSection
-                    skillInventory={filterList(
-                      report.harnessData.skillInventory,
-                      hiddenSet,
-                      "skillInventory",
-                      (s) => s.name,
-                    )}
+                    onNavigateToSkill={handleNavigateToSkill}
                   />
                 )}
 
@@ -745,6 +739,33 @@ export default function InsightDetailPage() {
                       ))}
                     </div>
                   </CollapsibleSection>
+                )}
+            </>
+          )}
+
+          {activeTab === "skills" && (
+            <>
+              {!isSectionHidden(hiddenSet, "skillInventory") &&
+                report.harnessData.skillInventory.length > 0 && (
+                  <div className="space-y-6">
+                    <SkillsShowcaseSection
+                      skillInventory={filterList(
+                        report.harnessData.skillInventory,
+                        hiddenSet,
+                        "skillInventory",
+                        (s) => s.name,
+                      )}
+                      autoOpenAnchor={pendingSkillAnchor}
+                    />
+                    <SkillCardGrid
+                      skillInventory={filterList(
+                        report.harnessData.skillInventory,
+                        hiddenSet,
+                        "skillInventory",
+                        (s) => s.name,
+                      )}
+                    />
+                  </div>
                 )}
             </>
           )}

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -445,21 +445,13 @@ export default function InsightDetailPage() {
                 <HowIWorkCluster harnessData={report.harnessData} />
               )}
 
-              {/* Workflow Diagrams */}
-              {report.harnessData.workflowData &&
-                !isSectionHidden(hiddenSet, "workflowData") && (
-                  <WorkflowDiagram
-                    workflowData={report.harnessData.workflowData}
-                    agentDispatch={report.harnessData.agentDispatch}
-                    authorHandle={report.author.username}
-                  />
-                )}
-
               {/* Skills Teaser — hero-thumbnail cards for the top shareable
                   skills. Clicking one switches to the Skills tab and opens
                   that deep-dive. Renders nothing when no skill carries
                   showcase data, so reports generated without --include-skills
-                  aren't affected. */}
+                  aren't affected. Placed between How-I-Work and the
+                  workflow diagram so the deep-dives sit next to the
+                  behavioral context that motivates them. */}
               {!isSectionHidden(hiddenSet, "skillInventory") &&
                 report.harnessData.skillInventory.length > 0 && (
                   <SkillsTeaserCard
@@ -470,6 +462,16 @@ export default function InsightDetailPage() {
                       (s) => s.name,
                     )}
                     onNavigateToSkill={handleNavigateToSkill}
+                  />
+                )}
+
+              {/* Workflow Diagrams */}
+              {report.harnessData.workflowData &&
+                !isSectionHidden(hiddenSet, "workflowData") && (
+                  <WorkflowDiagram
+                    workflowData={report.harnessData.workflowData}
+                    agentDispatch={report.harnessData.agentDispatch}
+                    authorHandle={report.author.username}
                   />
                 )}
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
@@ -500,6 +500,10 @@ export default function UploadPage() {
   const [showCurlFallback, setShowCurlFallback] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const harnessFileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    posthog.capture("profile_upload_started");
+  }, []);
 
   const toggleSection = (key: string) => {
     setDisabledSections((prev) => ({ ...prev, [key]: !prev[key] }));

--- a/src/components/ProfileTabs.tsx
+++ b/src/components/ProfileTabs.tsx
@@ -2,7 +2,7 @@
 
 import clsx from "clsx";
 
-export type ProfileTab = "dashboard" | "writeup" | "insights";
+export type ProfileTab = "dashboard" | "skills" | "writeup" | "insights";
 
 interface TabDef {
   key: ProfileTab;
@@ -109,6 +109,32 @@ function WriteupIcon({ className }: { className?: string }) {
   );
 }
 
+function SkillsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      aria-hidden="true"
+    >
+      {/* Hexagon shell — echoes the "module/building-block" metaphor. */}
+      <path
+        d="M12 2.75 20 7.25V16.75L12 21.25 4 16.75V7.25L12 2.75Z"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinejoin="round"
+      />
+      {/* Inner stacked slabs — suggest a mini-library of skills. */}
+      <path
+        d="M8 10.5h8M8 13h6M8 15.5h4"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
 function InsightsIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -150,6 +176,17 @@ const TABS: TabDef[] = [
     Icon: DashboardIcon,
   },
   {
+    key: "skills",
+    label: "Skills",
+    meta: "inventory · deep dives",
+    idleBg: "bg-emerald-100 dark:bg-emerald-900/30",
+    idleText: "text-emerald-600 dark:text-emerald-400",
+    activeFill: "bg-emerald-50 dark:bg-emerald-950/30",
+    activeBadgeBg: "bg-emerald-600",
+    activeShadow: "shadow-[0_4px_10px_-3px_rgba(5,150,105,0.45)]",
+    Icon: SkillsIcon,
+  },
+  {
     key: "writeup",
     label: "Write-up",
     byClaude: true,
@@ -183,7 +220,7 @@ export default function ProfileTabs({ active, onChange }: ProfileTabsProps) {
     <div
       role="tablist"
       aria-label="Profile sections"
-      className="relative mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/50 sm:grid-cols-3"
+      className="relative mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/50 sm:grid-cols-2 lg:grid-cols-4"
     >
       {TABS.map((tab) => {
         const isActive = active === tab.key;

--- a/src/components/ProjectLinks.tsx
+++ b/src/components/ProjectLinks.tsx
@@ -124,12 +124,17 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
   return (
     <div
       className={clsx(
-        "group relative overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow dark:border-slate-700 dark:bg-slate-800/50",
+        "group relative flex overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-shadow dark:border-slate-700 dark:bg-slate-800/50",
         hoverClass,
       )}
     >
       {showImage && safeOgImage && (
-        <div className="relative aspect-[16/7] w-full overflow-hidden bg-slate-100 dark:bg-slate-900">
+        // Horizontal thumbnail: fixed width, aspect ratio matches the
+        // OG 1200×630 standard (40:21), and object-contain so the full
+        // image is always visible — no cropping. Letterboxing falls
+        // back to a neutral slate fill. Hidden on the smallest screens
+        // to keep the card compact on phones.
+        <div className="relative my-3 ml-3 hidden aspect-[40/21] w-32 shrink-0 self-center overflow-hidden rounded-md bg-slate-100 dark:bg-slate-900 sm:block">
           {/* Plain <img> on purpose — OG images come from arbitrary
               third-party hosts and next/image would require wildcard
               remotePatterns in next.config.ts. URL has been gated by
@@ -138,14 +143,14 @@ function ProjectCard({ link }: { link: ProjectCardData }) {
           <img
             src={safeOgImage}
             alt=""
-            className="h-full w-full object-cover"
+            className="h-full w-full object-contain"
             onError={() => setImageFailed(true)}
             loading="lazy"
             referrerPolicy="no-referrer"
           />
         </div>
       )}
-      <div className="p-3">
+      <div className="min-w-0 flex-1 p-3">
         {showSiteRow && (
           <div className="mb-1 flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
             {safeFavicon && (

--- a/src/components/SkillCardGrid.tsx
+++ b/src/components/SkillCardGrid.tsx
@@ -54,14 +54,14 @@ function SkillCard({
       >
         {skill.source}
       </div>
-      {skill.description && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          aria-expanded={expanded}
-          aria-label={expanded ? "Collapse description" : "Expand description"}
-          className="group mt-2 flex w-full items-start gap-1.5 text-left"
-        >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse description" : "Expand description"}
+        className="group mt-2 flex w-full items-start gap-1.5 text-left"
+      >
+        {skill.description ? (
           <p
             className={`flex-1 text-xs leading-relaxed transition-all ${
               expanded ? "" : "line-clamp-2"
@@ -73,30 +73,34 @@ function SkillCard({
           >
             {skill.description}
           </p>
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            className={`mt-0.5 shrink-0 transition-transform duration-200 ${
-              expanded ? "rotate-180" : ""
-            } ${
-              dimmed
-                ? "text-slate-400 dark:text-slate-500"
-                : "text-slate-500 dark:text-slate-400"
-            }`}
-            aria-hidden="true"
-          >
-            <path
-              d="M3 4.5l3 3 3-3"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-        </button>
-      )}
+        ) : (
+          <p className="flex-1 text-xs italic text-slate-400 dark:text-slate-500">
+            No description provided
+          </p>
+        )}
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 12 12"
+          fill="none"
+          className={`mt-0.5 shrink-0 transition-transform duration-200 ${
+            expanded ? "rotate-180" : ""
+          } ${
+            dimmed
+              ? "text-slate-400 dark:text-slate-500"
+              : "text-slate-500 dark:text-slate-400"
+          }`}
+          aria-hidden="true"
+        >
+          <path
+            d="M3 4.5l3 3 3-3"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
     </div>
   );
 }
@@ -112,7 +116,7 @@ export default function SkillCardGrid({ skillInventory }: SkillCardGridProps) {
   return (
     <div className="mb-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
       <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
-        Skills & Commands
+        All skills &amp; commands
       </h3>
 
       {/* Active skills */}

--- a/src/components/SkillsShowcaseSection.tsx
+++ b/src/components/SkillsShowcaseSection.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import { hasShowcaseContent, type HarnessSkillEntry } from "@/types/insights";
 import { getSafeHeroDataUri } from "@/lib/safe-image";
 import { buildItemKey, slugItemKey } from "@/lib/item-visibility";
@@ -5,62 +8,116 @@ import { SkillReadme } from "@/components/SkillReadme";
 
 interface SkillsShowcaseSectionProps {
   skillInventory: HarnessSkillEntry[];
+  // Optional anchor id to auto-open on mount (e.g. "skill-foo"). When omitted,
+  // the component also checks the current URL hash for a matching anchor so
+  // the Dashboard teaser cards can deep-link into a specific deep dive.
+  autoOpenAnchor?: string | null;
 }
 
 const OTHER_CATEGORY = "Other";
 
 /**
- * Full Skills Showcase — renders each shareable skill's README and (when
- * present and validated) its hero image. Grouped by category when at least
- * one skill declares one; otherwise renders a flat list with no TOC.
+ * Skills-tab deep-dive accordion. Each shareable skill is rendered as a
+ * collapsible item with the README + hero image in the body. All items are
+ * collapsed by default so the page stays bounded — reader taps a row to
+ * read. Categories become section headers when at least one skill declares
+ * one.
  *
- * Renders nothing when no entry has showcase content. The section's id
- * (#skill-showcase) is the target of SkillsTeaserCard's "View all" link.
+ * Renders nothing when no entry has showcase content.
  */
 export function SkillsShowcaseSection({
   skillInventory,
+  autoOpenAnchor,
 }: SkillsShowcaseSectionProps) {
   const showcaseSkills = skillInventory.filter(hasShowcaseContent);
+
+  // Build a stable item-key → skill map so autoOpen logic and rendering
+  // agree on anchor ids. Keyed against the full inventory to match whatever
+  // the teaser card generated for deep-links.
+  const entries = showcaseSkills.map((skill) => ({
+    skill,
+    itemKey: buildItemKey(
+      skillInventory,
+      skillInventory.indexOf(skill),
+      (s) => s.name,
+    ),
+  }));
+
+  // Initial open state respects autoOpenAnchor synchronously so SSR output
+  // and the first client render match — otherwise the server would emit a
+  // collapsed accordion even when the parent asked for an open one.
+  const [openAnchor, setOpenAnchor] = useState<string | null>(
+    autoOpenAnchor ?? null,
+  );
+
+  // Reset openAnchor during render when the parent supplies a new
+  // autoOpenAnchor (e.g. a second teaser-card click after the Skills tab is
+  // already mounted). This is the React-recommended "adjust state based on
+  // prop change" pattern — keeps us out of the setState-inside-useEffect
+  // anti-pattern that ESLint catches.
+  const prevAutoOpenRef = useRef<string | null | undefined>(autoOpenAnchor);
+  if (autoOpenAnchor && prevAutoOpenRef.current !== autoOpenAnchor) {
+    prevAutoOpenRef.current = autoOpenAnchor;
+    setOpenAnchor(autoOpenAnchor);
+  }
+
+  // Fallback: on mount, if no explicit anchor was requested, open whichever
+  // item the URL hash points at so /insights/foo/bar#skill-x shared links
+  // land with that deep-dive expanded. Only runs once; safe to ignore the
+  // subsequent lint warning since this effect is a one-shot mount sync.
+  useEffect(() => {
+    if (autoOpenAnchor) return;
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash.replace(/^#/, "");
+    if (hash && entries.some((e) => `skill-${e.itemKey}` === hash)) {
+      setOpenAnchor(hash);
+    }
+    // Intentionally run-once on mount — entries/autoOpenAnchor changes are
+    // handled by the synchronous-prop-reset branch above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (showcaseSkills.length === 0) return null;
+
+  const toggle = (anchorId: string) => {
+    setOpenAnchor((cur) => (cur === anchorId ? null : anchorId));
+  };
 
   const anyHasCategory = showcaseSkills.some(
     (s) => typeof s.category === "string" && s.category.length > 0,
   );
 
-  // Build collision-safe item keys against the ORIGINAL skillInventory so
-  // anchor ids match whatever SkillsTeaserCard generated from the same list.
-  // Using the filtered showcaseSkills here would produce different indices
-  // and break the teaser "View all" anchors.
-  const itemKeyFor = (skill: HarnessSkillEntry): string =>
-    buildItemKey(skillInventory, skillInventory.indexOf(skill), (s) => s.name);
-
   if (!anyHasCategory) {
     return (
       <section id="skill-showcase" className="space-y-6">
-        <h2 className="text-xl font-semibold">Skill Showcase</h2>
-        <div className="space-y-8">
-          {showcaseSkills.map((skill) => {
-            const itemKey = itemKeyFor(skill);
-            return <SkillCard key={itemKey} itemKey={itemKey} skill={skill} />;
-          })}
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="text-xl font-semibold">Skill deep dives</h2>
+          <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+            {entries.length} published
+          </span>
         </div>
+        <Accordion
+          entries={entries}
+          openAnchor={openAnchor}
+          onToggle={toggle}
+        />
       </section>
     );
   }
 
   // Group by category; null/empty → "Other"
-  const groups = new Map<string, HarnessSkillEntry[]>();
-  for (const skill of showcaseSkills) {
+  const groups = new Map<string, typeof entries>();
+  for (const entry of entries) {
     const cat =
-      typeof skill.category === "string" && skill.category.length > 0
-        ? skill.category
+      typeof entry.skill.category === "string" &&
+      entry.skill.category.length > 0
+        ? entry.skill.category
         : OTHER_CATEGORY;
     const bucket = groups.get(cat);
-    if (bucket) bucket.push(skill);
-    else groups.set(cat, [skill]);
+    if (bucket) bucket.push(entry);
+    else groups.set(cat, [entry]);
   }
 
-  // Categories alphabetic, but Other always last
   const categories = [...groups.keys()].sort((a, b) => {
     if (a === OTHER_CATEGORY) return 1;
     if (b === OTHER_CATEGORY) return -1;
@@ -69,7 +126,12 @@ export function SkillsShowcaseSection({
 
   return (
     <section id="skill-showcase" className="space-y-6">
-      <h2 className="text-xl font-semibold">Skill Showcase</h2>
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-xl font-semibold">Skill deep dives</h2>
+        <span className="text-xs font-semibold text-slate-500 dark:text-slate-400">
+          {entries.length} published
+        </span>
+      </div>
       <nav aria-label="Skill categories" className="text-sm">
         <ul className="flex flex-wrap gap-3">
           {categories.map((cat) => (
@@ -88,62 +150,124 @@ export function SkillsShowcaseSection({
         <div
           key={cat}
           id={`skill-cat-${slugItemKey(cat) || "other"}`}
-          className="space-y-6"
+          className="space-y-3"
         >
           <h3 className="text-lg font-medium">{cat}</h3>
-          <div className="space-y-8">
-            {(groups.get(cat) ?? []).map((skill) => {
-              const itemKey = itemKeyFor(skill);
-              return (
-                <SkillCard key={itemKey} itemKey={itemKey} skill={skill} />
-              );
-            })}
-          </div>
+          <Accordion
+            entries={groups.get(cat) ?? []}
+            openAnchor={openAnchor}
+            onToggle={toggle}
+          />
         </div>
       ))}
     </section>
   );
 }
 
-function SkillCard({
+interface AccordionProps {
+  entries: { skill: HarnessSkillEntry; itemKey: string }[];
+  openAnchor: string | null;
+  onToggle: (anchorId: string) => void;
+}
+
+function Accordion({ entries, openAnchor, onToggle }: AccordionProps) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900/50">
+      {entries.map(({ skill, itemKey }, idx) => {
+        const anchorId = `skill-${itemKey}`;
+        const isOpen = openAnchor === anchorId;
+        return (
+          <AccordionItem
+            key={itemKey}
+            skill={skill}
+            anchorId={anchorId}
+            isOpen={isOpen}
+            onToggle={() => onToggle(anchorId)}
+            isLast={idx === entries.length - 1}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function AccordionItem({
   skill,
-  itemKey,
+  anchorId,
+  isOpen,
+  onToggle,
+  isLast,
 }: {
   skill: HarnessSkillEntry;
-  itemKey: string;
+  anchorId: string;
+  isOpen: boolean;
+  onToggle: () => void;
+  isLast: boolean;
 }) {
   const heroUri = getSafeHeroDataUri(skill);
-  const anchorId = `skill-${itemKey}`;
 
   return (
-    <article
+    <div
       id={anchorId}
-      className="rounded-lg border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-950"
+      className={
+        isLast ? "" : "border-b border-slate-100 dark:border-slate-800"
+      }
     >
-      <header className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
-        <div className="min-w-0 flex-1">
-          <h4 className="text-lg font-semibold">{skill.name}</h4>
-          {skill.description && (
-            <p className="text-sm text-zinc-600 dark:text-zinc-400">
-              {skill.description}
-            </p>
-          )}
-        </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        className={`flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors ${
+          isOpen
+            ? "bg-emerald-50/60 dark:bg-emerald-950/30"
+            : "hover:bg-slate-50 dark:hover:bg-slate-800/50"
+        }`}
+      >
+        <svg
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          className={`h-5 w-5 shrink-0 transition-transform ${
+            isOpen
+              ? "rotate-90 text-emerald-600 dark:text-emerald-400"
+              : "text-slate-400 dark:text-slate-500"
+          }`}
+          aria-hidden="true"
+        >
+          <path d="M7 5l6 5-6 5V5z" />
+        </svg>
+        <span className="shrink-0 text-sm font-semibold text-slate-900 dark:text-slate-100">
+          {skill.name}
+        </span>
+        {skill.description ? (
+          <span
+            className={`min-w-0 flex-1 text-xs text-slate-500 dark:text-slate-400 ${
+              isOpen ? "" : "truncate"
+            }`}
+          >
+            {skill.description}
+          </span>
+        ) : (
+          <span className="min-w-0 flex-1" />
+        )}
         <SourceBadge source={skill.source} />
-      </header>
-      {heroUri && (
-        <div className="mb-4 overflow-hidden rounded-md border border-zinc-200 dark:border-zinc-800">
-          <img
-            src={heroUri}
-            alt={skill.description || skill.name}
-            className="h-auto w-full"
-          />
+      </button>
+      {isOpen && (
+        <div className="border-t border-slate-100 bg-slate-50/60 px-5 pb-6 pt-4 dark:border-slate-800 dark:bg-slate-900/30">
+          {heroUri && (
+            <div className="mb-4 overflow-hidden rounded-lg border border-slate-200 dark:border-slate-700">
+              <img
+                src={heroUri}
+                alt={skill.description || skill.name}
+                className="h-auto w-full"
+              />
+            </div>
+          )}
+          <div className="skill-readme">
+            <SkillReadme markdown={skill.readme_markdown ?? ""} />
+          </div>
         </div>
       )}
-      <div className="prose prose-sm max-w-none dark:prose-invert">
-        <SkillReadme markdown={skill.readme_markdown ?? ""} />
-      </div>
-    </article>
+    </div>
   );
 }
 
@@ -151,7 +275,7 @@ function SourceBadge({ source }: { source: string }) {
   const isPlugin = source.startsWith("plugin:") || source === "plugin";
   return (
     <span
-      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
         isPlugin
           ? "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
           : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"

--- a/src/components/SkillsTeaserCard.tsx
+++ b/src/components/SkillsTeaserCard.tsx
@@ -1,76 +1,167 @@
+"use client";
+
 import { hasShowcaseContent, type HarnessSkillEntry } from "@/types/insights";
 import { buildItemKey } from "@/lib/item-visibility";
+import { getSafeHeroDataUri } from "@/lib/safe-image";
 
 interface SkillsTeaserCardProps {
   skillInventory: HarnessSkillEntry[];
+  // Called when a card or "See all" link is clicked — parent switches the
+  // active tab to "skills" and scrolls the anchor into view. When omitted,
+  // clicking falls back to the hash anchor alone.
+  onNavigateToSkill?: (anchorId: string) => void;
+}
+
+// Deterministic gradient fallback for skills without a hero image. Hashes
+// the skill name into one of a handful of curated color pairs so the same
+// skill renders the same gradient across loads. Matches the palette used
+// in the mockup so visual identity is consistent.
+const GRADIENTS: [string, string][] = [
+  ["#0f172a", "#4f46e5"],
+  ["#7c2d12", "#ea580c"],
+  ["#164e63", "#06b6d4"],
+  ["#1e1b4b", "#7c3aed"],
+  ["#064e3b", "#10b981"],
+  ["#7f1d1d", "#f43f5e"],
+];
+
+function gradientFor(name: string): [string, string] {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 31 + name.charCodeAt(i)) | 0;
+  }
+  return GRADIENTS[Math.abs(hash) % GRADIENTS.length];
 }
 
 /**
- * Top-5 teaser card that surfaces shareable skills with renderable showcase
- * content. Renders nothing when no entry carries showcase data — that's the
- * signal the report wasn't generated with --include-skills (or every showcase
- * skill was hidden).
+ * Teaser grid surfaced on the Dashboard tab that advertises the "Skill deep
+ * dives" this developer has published. Renders nothing when no skill carries
+ * showcase content (the signal that extract was run without --include-skills
+ * or every showcase skill is hidden).
  *
- * Sorted by `calls` desc with an alphabetic tiebreak, so the most-used skills
- * surface first. Targets the full SkillsShowcaseSection below via a "View all"
- * anchor.
+ * Sorted by `calls` desc with an alphabetic tiebreak. Each card links into
+ * the Skills tab (not rendered here) via onNavigateToSkill if provided, else
+ * via a plain hash anchor.
  */
-export function SkillsTeaserCard({ skillInventory }: SkillsTeaserCardProps) {
+export function SkillsTeaserCard({
+  skillInventory,
+  onNavigateToSkill,
+}: SkillsTeaserCardProps) {
   const showcaseSkills = skillInventory
     .filter(hasShowcaseContent)
+    .map((skill) => ({
+      skill,
+      itemKey: buildItemKey(
+        skillInventory,
+        skillInventory.indexOf(skill),
+        (s) => s.name,
+      ),
+    }))
     .sort((a, b) => {
-      const callsDiff = (b.calls ?? 0) - (a.calls ?? 0);
+      const callsDiff = (b.skill.calls ?? 0) - (a.skill.calls ?? 0);
       if (callsDiff !== 0) return callsDiff;
-      return a.name.localeCompare(b.name);
-    })
-    .slice(0, 5);
+      return a.skill.name.localeCompare(b.skill.name);
+    });
 
   if (showcaseSkills.length === 0) return null;
 
+  const topCards = showcaseSkills.slice(0, 3);
+  const totalCount = showcaseSkills.length;
+
+  const handleClick =
+    (anchorId: string) => (e: React.MouseEvent<HTMLAnchorElement>) => {
+      if (onNavigateToSkill) {
+        e.preventDefault();
+        onNavigateToSkill(anchorId);
+      }
+    };
+
   return (
-    <section className="rounded-lg border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-800 dark:bg-zinc-900/40">
-      <div className="mb-3 flex items-baseline justify-between">
-        <h2 className="text-lg font-semibold">Featured skills</h2>
+    <section className="rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900 dark:text-slate-100">
+          Skill deep dives
+          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-bold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+            {totalCount} published
+          </span>
+        </h2>
         <a
           href="#skill-showcase"
-          className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+          onClick={handleClick("")}
+          className="shrink-0 text-sm font-semibold text-blue-600 hover:underline dark:text-blue-400"
         >
-          View all →
+          See all {totalCount} in Skills tab →
         </a>
       </div>
-      <ul className="space-y-2">
-        {showcaseSkills.map((skill) => {
-          // Collision-safe keypath derived from the FULL input list so two
-          // skills with the same slugged name get distinct anchors matching
-          // the SkillCard DOM ids in SkillsShowcaseSection.
-          const itemKey = buildItemKey(
-            skillInventory,
-            skillInventory.indexOf(skill),
-            (s) => s.name,
-          );
+      <p className="mb-4 text-xs text-slate-500 dark:text-slate-400">
+        In-depth explanations this developer published for specific skills. Tap
+        a card to read.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {topCards.map(({ skill, itemKey }) => {
+          const heroUri = getSafeHeroDataUri(skill);
+          const anchorId = `skill-${itemKey}`;
+          const [from, to] = gradientFor(skill.name);
           return (
-            <li
+            <a
               key={itemKey}
-              className="flex items-center justify-between gap-3"
+              href={`#${anchorId}`}
+              onClick={handleClick(anchorId)}
+              className="group block overflow-hidden rounded-xl border border-slate-200 bg-white transition-all hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-[0_4px_14px_-3px_rgba(16,185,129,0.25)] dark:border-slate-700 dark:bg-slate-900"
             >
-              <div className="min-w-0 flex-1">
-                <a
-                  href={`#skill-${itemKey}`}
-                  className="font-medium hover:underline"
+              {heroUri ? (
+                <img
+                  src={heroUri}
+                  alt=""
+                  className="aspect-[5/2] w-full object-cover"
+                />
+              ) : (
+                <div
+                  aria-hidden="true"
+                  className="flex aspect-[5/2] w-full items-center justify-center text-base font-bold text-white"
+                  style={{
+                    background: `linear-gradient(135deg, ${from}, ${to})`,
+                  }}
                 >
                   {skill.name}
-                </a>
-                {skill.description && (
-                  <div className="truncate text-xs text-zinc-500">
+                </div>
+              )}
+              <div className="p-3.5">
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="truncate text-sm font-bold text-slate-900 dark:text-slate-100">
+                    {skill.name}
+                  </span>
+                  <SourceBadge source={skill.source} />
+                </div>
+                {skill.description ? (
+                  <p className="mb-2.5 line-clamp-2 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
                     {skill.description}
-                  </div>
+                  </p>
+                ) : (
+                  <p className="mb-2.5 text-xs italic text-slate-400 dark:text-slate-500">
+                    No description provided
+                  </p>
                 )}
+                <span className="inline-flex items-center gap-1 text-xs font-bold text-emerald-600 transition-transform group-hover:translate-x-0.5 dark:text-emerald-400">
+                  Read deep dive <span aria-hidden="true">→</span>
+                </span>
               </div>
-              <SourceBadge source={skill.source} />
-            </li>
+            </a>
           );
         })}
-      </ul>
+      </div>
+      {totalCount > topCards.length && (
+        <div className="mt-3 text-right">
+          <a
+            href="#skill-showcase"
+            onClick={handleClick("")}
+            className="text-xs font-semibold text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
+          >
+            + {totalCount - topCards.length} more deep dive
+            {totalCount - topCards.length === 1 ? "" : "s"} in the Skills tab →
+          </a>
+        </div>
+      )}
     </section>
   );
 }
@@ -79,7 +170,7 @@ function SourceBadge({ source }: { source: string }) {
   const isPlugin = source.startsWith("plugin:") || source === "plugin";
   return (
     <span
-      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
         isPlugin
           ? "bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
           : "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200"

--- a/src/components/__tests__/SkillsShowcaseSection.test.tsx
+++ b/src/components/__tests__/SkillsShowcaseSection.test.tsx
@@ -20,9 +20,15 @@ function makeSkill(
   };
 }
 
-function render(skills: HarnessSkillEntry[]): string {
+function render(
+  skills: HarnessSkillEntry[],
+  autoOpenAnchor: string | null = null,
+): string {
   return renderToStaticMarkup(
-    <SkillsShowcaseSection skillInventory={skills} />,
+    <SkillsShowcaseSection
+      skillInventory={skills}
+      autoOpenAnchor={autoOpenAnchor}
+    />,
   );
 }
 
@@ -67,7 +73,22 @@ describe("SkillsShowcaseSection", () => {
     expect(html.indexOf("Coding")).toBeLessThan(html.indexOf("Other"));
   });
 
-  it("renders a hero <img> with data: URI when valid PNG provided", () => {
+  it("renders a hero <img> with data: URI when the item is opened", () => {
+    const html = render(
+      [
+        makeSkill({
+          name: "with-hero",
+          hero_mime_type: "image/png",
+          hero_base64: TINY_PNG_B64,
+        }),
+      ],
+      "skill-with-hero",
+    );
+    expect(html).toContain("<img");
+    expect(html).toContain(`data:image/png;base64,${TINY_PNG_B64}`);
+  });
+
+  it("does not render hero or body when the item is collapsed (default)", () => {
     const html = render([
       makeSkill({
         name: "with-hero",
@@ -75,25 +96,32 @@ describe("SkillsShowcaseSection", () => {
         hero_base64: TINY_PNG_B64,
       }),
     ]);
-    expect(html).toContain("<img");
-    expect(html).toContain(`data:image/png;base64,${TINY_PNG_B64}`);
+    // Header still shows the name + badge, but the body (img, README
+    // prose container) is not in the DOM until the user expands.
+    expect(html).toContain("with-hero");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("skill-readme");
   });
 
-  it("omits <img> when hero_mime_type is missing", () => {
-    const html = render([
-      makeSkill({ name: "no-hero", hero_base64: TINY_PNG_B64 }),
-    ]);
+  it("omits <img> when hero_mime_type is missing (even when opened)", () => {
+    const html = render(
+      [makeSkill({ name: "no-hero", hero_base64: TINY_PNG_B64 })],
+      "skill-no-hero",
+    );
     expect(html).not.toContain("<img");
   });
 
   it("omits <img> when hero is malformed (caught by getSafeHeroDataUri)", () => {
-    const html = render([
-      makeSkill({
-        name: "bad-hero",
-        hero_mime_type: "image/png",
-        hero_base64: "not!valid!base64",
-      }),
-    ]);
+    const html = render(
+      [
+        makeSkill({
+          name: "bad-hero",
+          hero_mime_type: "image/png",
+          hero_base64: "not!valid!base64",
+        }),
+      ],
+      "skill-bad-hero",
+    );
     expect(html).not.toContain("<img");
   });
 
@@ -107,18 +135,26 @@ describe("SkillsShowcaseSection", () => {
     expect(html).toContain('id="skill-showcase"');
   });
 
-  it("renders the README markdown via SkillReadme (sanitized)", () => {
-    const html = render([
-      makeSkill({
-        name: "skill",
-        readme_markdown: "# Hello\n\n<script>alert(1)</script>\n\nWorld",
-      }),
-    ]);
+  it("renders the README markdown via SkillReadme when expanded (sanitized)", () => {
+    const html = render(
+      [
+        makeSkill({
+          name: "skill",
+          readme_markdown: "# Hello\n\n<script>alert(1)</script>\n\nWorld",
+        }),
+      ],
+      "skill-skill",
+    );
     expect(html).toContain("Hello");
     expect(html).toContain("World");
     // Sanitizer must strip the script tag
     expect(html).not.toContain("<script>");
     expect(html).not.toContain("alert(1)");
+  });
+
+  it("renders the Skill deep dives heading", () => {
+    const html = render([makeSkill({ name: "a" })]);
+    expect(html).toContain("Skill deep dives");
   });
 
   it("only renders skills with showcase content (skips bare-summary entries)", () => {
@@ -128,5 +164,17 @@ describe("SkillsShowcaseSection", () => {
     ]);
     expect(html).toContain("with-readme");
     expect(html).not.toContain("bare");
+  });
+
+  it("autoOpenAnchor expands the matching item and leaves others collapsed", () => {
+    const html = render(
+      [
+        makeSkill({ name: "alpha", readme_markdown: "# AlphaBody" }),
+        makeSkill({ name: "beta", readme_markdown: "# BetaBody" }),
+      ],
+      "skill-alpha",
+    );
+    expect(html).toContain("AlphaBody");
+    expect(html).not.toContain("BetaBody");
   });
 });

--- a/src/components/__tests__/SkillsTeaserCard.test.tsx
+++ b/src/components/__tests__/SkillsTeaserCard.test.tsx
@@ -21,6 +21,11 @@ function render(skills: HarnessSkillEntry[]): string {
   return renderToStaticMarkup(<SkillsTeaserCard skillInventory={skills} />);
 }
 
+// Visible card count on the Dashboard — matches the teaser grid in the
+// SkillsTeaserCard component. Kept as a constant so tests track the
+// component without hard-coding the number in multiple places.
+const VISIBLE_CARDS = 3;
+
 describe("SkillsTeaserCard", () => {
   it("renders nothing when no skill has showcase content", () => {
     const html = render([
@@ -33,16 +38,17 @@ describe("SkillsTeaserCard", () => {
     expect(render([])).toBe("");
   });
 
-  it("renders top-5 shareable skills sorted by calls desc", () => {
+  it("orders top cards by calls desc — anchor href order reflects the sort", () => {
     const skills = [
       makeSkill({ name: "low", calls: 1 }),
       makeSkill({ name: "high", calls: 100 }),
       makeSkill({ name: "mid", calls: 50 }),
     ];
     const html = render(skills);
-    const highIdx = html.indexOf("high");
-    const midIdx = html.indexOf("mid");
-    const lowIdx = html.indexOf("low");
+    const highIdx = html.indexOf('href="#skill-high"');
+    const midIdx = html.indexOf('href="#skill-mid"');
+    const lowIdx = html.indexOf('href="#skill-low"');
+    expect(highIdx).toBeGreaterThan(-1);
     expect(highIdx).toBeLessThan(midIdx);
     expect(midIdx).toBeLessThan(lowIdx);
   });
@@ -53,19 +59,29 @@ describe("SkillsTeaserCard", () => {
       makeSkill({ name: "alpha", calls: 5 }),
     ];
     const html = render(skills);
-    expect(html.indexOf("alpha")).toBeLessThan(html.indexOf("zebra"));
+    expect(html.indexOf('href="#skill-alpha"')).toBeLessThan(
+      html.indexOf('href="#skill-zebra"'),
+    );
   });
 
-  it("caps at 5 entries even when more have showcase content", () => {
+  it("caps visible cards and links overflow into the Skills tab", () => {
     const skills = Array.from({ length: 8 }, (_, i) =>
       makeSkill({ name: `skill-${i}`, calls: 100 - i }),
     );
     const html = render(skills);
-    // Top 5 should appear
-    expect(html).toContain("skill-0");
-    expect(html).toContain("skill-4");
-    // 6th should not
-    expect(html).not.toContain("skill-5");
+    // Visible cards (top VISIBLE_CARDS) each get a hash anchor
+    for (let i = 0; i < VISIBLE_CARDS; i++) {
+      expect(html).toContain(`href="#skill-skill-${i}"`);
+    }
+    // Overflow skills are NOT rendered as anchor cards on Dashboard
+    for (let i = VISIBLE_CARDS; i < 8; i++) {
+      expect(html).not.toContain(`href="#skill-skill-${i}"`);
+    }
+    // Header + footer link both advertise the total count of 8
+    expect(html).toContain("See all 8 in Skills tab →");
+    expect(html).toContain("8 published");
+    // Footer pluralizes the overflow count correctly
+    expect(html).toContain(`+ ${8 - VISIBLE_CARDS} more deep dives`);
   });
 
   it("excludes entries without showcase content", () => {
@@ -78,14 +94,14 @@ describe("SkillsTeaserCard", () => {
     expect(html).not.toContain("without-readme");
   });
 
-  it("renders View all anchor pointing at #skill-showcase", () => {
+  it("renders See all link pointing at #skill-showcase", () => {
     const html = render([makeSkill({ name: "a" })]);
     expect(html).toContain('href="#skill-showcase"');
   });
 
   it("renders skill anchors with kebab-case ids", () => {
     const html = render([makeSkill({ name: "Some Cool Skill" })]);
-    expect(html).toContain("#skill-some-cool-skill");
+    expect(html).toContain('href="#skill-some-cool-skill"');
   });
 
   it("renders distinct badges for plugin vs custom skills", () => {
@@ -95,5 +111,25 @@ describe("SkillsTeaserCard", () => {
     ]);
     expect(html).toContain("plugin");
     expect(html).toContain("custom");
+  });
+
+  it("renders the Skill deep dives heading + Read deep dive CTA", () => {
+    const html = render([makeSkill({ name: "a" })]);
+    expect(html).toContain("Skill deep dives");
+    expect(html).toContain("Read deep dive");
+  });
+
+  it("shows placeholder when a skill has no description", () => {
+    const html = render([makeSkill({ name: "no-desc", description: "" })]);
+    expect(html).toContain("No description provided");
+  });
+
+  it("footer link uses singular wording when exactly one skill overflows", () => {
+    const skills = Array.from({ length: VISIBLE_CARDS + 1 }, (_, i) =>
+      makeSkill({ name: `s-${i}`, calls: 100 - i }),
+    );
+    const html = render(skills);
+    expect(html).toContain("+ 1 more deep dive in the Skills tab");
+    expect(html).not.toContain("+ 1 more deep dives");
   });
 });


### PR DESCRIPTION
## Summary

- Promotes skill showcase content to its own **Skills** tab (emerald, 4th slot between Dashboard and Write-up)
- **Dashboard** keeps a compact teaser: top 3 deep dives as hero-thumbnail cards with **"Read deep dive →"** CTAs that switch to the Skills tab and auto-open the clicked item
- **SkillsShowcaseSection** is now a collapsed-by-default accordion with polished typography (styled headings, code blocks, tables, blockquotes) instead of a wall of expanded READMEs
- **SkillCardGrid** renamed to "All skills & commands"; every card now shows a description line (placeholder when missing) so the expand affordance is consistent
- Deep-link support: \`#skill-foo\` on page load opens that accordion item; teaser clicks pass the anchor through a parent callback

## Why

Previously, every skill's README rendered expanded inline on the Dashboard — reports with many write-ups became unscrollable. Plugin skills frequently showed "no description" with a non-functional expand chevron. The new Skills tab keeps Dashboard light while giving write-ups the real estate (and typography) they deserve.

## Design process

\`docs/mockups/skills-section-redesign.html\` walks through the four options considered (A current / B minimal / C new tab / D typography) plus the iteration on the Dashboard → Skills hand-off (E teaser / F inline preview / G drawer / H no-tab). User settled on E + D with the "Skill deep dives" name.

## Test plan

- [x] 505/505 vitest pass (added 16 cases across SkillsTeaserCard + SkillsShowcaseSection)
- [x] ESLint clean on all changed files (only pre-existing \`<img>\` warnings for data-URI heroes)
- [x] Typecheck clean on changed files
- [ ] Vercel preview: load \`/insights/kabirdos/20260413-53fmw7\`, verify Skills tab exists
- [ ] Click a teaser card on Dashboard → verify tab switches to Skills + correct accordion opens
- [ ] Open an accordion item → verify hero + polished typography render
- [ ] Share a \`#skill-foo\` link → verify it auto-opens that item
- [ ] All skills & commands — verify no card shows empty/missing description anymore