### PR TITLE
fix: stripHiddenHarnessData no longer crashes on missing HarnessData fields

### DIFF
--- a/src/lib/__tests__/harness-section-visibility.test.ts
+++ b/src/lib/__tests__/harness-section-visibility.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { stripHiddenHarnessData } from "../harness-section-visibility";
+import type { HarnessData } from "@/types/insights";
+
+function buildFullHarnessData(): HarnessData {
+  return {
+    stats: {} as HarnessData["stats"],
+    autonomy: {} as HarnessData["autonomy"],
+    featurePills: [],
+    toolUsage: { Read: 10, Edit: 5 },
+    skillInventory: [
+      { name: "Alpha" } as HarnessData["skillInventory"][number],
+    ],
+    hookDefinitions: [
+      {
+        event: "PreToolUse",
+        matcher: "Bash",
+      } as HarnessData["hookDefinitions"][number],
+    ],
+    hookFrequency: {},
+    plugins: [{ name: "Plug" } as HarnessData["plugins"][number]],
+    harnessFiles: ["CLAUDE.md"],
+    fileOpStyle: {} as HarnessData["fileOpStyle"],
+    agentDispatch: null,
+    cliTools: { gh: 1 },
+    languages: { ts: 1 },
+    models: { opus: 1 },
+    permissionModes: { default: 1 },
+    mcpServers: { foo: 1 },
+    gitPatterns: {
+      prCount: 1,
+      commitCount: 2,
+      linesAdded: "100",
+      branchPrefixes: { feat: 1 },
+    },
+    versions: ["1.0.0"],
+    writeupSections: [{ title: "Intro", contentHtml: "<p>x</p>" }],
+    workflowData: null,
+    integrityHash: "abc",
+    skillVersion: null,
+  };
+}
+
+describe("stripHiddenHarnessData", () => {
+  it("does not throw when array/object fields are missing (legacy schema)", () => {
+    // Simulate an older-schema row missing several fields entirely.
+    const partial = {
+      stats: {},
+      autonomy: {},
+      featurePills: [],
+      hookFrequency: {},
+      fileOpStyle: {},
+      agentDispatch: null,
+      workflowData: null,
+      integrityHash: "abc",
+      skillVersion: null,
+      // Intentionally missing: toolUsage, skillInventory, hookDefinitions,
+      // plugins, harnessFiles, cliTools, languages, models, permissionModes,
+      // mcpServers, gitPatterns, versions, writeupSections.
+    } as unknown as HarnessData;
+
+    expect(() =>
+      stripHiddenHarnessData(partial, ["skillInventory"]),
+    ).not.toThrow();
+
+    const result = stripHiddenHarnessData(partial, ["skillInventory"]);
+    expect(result.skillInventory).toEqual([]);
+    expect(result.gitPatterns).toEqual({
+      prCount: 0,
+      commitCount: 0,
+      linesAdded: "0",
+      branchPrefixes: {},
+    });
+    // Other missing fields default to empty containers via the nullish-coalesce.
+    expect(result.toolUsage).toEqual({});
+    expect(result.plugins).toEqual([]);
+    expect(result.versions).toEqual([]);
+  });
+
+  it("does not throw when gitPatterns is missing and a hidden section is requested", () => {
+    const partial = {
+      stats: {},
+      autonomy: {},
+      featurePills: [],
+      hookFrequency: {},
+      fileOpStyle: {},
+      agentDispatch: null,
+      workflowData: null,
+      integrityHash: "abc",
+      skillVersion: null,
+      toolUsage: {},
+      skillInventory: [],
+      hookDefinitions: [],
+      plugins: [],
+      harnessFiles: [],
+      cliTools: {},
+      languages: {},
+      models: {},
+      permissionModes: {},
+      mcpServers: {},
+      versions: [],
+      writeupSections: [],
+      // gitPatterns missing
+    } as unknown as HarnessData;
+
+    expect(() => stripHiddenHarnessData(partial, ["plugins"])).not.toThrow();
+  });
+
+  it("returns data unchanged when there are no hidden sections (early return)", () => {
+    const full = buildFullHarnessData();
+    const result = stripHiddenHarnessData(full, []);
+    expect(result).toBe(full);
+  });
+
+  it("round-trips full HarnessData with empty-array fields and a section hidden", () => {
+    const full = buildFullHarnessData();
+    full.versions = [];
+    full.harnessFiles = [];
+
+    const result = stripHiddenHarnessData(full, ["plugins"]);
+
+    // Hidden section is wiped.
+    expect(result.plugins).toEqual([]);
+    // Empty array fields preserved.
+    expect(result.versions).toEqual([]);
+    expect(result.harnessFiles).toEqual([]);
+    // Untouched fields round-trip.
+    expect(result.skillInventory).toHaveLength(1);
+    expect(result.cliTools).toEqual({ gh: 1 });
+    expect(result.gitPatterns.prCount).toBe(1);
+    expect(result.gitPatterns.branchPrefixes).toEqual({ feat: 1 });
+  });
+});

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -96,22 +96,24 @@ export function stripHiddenHarnessData(
 
   const copy: HarnessData = {
     ...data,
-    toolUsage: { ...data.toolUsage },
-    skillInventory: [...data.skillInventory],
-    hookDefinitions: [...data.hookDefinitions],
-    plugins: [...data.plugins],
-    harnessFiles: [...data.harnessFiles],
-    cliTools: { ...data.cliTools },
-    languages: { ...data.languages },
-    models: { ...data.models },
-    permissionModes: { ...data.permissionModes },
-    mcpServers: { ...data.mcpServers },
+    toolUsage: { ...(data.toolUsage ?? {}) },
+    skillInventory: [...(data.skillInventory ?? [])],
+    hookDefinitions: [...(data.hookDefinitions ?? [])],
+    plugins: [...(data.plugins ?? [])],
+    harnessFiles: [...(data.harnessFiles ?? [])],
+    cliTools: { ...(data.cliTools ?? {}) },
+    languages: { ...(data.languages ?? {}) },
+    models: { ...(data.models ?? {}) },
+    permissionModes: { ...(data.permissionModes ?? {}) },
+    mcpServers: { ...(data.mcpServers ?? {}) },
     gitPatterns: {
-      ...data.gitPatterns,
-      branchPrefixes: { ...data.gitPatterns.branchPrefixes },
+      prCount: data.gitPatterns?.prCount ?? 0,
+      commitCount: data.gitPatterns?.commitCount ?? 0,
+      linesAdded: data.gitPatterns?.linesAdded ?? "0",
+      branchPrefixes: { ...(data.gitPatterns?.branchPrefixes ?? {}) },
     },
-    versions: [...data.versions],
-    writeupSections: [...data.writeupSections],
+    versions: [...(data.versions ?? [])],
+    writeupSections: [...(data.writeupSections ?? [])],
   };
 
   // First pass: handle section-level (top-key) hides
@@ -206,12 +208,7 @@ export function stripHiddenHarnessData(
     );
   }
   if (!isSectionHidden(hidden, "versions")) {
-    copy.versions = filterList(
-      copy.versions,
-      hidden,
-      "versions",
-      (v) => v,
-    );
+    copy.versions = filterList(copy.versions, hidden, "versions", (v) => v);
   }
   if (!isSectionHidden(hidden, "toolUsage")) {
     copy.toolUsage = filterRecord(copy.toolUsage, hidden, "toolUsage");
@@ -235,16 +232,8 @@ export function stripHiddenHarnessData(
   if (copy.agentDispatch && !isSectionHidden(hidden, "agentDispatch")) {
     copy.agentDispatch = {
       ...copy.agentDispatch,
-      types: filterRecord(
-        copy.agentDispatch.types,
-        hidden,
-        "agentDispatch",
-      ),
-      models: filterRecord(
-        copy.agentDispatch.models,
-        hidden,
-        "agentDispatch",
-      ),
+      types: filterRecord(copy.agentDispatch.types, hidden, "agentDispatch"),
+      models: filterRecord(copy.agentDispatch.models, hidden, "agentDispatch"),
     };
   }
 


### PR DESCRIPTION
Closes #114.

## Root cause

`stripHiddenHarnessData` in `src/lib/harness-section-visibility.ts` builds its working `copy` by spreading every array/record field directly (e.g. `hookDefinitions: [...data.hookDefinitions]`, `gitPatterns: { ...data.gitPatterns, branchPrefixes: { ...data.gitPatterns.branchPrefixes } }`). When a stored `harnessData` row is missing any of these fields — common for older-schema rows or rows where empty collections were persisted as `undefined` rather than `[]`/`{}` — the spread throws `TypeError: X is not iterable` (or `Cannot read properties of undefined` for `gitPatterns.branchPrefixes`), and the public detail route 500s before a single section is stripped.

## Fix

Add a nullish-coalesce default to every spread in the `copy` initializer:

```ts
hookDefinitions: [...(data.hookDefinitions ?? [])],
cliTools: { ...(data.cliTools ?? {}) },
```

`gitPatterns` is defaulted field-by-field (`prCount`, `commitCount`, `linesAdded`, `branchPrefixes`) to satisfy its required shape without TS duplicate-key errors.

## Test plan

- [x] New `src/lib/__tests__/harness-section-visibility.test.ts` covers: partial `HarnessData` with most fields missing, partial with `gitPatterns` missing, full data with empty-array fields round-trips, and the no-hidden-sections early-return identity.
- [x] `npx vitest run` — 528 passed (was 524 before, +4 new tests).
- [x] `codex review --base main` — clean, no findings.