### PR TITLE
feat(tokens): backfill existing reports + refresh demo tokens for Option B

### DIFF
--- a/prisma/__tests__/seed-helpers.test.ts
+++ b/prisma/__tests__/seed-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   computeDefaultAgentDispatch,
   computeDefaultBranchPrefixes,
   computeDefaultHookFrequency,
+  computeDefaultPerModelTokens,
   defaultProjectSeedFor,
 } from "../seed-helpers";
 
@@ -159,5 +160,45 @@ describe("defaultProjectSeedFor", () => {
 
   it("Sam has exactly one project (the junior dev)", () => {
     expect(defaultProjectSeedFor("sam")).toHaveLength(1);
+  });
+});
+
+describe("computeDefaultPerModelTokens", () => {
+  it("per-model sums equal the target total-throughput", () => {
+    const total = 42_000_000;
+    const out = computeDefaultPerModelTokens(total, {
+      "claude-sonnet-4-6": 700,
+      "claude-opus-4-6": 300,
+    });
+    const sum = Object.values(out).reduce(
+      (acc, b) => acc + b.input + b.output + b.cache_read + b.cache_create,
+      0,
+    );
+    expect(sum).toBe(total);
+  });
+
+  it("distributes across categories with cache_read dominant", () => {
+    const out = computeDefaultPerModelTokens(10_000_000, {
+      "claude-sonnet-4-6": 1,
+    });
+    const b = out["claude-sonnet-4-6"];
+    expect(b.cache_read).toBeGreaterThan(b.input + b.output + b.cache_create);
+    expect(b.cache_read / 10_000_000).toBeGreaterThan(0.7);
+  });
+
+  it("respects model shares within ~1 token of rounding", () => {
+    const out = computeDefaultPerModelTokens(1_000_000, {
+      a: 3,
+      b: 1,
+    });
+    const sumA =
+      out.a.input + out.a.output + out.a.cache_read + out.a.cache_create;
+    const sumB =
+      out.b.input + out.b.output + out.b.cache_read + out.b.cache_create;
+    expect(sumA).toBeGreaterThan(sumB * 2.5);
+  });
+
+  it("handles empty model map gracefully", () => {
+    expect(computeDefaultPerModelTokens(100, {})).toEqual({});
   });
 });

--- a/prisma/seed-demos.ts
+++ b/prisma/seed-demos.ts
@@ -11,6 +11,7 @@ import {
   computeDefaultAgentDispatch,
   computeDefaultBranchPrefixes,
   computeDefaultHookFrequency,
+  computeDefaultPerModelTokens,
   defaultProjectSeedFor,
 } from "./seed-helpers";
 
