### PR TITLE
fix(upload): demote blue on nav/stepper so drop zone dominates

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -935,9 +935,9 @@ export default function UploadPage() {
               className={clsx(
                 "flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium transition-colors",
                 i === stepIndex
-                  ? "bg-blue-600 text-white"
+                  ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
                   : i < stepIndex
-                    ? "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-900/50"
+                    ? "bg-slate-200 text-slate-700 hover:bg-slate-300 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
                     : "bg-slate-100 dark:bg-slate-800 text-slate-400",
               )}
             >
@@ -949,7 +949,7 @@ export default function UploadPage() {
                 className={clsx(
                   "h-px w-8",
                   i < stepIndex
-                    ? "bg-blue-300 dark:bg-blue-700"
+                    ? "bg-slate-400 dark:bg-slate-500"
                     : "bg-slate-200 dark:bg-slate-700",
                 )}
               />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { useSession, signIn, signOut } from "next-auth/react";
 import {
   Menu,
@@ -27,6 +28,8 @@ const navLinks = [
 
 export default function Header() {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
+  const onUploadPage = pathname === "/upload";
   const [mobileOpen, setMobileOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -81,7 +84,13 @@ export default function Header() {
             <>
               <Link
                 href="/upload"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                aria-current={onUploadPage ? "page" : undefined}
+                className={clsx(
+                  "inline-flex items-center gap-1.5 rounded-lg px-4 py-2 text-sm font-medium transition-colors",
+                  onUploadPage
+                    ? "bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700"
+                    : "bg-blue-600 text-white hover:bg-blue-700",
+                )}
               >
                 <Upload className="h-4 w-4" />
                 Upload
@@ -194,7 +203,13 @@ export default function Header() {
                 <Link
                   href="/upload"
                   onClick={() => setMobileOpen(false)}
-                  className="flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium text-blue-600 dark:text-blue-400"
+                  aria-current={onUploadPage ? "page" : undefined}
+                  className={clsx(
+                    "flex items-center gap-2 rounded-lg px-3 py-2.5 text-sm font-medium",
+                    onUploadPage
+                      ? "text-slate-700 dark:text-slate-300"
+                      : "text-blue-600 dark:text-blue-400",
+                  )}
                 >
                   <Upload className="h-4 w-4" />
                   Upload Report


### PR DESCRIPTION
Closes #88.

## Summary
- Header Upload button: on `/upload` it switches to a neutral you-are-here treatment (`slate-100` with ring) instead of `bg-blue-600`. Elsewhere it stays the primary blue CTA.
- Mobile Upload link: same treatment — slate instead of blue when on `/upload`.
- Step indicator pills: active step is now `slate-900`, completed steps are `slate-200`, connectors are `slate-400`. The drop zone is now the only blue/actionable surface in view on Step 1.

Uses `usePathname()` to scope the demotion to `/upload` only.

## Test plan
- [ ] `/upload` — header Upload button is neutral, stepper is slate, drop zone is the most prominent blue
- [ ] `/` and other pages — header Upload button is still the blue primary CTA
- [ ] Stepper advance (Upload → Projects → Review) — current step is slate-900, completed steps are slate-200 with check icons, connectors darken when traversed
- [ ] Dark mode — all states legible
- [ ] Mobile nav — Upload link neutral on `/upload`, blue elsewhere