### PR TITLE
fix(upload): update harness path hint to ~/.claude/insight-harness/report.html

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -88,7 +88,7 @@ const EMPTY_FORM: ProjectFormInput = {
 };
 
 const INSIGHTS_PATH = "~/.claude/usage-data/report.html";
-const HARNESS_PATH = "~/.claude/usage-data/insight-harness.html";
+const HARNESS_PATH = "~/.claude/insight-harness/report.html";
 
 const SAMPLE_PROFILE_USERNAME = "kabirdos";
 const SAMPLE_PROFILE_SLUG = "20260413-e3n48n";
@@ -669,7 +669,7 @@ export default function UploadPage() {
       handleFile(f);
     } else {
       setError(
-        "That's not an HTML file. Run /insight-harness in Claude Code — the report saves to ~/.claude/usage-data/insight-harness.html.",
+        "That's not an HTML file. Run /insight-harness in Claude Code — the report saves to ~/.claude/insight-harness/report.html.",
       );
     }
   };
@@ -1143,7 +1143,7 @@ export default function UploadPage() {
                 setDragOver={setDragOverHarness}
                 path={HARNESS_PATH}
                 loading={loading}
-                filename="insight-harness.html"
+                filename="report.html"
               />
             </div>
           </div>


### PR DESCRIPTION
Companion to [kabirdos/insight-harness#10](https://github.com/kabirdos/insight-harness/pull/10).

## Context

insight-harness was writing its output to `~/.claude/usage-data/insight-harness.html`, which is Claude Code's namespace for the built-in `/insights` report. That PR moves the primary output to a dedicated `~/.claude/insight-harness/report.html`.

## This PR

Updates the `/upload` page to match:

- `HARNESS_PATH` constant — the path shown in the drop-zone hint card
- Error message shown when a non-HTML file is dropped
- Drop-zone filename label (`insight-harness.html` → `report.html`)

Both zones (`/insights` and `/insight-harness`) now use `report.html` as their filename hint; they remain disambiguated by the full `path` shown above each drop zone and by their section headings.

## Not changed

`INSIGHTS_PATH` (`~/.claude/usage-data/report.html`) is Claude Code's built-in `/insights` report, unrelated to this move.