### PR TITLE
fix: leaderboard honors hiddenHarnessSections for gitPatterns

### DIFF
--- a/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/src/app/api/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Privacy regression tests for GET /api/leaderboard.
+ *
+ * Codex review on the token-attribution work surfaced that the leaderboard
+ * route resolved linesAdded / linesRemoved directly from harnessData and
+ * the scalar columns without honoring `hiddenHarnessSections`. The detail
+ * route (PR #113) and list-feed routes (PR #115) already strip hidden
+ * sections; this guards that the leaderboard does too, specifically for
+ * the "gitPatterns" section which gates line-count exposure.
+ *
+ * Follows the mocked-Prisma pattern from
+ * src/app/api/insights/[username]/[slug]/__tests__/route.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+// ── Mock the Prisma client ──────────────────────────────────────────
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    insightReport: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+// ── Imports after mocks ─────────────────────────────────────────────
+
+import { prisma } from "@/lib/db";
+import { GET as getLeaderboard } from "../route";
+
+const mockPrisma = prisma as unknown as {
+  insightReport: { findMany: Mock };
+};
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/**
+ * A full-shape HarnessData fixture with a nonzero gitPatterns.linesAdded
+ * string. stripHiddenHarnessData spreads every known key, so the fixture
+ * has to carry the full shape or the filter throws before assertions run.
+ */
+function buildHarnessDataFixture(linesAddedString: string) {
+  return {
+    stats: { lifetimeTokens: 1_000_000 },
+    autonomy: {} as unknown,
+    featurePills: [],
+    toolUsage: {},
+    skillInventory: [],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {} as unknown,
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 42,
+      commitCount: 100,
+      linesAdded: linesAddedString,
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "test-hash",
+    skillVersion: null,
+  };
+}
+
+function buildReportRow(opts: {
+  username: string;
+  hiddenHarnessSections: string[];
+  harnessLinesAddedString: string;
+  scalarLinesAdded: number | null;
+  scalarLinesRemoved: number | null;
+}) {
+  return {
+    publishedAt: new Date("2026-04-01T00:00:00.000Z"),
+    totalTokens: 500_000,
+    durationHours: 10,
+    sessionCount: 20,
+    linesAdded: opts.scalarLinesAdded,
+    linesRemoved: opts.scalarLinesRemoved,
+    dayCount: 7,
+    harnessData: buildHarnessDataFixture(opts.harnessLinesAddedString),
+    hiddenHarnessSections: opts.hiddenHarnessSections,
+    author: {
+      username: opts.username,
+      displayName: opts.username,
+      avatarUrl: null,
+    },
+  };
+}
+
+function getRequest(url: string): Request {
+  return new Request(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/leaderboard — hiddenHarnessSections privacy", () => {
+  it("zeroes linesAdded/linesRemoved for rows that hid gitPatterns, and preserves them for others", async () => {
+    const hiddenRow = buildReportRow({
+      username: "hider",
+      hiddenHarnessSections: ["gitPatterns"],
+      // Nonzero harness string — the pre-fix bug would surface this parsed
+      // as ~44000 through resolveLinesAdded.
+      harnessLinesAddedString: "44.0K",
+      // Also seed scalar columns so we cover the demo/seeded-report path
+      // where resolveLinesAdded prefers the scalar. The fix must zero
+      // BOTH sources when gitPatterns is hidden.
+      scalarLinesAdded: 12345,
+      scalarLinesRemoved: 678,
+    });
+    const visibleRow = buildReportRow({
+      username: "sharer",
+      hiddenHarnessSections: [],
+      harnessLinesAddedString: "10.0K",
+      scalarLinesAdded: null,
+      scalarLinesRemoved: null,
+    });
+
+    mockPrisma.insightReport.findMany.mockResolvedValue([
+      hiddenRow,
+      visibleRow,
+    ]);
+
+    const response = await getLeaderboard(
+      getRequest("http://localhost/api/leaderboard"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    const byUser: Record<
+      string,
+      { linesAdded: number | null; linesRemoved: number | null }
+    > = {};
+    for (const row of body.data) {
+      byUser[row.username] = {
+        linesAdded: row.linesAdded,
+        linesRemoved: row.linesRemoved,
+      };
+    }
+
+    // Privacy contract: hider's line counts must be zeroed out even
+    // though both harnessData.gitPatterns.linesAdded AND the scalar
+    // column carried real values.
+    expect(byUser.hider.linesAdded).toBe(0);
+    expect(byUser.hider.linesRemoved).toBe(0);
+
+    // Non-regression: sharer (no hidden sections) still sees the
+    // parsed harness value ("10.0K" → 10_000).
+    expect(byUser.sharer.linesAdded).toBe(10_000);
+  });
+
+  it("treats a null hiddenHarnessSections (legacy rows) as nothing hidden", async () => {
+    // Older rows may have hiddenHarnessSections === null rather than [].
+    // The fix must not throw and must not accidentally treat null as
+    // "everything hidden".
+    const legacyRow = {
+      ...buildReportRow({
+        username: "legacy",
+        hiddenHarnessSections: [],
+        harnessLinesAddedString: "5.0K",
+        scalarLinesAdded: null,
+        scalarLinesRemoved: null,
+      }),
+      hiddenHarnessSections: null as unknown as string[],
+    };
+
+    mockPrisma.insightReport.findMany.mockResolvedValue([legacyRow]);
+
+    const response = await getLeaderboard(
+      getRequest("http://localhost/api/leaderboard"),
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data[0].linesAdded).toBe(5_000);
+  });
+});

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
+import { filterReportForListFeed } from "@/lib/filter-report-response";
 
 export interface LeaderboardRow {
   rank: number;
@@ -50,6 +51,7 @@ export async function GET(request: Request) {
         linesRemoved: true,
         dayCount: true,
         harnessData: true,
+        hiddenHarnessSections: true,
         author: {
           select: {
             username: true,
@@ -76,6 +78,20 @@ export async function GET(request: Request) {
       const days = r.dayCount ?? 0;
       const weeks = days > 0 ? days / 7 : 0;
       const weeklyRate = weeks > 0 ? total / weeks : 0;
+      // Honor hiddenHarnessSections so users who hid "gitPatterns" on the
+      // edit page don't leak their line counts on the public leaderboard.
+      // Delegates to the same list-feed filter used by /api/insights and
+      // /api/top so the harnessData fallback path stays in lockstep across
+      // read surfaces. Additionally we zero the scalar columns when
+      // gitPatterns is hidden, since resolveLines* prefers the scalar and
+      // the scalar isn't stripped by the shared filter (demo/seeded data
+      // path — see src/lib/lines-of-code.ts).
+      const filtered = filterReportForListFeed({
+        harnessData: r.harnessData,
+        hiddenHarnessSections: r.hiddenHarnessSections,
+      });
+      const gitHidden =
+        r.hiddenHarnessSections?.includes("gitPatterns") ?? false;
       return {
         username: r.author.username,
         displayName: r.author.displayName,
@@ -84,14 +100,18 @@ export async function GET(request: Request) {
         totalTokens: total,
         sessionCount: r.sessionCount ?? 0,
         durationHours: r.durationHours ?? 0,
-        linesAdded: resolveLinesAdded({
-          linesAdded: r.linesAdded,
-          harnessData: r.harnessData as never,
-        }),
-        linesRemoved: resolveLinesRemoved({
-          linesRemoved: r.linesRemoved,
-          harnessData: r.harnessData as never,
-        }),
+        linesAdded: gitHidden
+          ? 0
+          : resolveLinesAdded({
+              linesAdded: r.linesAdded,
+              harnessData: filtered.harnessData as never,
+            }),
+        linesRemoved: gitHidden
+          ? 0
+          : resolveLinesRemoved({
+              linesRemoved: r.linesRemoved,
+              harnessData: filtered.harnessData as never,
+            }),
         dayCount: r.dayCount,
         publishedAt: r.publishedAt.toISOString(),
         weeklyRate,


### PR DESCRIPTION
## Summary

Codex review on the token-attribution work surfaced a P1 privacy leak in `src/app/api/leaderboard/route.ts`: the route resolved `linesAdded` / `linesRemoved` directly from `harnessData` and the scalar columns without honoring the report's `hiddenHarnessSections`. Real users who hid the `"gitPatterns"` section on the edit page still had their line counts exposed on the public leaderboard. The detail route (PR #113) and list-feed route (PR #115) already strip hidden sections correctly — the leaderboard was the hole.

## Fix

- Select `hiddenHarnessSections` alongside the other leaderboard fields.
- Route the `harnessData` fallback through `filterReportForListFeed` — the same helper `/api/insights` and `/api/top` use — so the harness string path stays in lockstep with the other read surfaces.
- Additionally zero the scalar `linesAdded` / `linesRemoved` when `gitPatterns` is hidden. `resolveLinesAdded` prefers the scalar column, and the shared filter doesn't touch scalars (they're on the `InsightReport` row, not in `harnessData`), so demo/seeded reports that populate the scalar path would otherwise still leak.

## Test

New `src/app/api/leaderboard/__tests__/route.test.ts` following the mocked-Prisma pattern from `src/app/api/insights/[username]/[slug]/__tests__/route.test.ts`:

- A report with `hiddenHarnessSections: ["gitPatterns"]` and nonzero values in BOTH `harnessData.gitPatterns.linesAdded` (`"44.0K"`) and the scalar column (`12345`) produces `linesAdded: 0` / `linesRemoved: 0` on the leaderboard row.
- A sibling report with no hidden sections still surfaces its parsed value (`"10.0K"` → `10_000`).
- A legacy row with `hiddenHarnessSections: null` is treated as "nothing hidden" (null-safety guard).

Full suite: 519 passed (30 files), up from 517 — two new tests, no regressions.

## Context

Closes the same class of bug as PR #113 (detail route harnessData stripping) and PR #115 (list-feed + extended hidden-section coverage). Kept to one route, one helper delegation, and one regression test — no unrelated changes.

## Test plan

- [ ] Verify on a staging report with `hiddenHarnessSections: ["gitPatterns"]` that `/api/leaderboard` returns `linesAdded: 0` / `linesRemoved: 0` for that user's row.
- [ ] Verify other users (no hidden sections) still show their real line counts.
- [ ] Spot-check that the detail page (`/insights/[slug]`) for the hidden-gitPatterns user also continues to hide its git card (should be unaffected by this PR but worth confirming no shared regressions).