### PR TITLE
feat(home): Leaderboard tab (lifetime / weekly) replaces Most Voted

### DIFF
--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
+
+export interface LeaderboardRow {
+  rank: number;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  lifetimeTokens: number;
+  totalTokens: number;
+  sessionCount: number;
+  durationHours: number;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  dayCount: number | null;
+  publishedAt: string;
+  weeklyRate: number;
+}
+
+/**
+ * Leaderboard endpoint — one row per user, ranked by lifetime or weekly
+ * token usage. Reads off each user's most recent published report
+ * (matching the "vanity metrics" on their public profile). Cache tokens
+ * are excluded because the upstream `lifetimeTokens` field and
+ * `primaryModel` convention sum input+output only.
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const rank = searchParams.get("rank") === "weekly" ? "weekly" : "lifetime";
+    const page = Math.max(1, Number(searchParams.get("page") ?? "1"));
+    const limit = Math.min(
+      50,
+      Math.max(1, Number(searchParams.get("limit") ?? "10")),
+    );
+
+    // Pull every published report ordered newest-first, then dedupe by
+    // author keeping the latest. With hundreds of users this fits easily
+    // in memory; when the population grows past a few thousand we'll
+    // push this into a materialized view or window function.
+    const reports = await prisma.insightReport.findMany({
+      orderBy: { publishedAt: "desc" },
+      select: {
+        publishedAt: true,
+        totalTokens: true,
+        durationHours: true,
+        sessionCount: true,
+        linesAdded: true,
+        linesRemoved: true,
+        dayCount: true,
+        harnessData: true,
+        author: {
+          select: {
+            username: true,
+            displayName: true,
+            avatarUrl: true,
+          },
+        },
+      },
+    });
+
+    const latestByUser = new Map<string, (typeof reports)[number]>();
+    for (const r of reports) {
+      if (!latestByUser.has(r.author.username)) {
+        latestByUser.set(r.author.username, r);
+      }
+    }
+
+    const rows = [...latestByUser.values()].map((r) => {
+      const hd = r.harnessData as {
+        stats?: { lifetimeTokens?: number };
+      } | null;
+      const total = r.totalTokens ?? 0;
+      const lifetime = hd?.stats?.lifetimeTokens ?? total;
+      const days = r.dayCount ?? 0;
+      const weeks = days > 0 ? days / 7 : 0;
+      const weeklyRate = weeks > 0 ? total / weeks : 0;
+      return {
+        username: r.author.username,
+        displayName: r.author.displayName,
+        avatarUrl: r.author.avatarUrl,
+        lifetimeTokens: lifetime,
+        totalTokens: total,
+        sessionCount: r.sessionCount ?? 0,
+        durationHours: r.durationHours ?? 0,
+        linesAdded: resolveLinesAdded({
+          linesAdded: r.linesAdded,
+          harnessData: r.harnessData as never,
+        }),
+        linesRemoved: resolveLinesRemoved({
+          linesRemoved: r.linesRemoved,
+          harnessData: r.harnessData as never,
+        }),
+        dayCount: r.dayCount,
+        publishedAt: r.publishedAt.toISOString(),
+        weeklyRate,
+      };
+    });
+
+    rows.sort((a, b) => {
+      const av = rank === "weekly" ? a.weeklyRate : a.lifetimeTokens;
+      const bv = rank === "weekly" ? b.weeklyRate : b.lifetimeTokens;
+      if (bv !== av) return bv - av;
+      return (
+        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+      );
+    });
+
+    const skip = (page - 1) * limit;
+    const paged: LeaderboardRow[] = rows
+      .slice(skip, skip + limit)
+      .map((row, i) => ({ rank: skip + i + 1, ...row }));
+
+    return NextResponse.json({
+      data: paged,
+      pagination: {
+        page,
+        limit,
+        total: rows.length,
+        totalPages: Math.ceil(rows.length / limit),
+      },
+    });
+  } catch (error) {
+    console.error("GET /api/leaderboard error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch leaderboard" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
-import { TrendingUp, Clock, Flame, Upload } from "lucide-react";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { Clock, Flame, Upload, Trophy } from "lucide-react";
 import Link from "next/link";
 import ShareButton from "@/components/ShareButton";
 import Image from "next/image";
 import clsx from "clsx";
+import LeaderboardRow from "@/components/LeaderboardRow";
+import type { LeaderboardRow as LeaderboardRowData } from "@/app/api/leaderboard/route";
 import {
   normalizeSkills,
   SKILL_METADATA,
@@ -33,7 +35,8 @@ function parseSkillSource(skill: string): {
   };
 }
 
-type SortOption = "newest" | "most_voted" | "trending";
+type SortOption = "newest" | "leaderboard" | "trending";
+type LeaderboardRank = "lifetime" | "weekly";
 
 // ── Data shape ──────────────────────────────────────────────
 // Narrow view of HarnessData the homepage card actually reads.
@@ -326,7 +329,7 @@ const sortOptions: {
   icon: React.ComponentType<{ className?: string }>;
 }[] = [
   { value: "newest", label: "Newest", icon: Clock },
-  { value: "most_voted", label: "Most Voted", icon: TrendingUp },
+  { value: "leaderboard", label: "Leaderboard", icon: Trophy },
   { value: "trending", label: "Trending", icon: Flame },
 ];
 
@@ -909,16 +912,102 @@ function ProfileCard({
   );
 }
 
+// ── Leaderboard ─────────────────────────────────────────────
+function Leaderboard({
+  rows,
+  rank,
+  onRankChange,
+  loading,
+  hasMore,
+  sentinelRef,
+}: {
+  rows: LeaderboardRowData[];
+  rank: LeaderboardRank;
+  onRankChange: (r: LeaderboardRank) => void;
+  loading: boolean;
+  hasMore: boolean;
+  sentinelRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const ranks: { value: LeaderboardRank; label: string }[] = [
+    { value: "lifetime", label: "Lifetime" },
+    { value: "weekly", label: "Weekly" },
+  ];
+  const showInitialSkeleton = loading && rows.length === 0;
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-slate-500">
+          Ranked by {rank === "weekly" ? "tokens / week" : "lifetime tokens"}
+        </p>
+        <div className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white p-0.5 text-xs dark:border-slate-700 dark:bg-slate-900">
+          {ranks.map((r) => (
+            <button
+              key={r.value}
+              onClick={() => onRankChange(r.value)}
+              className={clsx(
+                "rounded-md px-3 py-1 font-medium transition-colors",
+                rank === r.value
+                  ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                  : "text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200",
+              )}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {showInitialSkeleton ? (
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-[68px] animate-pulse rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900"
+            />
+          ))}
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No eligible reports yet.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {rows.map((row) => (
+            <LeaderboardRow key={`${row.username}-${row.rank}`} row={row} />
+          ))}
+          {hasMore && (
+            <div
+              ref={sentinelRef}
+              className="py-6 text-center text-xs text-slate-400 dark:text-slate-500"
+            >
+              {loading ? "Loading…" : "Scroll for more"}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── Page ────────────────────────────────────────────────────
 export default function HomePage() {
   const [insights, setInsights] = useState<InsightSummary[]>([]);
   const [sort, setSort] = useState<SortOption>("newest");
   const [loading, setLoading] = useState(true);
+  const [leaderRank, setLeaderRank] = useState<LeaderboardRank>("lifetime");
+  const [leaderRows, setLeaderRows] = useState<LeaderboardRowData[]>([]);
+  const [leaderPage, setLeaderPage] = useState(1);
+  const [leaderHasMore, setLeaderHasMore] = useState(false);
+  const [leaderLoading, setLeaderLoading] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   // Loading is flipped true in the sort-change handler below; the initial
   // render already starts with loading=true, so the effect never needs to
   // set it synchronously (which would trip react-hooks/set-state-in-effect).
   useEffect(() => {
+    if (sort === "leaderboard") return;
     // Fetch a wider window than we display so the client-side author
     // dedupe (below) doesn't leave the "Recent Profiles" grid short
     // when one author has multiple recent reports. 30 > default 20
@@ -952,6 +1041,56 @@ export default function HomePage() {
       .catch(() => setInsights([]))
       .finally(() => setLoading(false));
   }, [sort]);
+
+  // Leaderboard fetch — resets on tab/rank change, appends on page bump.
+  useEffect(() => {
+    if (sort !== "leaderboard") return;
+    let cancelled = false;
+    fetch(`/api/leaderboard?rank=${leaderRank}&page=${leaderPage}&limit=10`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return;
+        const rows = (json.data ?? []) as LeaderboardRowData[];
+        setLeaderRows((prev) => (leaderPage === 1 ? rows : [...prev, ...rows]));
+        const pagination = json.pagination as
+          | { page: number; totalPages: number }
+          | undefined;
+        setLeaderHasMore(
+          pagination ? pagination.page < pagination.totalPages : false,
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        if (leaderPage === 1) setLeaderRows([]);
+        setLeaderHasMore(false);
+      })
+      .finally(() => {
+        if (!cancelled) setLeaderLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sort, leaderRank, leaderPage]);
+
+  // Infinite-scroll sentinel for leaderboard. Only observes while the
+  // leaderboard tab is active and more pages exist.
+  useEffect(() => {
+    if (sort !== "leaderboard") return;
+    if (!leaderHasMore || leaderLoading) return;
+    const node = sentinelRef.current;
+    if (!node) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          setLeaderLoading(true);
+          setLeaderPage((p) => p + 1);
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [sort, leaderHasMore, leaderLoading]);
 
   // Dedupe by author so the featured person doesn't also appear in the
   // "Recent Profiles" grid. One card per author.
@@ -1005,7 +1144,14 @@ export default function HomePage() {
                 key={value}
                 onClick={() => {
                   if (value === sort) return;
-                  setLoading(true);
+                  if (value === "leaderboard") {
+                    setLeaderRows([]);
+                    setLeaderPage(1);
+                    setLeaderHasMore(false);
+                    setLeaderLoading(true);
+                  } else {
+                    setLoading(true);
+                  }
                   setSort(value);
                 }}
                 className={clsx(
@@ -1022,7 +1168,23 @@ export default function HomePage() {
           </div>
         </div>
 
-        {loading ? (
+        {sort === "leaderboard" ? (
+          <Leaderboard
+            rows={leaderRows}
+            rank={leaderRank}
+            onRankChange={(r) => {
+              if (r === leaderRank) return;
+              setLeaderRows([]);
+              setLeaderPage(1);
+              setLeaderHasMore(false);
+              setLeaderLoading(true);
+              setLeaderRank(r);
+            }}
+            loading={leaderLoading}
+            hasMore={leaderHasMore}
+            sentinelRef={sentinelRef}
+          />
+        ) : loading ? (
           <div className="grid gap-4 lg:grid-cols-2">
             {Array.from({ length: 4 }).map((_, i) => (
               <div

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import clsx from "clsx";
+import { buildProfileUrl } from "@/lib/urls";
+import type { LeaderboardRow as LeaderboardRowData } from "@/app/api/leaderboard/route";
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
+  return `${Math.round(n)}`;
+}
+
+function formatLines(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return Math.round(n).toLocaleString();
+}
+
+function Stat({
+  label,
+  value,
+  mono = true,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-end text-right">
+      <span
+        className={clsx(
+          "text-sm font-bold text-slate-900 dark:text-white",
+          mono && "font-mono",
+        )}
+      >
+        {value}
+      </span>
+      <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function Lines({
+  added,
+  removed,
+}: {
+  added: number | null;
+  removed: number | null;
+}) {
+  if ((added ?? 0) === 0 && (removed ?? 0) === 0) {
+    return <span className="text-slate-400 dark:text-slate-600">—</span>;
+  }
+  return (
+    <span className="flex items-baseline gap-1.5 font-mono text-sm font-bold">
+      <span className="text-emerald-600 dark:text-emerald-400">
+        +{formatLines(added ?? 0)}
+      </span>
+      {(removed ?? 0) > 0 && (
+        <span className="text-rose-600 dark:text-rose-400">
+          -{formatLines(removed ?? 0)}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export default function LeaderboardRow({ row }: { row: LeaderboardRowData }) {
+  const href = buildProfileUrl(row.username);
+  const initial = (row.displayName || row.username)[0]?.toUpperCase() ?? "?";
+  const isTop3 = row.rank <= 3;
+
+  return (
+    <Link
+      href={href}
+      className="group grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-xl border border-slate-200 bg-white px-4 py-3 transition-all hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700 sm:px-5"
+    >
+      {/* Rank + avatar + name */}
+      <div className="flex items-center gap-3 sm:gap-4">
+        <span
+          className={clsx(
+            "flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-mono text-sm font-bold tabular-nums",
+            isTop3
+              ? "bg-amber-100 text-amber-700 ring-1 ring-inset ring-amber-200 dark:bg-amber-900/40 dark:text-amber-300 dark:ring-amber-800/60"
+              : "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
+          )}
+        >
+          {row.rank}
+        </span>
+        {row.avatarUrl ? (
+          <Image
+            src={row.avatarUrl}
+            alt=""
+            width={40}
+            height={40}
+            className="h-10 w-10 rounded-full"
+          />
+        ) : (
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 text-base font-bold text-white">
+            {initial}
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <div className="truncate text-sm font-bold text-slate-900 group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
+          {row.displayName || row.username}
+        </div>
+        <div className="truncate text-xs font-medium text-slate-400 dark:text-slate-500">
+          @{row.username}
+        </div>
+      </div>
+
+      {/* Stats — collapse to lifetime-only on mobile */}
+      <div className="flex items-center gap-5 sm:gap-6">
+        <Stat label="Lifetime" value={formatTokens(row.lifetimeTokens)} />
+        <div className="hidden sm:block">
+          <Stat label="30d Tokens" value={formatTokens(row.totalTokens)} />
+        </div>
+        <div className="hidden md:block">
+          <Stat label="Sessions" value={row.sessionCount.toLocaleString()} />
+        </div>
+        <div className="hidden md:block">
+          <Stat label="Active" value={`${row.durationHours}h`} />
+        </div>
+        <div className="hidden lg:block">
+          <Stat
+            label="Lines"
+            value={<Lines added={row.linesAdded} removed={row.linesRemoved} />}
+            mono={false}
+          />
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
Closes #98.

## Summary
- New `GET /api/leaderboard?rank=lifetime|weekly&page=N&limit=10` — returns one row per user, ranked by their latest published report's lifetime tokens (default) or normalized weekly rate (`totalTokens / (dayCount/7)`). Ties break on most recent publish date.
- New `LeaderboardRow` component — rank badge (top 3 highlighted), avatar, username, lifetime tokens, 30d tokens, sessions, active hours, +/- lines of code (columns collapse at `sm`/`md`/`lg`).
- `src/app/page.tsx` — `Most Voted` tab replaced with `Leaderboard`, `Newest` and `Trending` untouched. Leaderboard tab renders the row list with a Lifetime/Weekly sub-toggle and IntersectionObserver-driven infinite scroll (10 rows per page).
- Lifetime tokens read `harnessData.stats.lifetimeTokens` with `totalTokens` fallback — matches the hero banner convention on `HeroStats`.
- `/top` is untouched — it remains the sort/filter explore surface.

## Notes
- Cache-token exclusion is inherited from the upstream `lifetimeTokens` parser field (which already sums input+output only, matching the `primaryModel` derivation). If issue #43 (parser cache-read undercount) ships, leaderboard numbers will shift along with the rest of the site.
- Ranking is computed in-memory after a single `findMany` of all published reports. Fine at current scale — revisit with a materialized view or window function once the user count climbs past a few thousand.

## Test plan
- [ ] `/` — `Leaderboard` tab renders top 10 users sorted by lifetime tokens
- [ ] Lifetime/Weekly toggle re-sorts list and resets to page 1
- [ ] Scrolling near the bottom loads more rows via infinite scroll
- [ ] Row links to `/<username>` profile
- [ ] Row shows lifetime, 30d tokens, sessions, active hours, +/- LOC — no plugins/heatmap/skills count
- [ ] Tie-breaker (identical tokens) favors most recent publish date
- [ ] Switching back to `Newest`/`Trending` still renders the card feed
- [ ] `/top` is unchanged
- [ ] Mobile — stat columns collapse gracefully
- [ ] Dark mode — all states legible