@@ -304,6 +305,11 @@ function harnessReport(
       cliTools: opts.cliTools,
       languages: opts.languages,
       models: opts.models,
+      // 4-way breakdown for the USD cost estimator's accurate Path 1.
+      // Sums to opts.tokens so the stored totalTokens and the sum of
+      // perModelTokens stay consistent (the backfill script relies on
+      // this invariant to recompute totalTokens from perModelTokens).
+      perModelTokens: computeDefaultPerModelTokens(opts.tokens, opts.models),
       permissionModes: opts.permissionModes ?? { plan: 60, auto: 40 },
       mcpServers: opts.mcpServers ?? {},
       gitPatterns: {
@@ -460,7 +466,10 @@ async function seed() {
       days: 30,
       linesAdded: 28400,
       linesRemoved: 9200,
-      tokens: 4200000,
+      // Full-throughput 30d total (Option B — input + output + cache_read +
+      // cache_creation). Old value was ~4.2M input+output only; heavy
+      // agentic Fire-and-Forget usage pushes that 15-20x with cache traffic.
+      tokens: 72_000_000,
       durationHours: 86,
       avgSession: 36,
       skills: 18,
@@ -745,7 +754,8 @@ async function seed() {
       days: 27,
       linesAdded: 12300,
       linesRemoved: 3800,
-      tokens: 2800000,
+      // Directive / SaaS builder — moderate caching, ~15x scale-up.
+      tokens: 42_000_000,
       durationHours: 52,
       avgSession: 47,
       skills: 24,
@@ -1057,7 +1067,8 @@ async function seed() {
       days: 30,
       linesAdded: 22100,
       linesRemoved: 8400,
-      tokens: 3500000,
+      // Heavy agent work + long-context embeddings → aggressive caching.
+      tokens: 65_000_000,
       durationHours: 72,
       avgSession: 44,
       skills: 12,
@@ -1315,7 +1326,8 @@ async function seed() {
       days: 28,
       linesAdded: 22100,
       linesRemoved: 6800,
-      tokens: 3100000,
+      // Infra / incident tooling — collaborative, plenty of context reuse.
+      tokens: 48_000_000,
       durationHours: 54,
       avgSession: 28,
       skills: 9,
@@ -1467,7 +1479,8 @@ async function seed() {
       days: 27,
       linesAdded: 8900,
       linesRemoved: 3100,
-      tokens: 2400000,
+      // Freelance / Rails — collaborative, medium cache ratio.
+      tokens: 32_000_000,
       durationHours: 38,
       avgSession: 25,
       skills: 7,
@@ -1636,7 +1649,8 @@ async function seed() {
       days: 21,
       linesAdded: 4200,
       linesRemoved: 800,
-      tokens: 780000,
+      // New to Claude Code, short exploratory sessions, lighter caching.
+      tokens: 9_500_000,
       durationHours: 18,
       avgSession: 22,
       skills: 4,

--- a/prisma/seed-helpers.ts
+++ b/prisma/seed-helpers.ts
@@ -6,6 +6,49 @@
  * instantiation that seed-demos.ts does at module load.
  */
 
+export interface ModelTokenBreakdown {
+  input: number;
+  output: number;
+  cache_read: number;
+  cache_create: number;
+}
+
+/**
+ * Build a plausible 4-way perModelTokens breakdown from a total-throughput
+ * target and per-model shares. Distribution matches what real Claude Code
+ * reports produce: cache_read dominates at ~88%, input + output are a few
+ * percent each, cache_create fills the rest. Keeps the per-model sum
+ * consistent with totalTokens and gives the USD cost estimator realistic
+ * Path 1 inputs.
+ */
+export function computeDefaultPerModelTokens(
+  totalThroughput: number,
+  modelShares: Record<string, number>,
+): Record<string, ModelTokenBreakdown> {
+  const totalShare = Object.values(modelShares).reduce((a, b) => a + b, 0) || 1;
+  const entries = Object.entries(modelShares);
+  const result: Record<string, ModelTokenBreakdown> = {};
+  let runningTotal = 0;
+  entries.forEach(([model, share], i) => {
+    const isLast = i === entries.length - 1;
+    const modelTotal = isLast
+      ? Math.max(0, totalThroughput - runningTotal)
+      : Math.round((share / totalShare) * totalThroughput);
+    runningTotal += modelTotal;
+    const input = Math.round(modelTotal * 0.015);
+    const output = Math.round(modelTotal * 0.035);
+    const cacheCreate = Math.round(modelTotal * 0.07);
+    const cacheRead = Math.max(0, modelTotal - input - output - cacheCreate);
+    result[model] = {
+      input,
+      output,
+      cache_read: cacheRead,
+      cache_create: cacheCreate,
+    };
+  });
+  return result;
+}
+
 export interface DefaultAgentDispatch {
   totalAgents: number;
   types: Record<string, number>;

--- a/scripts/backfill-total-tokens.ts
+++ b/scripts/backfill-total-tokens.ts
@@ -1,0 +1,152 @@
+/**
+ * One-time backfill for the totalTokens switch from
+ * "input + output" (Option A) to "input + output + cache_read +
+ * cache_creation" (Option B / full throughput). See insight-harness#7.
+ *
+ * Reports uploaded before the skill v2.7.0 update carry the old (low)
+ * totalTokens value. For any report that still has its 4-way per-model
+ * breakdown in harnessData.perModelTokens, we can rebuild the correct
+ * number server-side. Reports without that field (pre-v2.4 uploads,
+ * demo seeds) are left untouched — we have no way to reconstruct the
+ * missing cache counts.
+ *
+ * Run:
+ *   npx tsx scripts/backfill-total-tokens.ts            # dry run
+ *   npx tsx scripts/backfill-total-tokens.ts --apply    # write changes
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+interface ModelBreakdown {
+  input?: number;
+  output?: number;
+  cache_read?: number;
+  cache_create?: number;
+}
+
+function sumThroughput(perModelTokens: Record<string, ModelBreakdown>): number {
+  let total = 0;
+  for (const breakdown of Object.values(perModelTokens)) {
+    total +=
+      (breakdown.input ?? 0) +
+      (breakdown.output ?? 0) +
+      (breakdown.cache_read ?? 0) +
+      (breakdown.cache_create ?? 0);
+  }
+  return total;
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const reports = await prisma.insightReport.findMany({
+    select: {
+      id: true,
+      slug: true,
+      totalTokens: true,
+      harnessData: true,
+      author: { select: { username: true } },
+    },
+  });
+
+  let candidates = 0;
+  let skipped = 0;
+  let unchanged = 0;
+  const rows: Array<{
+    id: string;
+    slug: string;
+    username: string;
+    old: number;
+    next: number;
+    ratio: string;
+  }> = [];
+
+  for (const report of reports) {
+    const hd = report.harnessData as {
+      perModelTokens?: Record<string, ModelBreakdown> | null;
+      stats?: { totalTokens?: number } | null;
+    } | null;
+    const perModel = hd?.perModelTokens;
+    if (!perModel || typeof perModel !== "object") {
+      skipped++;
+      continue;
+    }
+    const next = sumThroughput(perModel);
+    const old = report.totalTokens ?? 0;
+    if (next <= 0 || next === old) {
+      unchanged++;
+      continue;
+    }
+    candidates++;
+    rows.push({
+      id: report.id,
+      slug: report.slug,
+      username: report.author.username,
+      old,
+      next,
+      ratio: old > 0 ? (next / old).toFixed(1) + "x" : "n/a",
+    });
+  }
+
+  console.log(`\nScanned ${reports.length} reports`);
+  console.log(
+    `  ${candidates} need updating · ${unchanged} already match · ${skipped} lack perModelTokens (skipped)`,
+  );
+
+  if (candidates === 0) {
+    console.log("\nNothing to do.");
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log("\nPreview (up to 20):");
+  for (const r of rows.slice(0, 20)) {
+    console.log(
+      `  @${r.username} / ${r.slug}  ${r.old.toLocaleString()} → ${r.next.toLocaleString()}  (${r.ratio})`,
+    );
+  }
+  if (rows.length > 20) {
+    console.log(`  …and ${rows.length - 20} more`);
+  }
+
+  if (!apply) {
+    console.log(
+      "\nDry run — no changes written. Re-run with --apply to persist.",
+    );
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log("\nApplying updates…");
+  let written = 0;
+  for (const r of rows) {
+    const existing = await prisma.insightReport.findUnique({
+      where: { id: r.id },
+      select: { harnessData: true },
+    });
+    if (!existing?.harnessData) continue;
+    const hd = existing.harnessData as Record<string, unknown>;
+    const stats = (hd.stats as Record<string, unknown> | undefined) ?? {};
+    const nextHarnessData = {
+      ...hd,
+      stats: { ...stats, totalTokens: r.next },
+    };
+    await prisma.insightReport.update({
+      where: { id: r.id },
+      data: {
+        totalTokens: r.next,
+        harnessData: nextHarnessData,
+      },
+    });
+    written++;
+  }
+  console.log(`  ✓ Updated ${written} reports`);
+
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/backfill-total-tokens.ts
+++ b/scripts/backfill-total-tokens.ts
@@ -15,6 +15,7 @@
  *   npx tsx scripts/backfill-total-tokens.ts --apply    # write changes
  */
 
+import "dotenv/config";
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
@@ -52,6 +53,7 @@ async function main() {
 
   let candidates = 0;
   let skipped = 0;
+  let hiddenSkipped = 0;
   let unchanged = 0;
   const rows: Array<{
     id: string;
@@ -72,8 +74,16 @@ async function main() {
       skipped++;
       continue;
     }
+    // `totalTokens` is on the PUT allowlist and the schema marks it
+    // nullable — the convention for "author hid this stat" is null, not
+    // zero. Writing a fresh value would unhide data the author
+    // intentionally redacted, so skip those rows entirely.
+    if (report.totalTokens === null) {
+      hiddenSkipped++;
+      continue;
+    }
     const next = sumThroughput(perModel);
-    const old = report.totalTokens ?? 0;
+    const old = report.totalTokens;
     if (next <= 0 || next === old) {
       unchanged++;
       continue;
@@ -91,7 +101,7 @@ async function main() {
 
   console.log(`\nScanned ${reports.length} reports`);
   console.log(
-    `  ${candidates} need updating · ${unchanged} already match · ${skipped} lack perModelTokens (skipped)`,
+    `  ${candidates} need updating · ${unchanged} already match · ${skipped} lack perModelTokens (skipped) · ${hiddenSkipped} author-hidden (skipped)`,
   );
 
   if (candidates === 0) {


### PR DESCRIPTION
Pairs with insight-harness v2.7.0 which switched the headline Tokens stat to full throughput (input + output + cache_read + cache_creation). Existing reports in the DB carry the old under-counted value because \`totalTokens\` is a snapshot taken at report-generation time — this PR addresses both the old-uploads gap and the demo data.

## Backfill script (\`scripts/backfill-total-tokens.ts\`)
- Walks every \`InsightReport\` row
- For rows with \`harnessData.perModelTokens\` populated (post-v2.4 uploads), recomputes \`totalTokens\` by summing all 4 categories across every model
- Updates both the scalar \`totalTokens\` column and \`harnessData.stats.totalTokens\`
- Dry run by default; \`--apply\` persists

Rows without \`perModelTokens\` stay untouched — we can't reconstruct missing cache counts. Users can regenerate and re-upload when they upgrade the skill.

## Demo refresh
- All 6 demo users' \`tokens:\` bumped to realistic full-throughput magnitudes (~15-20x previous values). Previous values were input+output-only; typical agentic cache ratios push that up by an order of magnitude.
- New \`computeDefaultPerModelTokens\` helper splits a throughput target across the 4 categories (cache_read ~88%, cache_create ~7%, output ~3.5%, input ~1.5% — matches real Claude Code reports) and distributes by the \`models: {...}\` shares already in each demo
- \`harnessData.perModelTokens\` now emitted for every demo, so the USD cost estimator takes its accurate Path 1 branch and the backfill script's \"perModelTokens sum equals totalTokens\" invariant holds

## Test plan
- [ ] \`npx tsx scripts/backfill-total-tokens.ts\` reports the number of reports needing updates and shows a preview (dry run)
- [ ] \`npx tsx scripts/backfill-total-tokens.ts --apply\` updates those rows; re-running reports 0 candidates
- [ ] \`npx tsx prisma/seed-demos.ts --cleanup && npx tsx prisma/seed-demos.ts\` — demo profiles show 30M-70M \"Tokens\" (was 2M-4M)
- [ ] Profile card, leaderboard, and hero banner all render the new values cleanly
- [ ] Existing seed-helpers tests pass; new \`computeDefaultPerModelTokens\` tests cover sum invariant, distribution shape, and share respect