### PR TITLE
fix(labels): 'Tokens' -> 'Billable Tokens' to match upstream parser switch

### DIFF
--- a/src/app/api/og/[username]/[slug]/route.tsx
+++ b/src/app/api/og/[username]/[slug]/route.tsx
@@ -455,7 +455,7 @@ export async function GET(
               marginTop: "10px",
             }}
           >
-            Lifetime tokens
+            Lifetime billable tokens
           </span>
         </div>
 

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -378,9 +378,9 @@ export default function ActivityHeatmap({
           ariaValueLabel="sessions"
         />
         <GridHeatmap
-          title="Tokens"
+          title="Billable Tokens"
           bigNumber={formatTokens(totalTokensSum)}
-          bigNumberLabel="total tokens"
+          bigNumberLabel="total billable tokens"
           scale="amber"
           data={tokensDaily}
           formatValue={(n) => (n > 0 ? formatTokens(n) : "")}

--- a/src/components/HarnessOverview.tsx
+++ b/src/components/HarnessOverview.tsx
@@ -35,7 +35,10 @@ export default function HarnessOverview({ harnessData }: HarnessOverviewProps) {
         </div>
         <div className="flex flex-wrap gap-6">
           {stats.totalTokens > 0 && (
-            <StatCell value={formatNumber(stats.totalTokens)} label="Tokens" />
+            <StatCell
+              value={formatNumber(stats.totalTokens)}
+              label="Billable Tokens"
+            />
           )}
           {stats.durationHours > 0 && (
             <StatCell value={`${stats.durationHours}h`} label="Duration" />

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -243,7 +243,7 @@ export default function HeroStats({
             {formatNumber(lifetimeTokens)}
           </div>
           <div className="mt-2 text-[13px] font-bold uppercase tracking-[0.1em] text-slate-500 dark:text-slate-400">
-            Lifetime Tokens
+            Lifetime Billable Tokens
           </div>
           {stats.totalTokens > 0 && stats.totalTokens !== lifetimeTokens && (
             <div className="mt-1.5 text-[13px] font-medium text-slate-400 dark:text-slate-500">
@@ -256,7 +256,7 @@ export default function HeroStats({
         {stats.totalTokens > 0 && (
           <StatCard
             value={formatNumber(stats.totalTokens)}
-            label="Tokens"
+            label="Billable Tokens"
             rate={perWeek(stats.totalTokens, dayCount)}
             numericSeed={stats.totalTokens}
           />

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -117,9 +117,12 @@ export default function LeaderboardRow({ row }: { row: LeaderboardRowData }) {
 
       {/* Stats — collapse to lifetime-only on mobile */}
       <div className="flex items-center gap-5 sm:gap-6">
-        <Stat label="Lifetime" value={formatTokens(row.lifetimeTokens)} />
+        <Stat
+          label="Lifetime Billable"
+          value={formatTokens(row.lifetimeTokens)}
+        />
         <div className="hidden sm:block">
-          <Stat label="30d Tokens" value={formatTokens(row.totalTokens)} />
+          <Stat label="30d Billable" value={formatTokens(row.totalTokens)} />
         </div>
         <div className="hidden md:block">
           <Stat label="Sessions" value={row.sessionCount.toLocaleString()} />


### PR DESCRIPTION
Companion PR to kabirdos/insight-harness#7 which switches \`totalTokens\` and \`lifetimeTokens\` in the parser to a billing-weighted sum: \`input + output + 0.1 * cache_read + 1.25 * cache_create\`. Mirrors the API pricing formula already used by \`estimateApiCostUsd\`.

## Label changes
- \`src/components/HeroStats.tsx\` — banner label \`Lifetime Tokens\` -> \`Lifetime Billable Tokens\`; 30d StatCard \`Tokens\` -> \`Billable Tokens\`
- \`src/components/HarnessOverview.tsx\` — \`Tokens\` -> \`Billable Tokens\`
- \`src/components/ActivityHeatmap.tsx\` — heatmap title \`Tokens\` -> \`Billable Tokens\`; aria/label copy matches
- \`src/components/LeaderboardRow.tsx\` — \`Lifetime\` -> \`Lifetime Billable\`, \`30d Tokens\` -> \`30d Billable\`
- \`src/app/api/og/[username]/[slug]/route.tsx\` — OG image sub-label \`Lifetime tokens\` -> \`Lifetime billable tokens\`

**Data fields are unchanged** — \`totalTokens\` / \`lifetimeTokens\` keep their names, just the displayed unit is now honest.

## Merge order
Merge **insight-harness#7 first** (and publish skill v2.7.0), then this. If this ships before #7, the labels read correctly against the old under-reported number — not harmful but semantically loose.

## Test plan
- [ ] Home leaderboard rows show \`Lifetime Billable\` / \`30d Billable\` column headers
- [ ] Profile page banner reads \`Lifetime Billable Tokens\`
- [ ] Profile page stat cards read \`Billable Tokens\`
- [ ] Activity heatmap title reads \`Billable Tokens\`
- [ ] OG card sub-label reads \`Lifetime billable tokens\`
- [ ] HarnessOverview stat cell reads \`Billable Tokens\`