### PR TITLE
test: POST /api/upload integration with real v2.7.0 fixture

### DIFF
--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Integration test for POST /api/upload — the route that runs harness
+ * HTML through parseHarnessHtml + parseInsightsHtml and returns the
+ * structured payload the client uses to drive report creation.
+ *
+ * Why this exists (#106):
+ *   - The route has zero existing route-level coverage. A parser
+ *     regression on a new harness format silently breaks report
+ *     creation in production.
+ *   - This test feeds a real-shaped v2.7.0 fixture end-to-end so the
+ *     happy path is locked in. Future format changes that break the
+ *     parser will show up here before they ship.
+ *
+ * Note on Prisma: this route does NOT touch the database. It parses,
+ * normalizes, and returns JSON. Persistence happens in a separate
+ * route the client calls afterwards. So the issue's "report row
+ * created" assertion is covered by that downstream route's tests, not
+ * here. We still mock @/lib/db to follow the established pattern and
+ * to defend against accidental future Prisma calls in this handler.
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// ── Mock @/lib/db to match the repo route-test pattern ──────────────
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    report: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+// ── Mock next-auth ──────────────────────────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+// ── Imports after mocks ─────────────────────────────────────────────
+
+import { auth } from "@/lib/auth";
+import { POST as uploadPOST } from "../route";
+
+const mockAuth = auth as unknown as Mock;
+
+// ── Fixture loader ──────────────────────────────────────────────────
+
+const FIXTURE_PATH = resolve(
+  __dirname,
+  "../../../../lib/__tests__/fixtures/insight-harness-v2.7.0.html",
+);
+const FIXTURE_HTML = readFileSync(FIXTURE_PATH, "utf-8");
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function mockSession(userId: string | null) {
+  if (userId === null) {
+    mockAuth.mockResolvedValue(null);
+  } else {
+    mockAuth.mockResolvedValue({ user: { id: userId } });
+  }
+}
+
+function uploadRequest(
+  html: string,
+  filename = "insight-harness.html",
+): Request {
+  const formData = new FormData();
+  formData.append("file", new File([html], filename, { type: "text/html" }));
+  return new Request("http://localhost/api/upload", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("POST /api/upload — auth", () => {
+  it("returns 401 when there is no session", async () => {
+    mockSession(null);
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /api/upload — input validation", () => {
+  it("returns 400 when no file field is present", async () => {
+    mockSession("user-1");
+    const formData = new FormData();
+    const request = new Request("http://localhost/api/upload", {
+      method: "POST",
+      body: formData,
+    });
+    const response = await uploadPOST(request);
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 when filename does not end in .html or .htm", async () => {
+    mockSession("user-1");
+    const response = await uploadPOST(
+      uploadRequest(FIXTURE_HTML, "report.pdf"),
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe("POST /api/upload — v2.7.0 harness fixture happy path", () => {
+  it("parses the fixture end-to-end and returns reportType=insight-harness", async () => {
+    mockSession("user-1");
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.reportType).toBe("insight-harness");
+  });
+
+  it("prefers harness-level stats over embedded /insights values (override behavior)", async () => {
+    // The route MUST prefer harnessData.stats over the parse of the
+    // embedded /insights tab for sessionCount + commitCount, and MUST
+    // prefer harnessData.enhancedStats over the .stat-row scrape for
+    // lines/files/days/msgs-per-day. The fixture deliberately carries
+    // DIFFERENT values in each source so a regression that drops the
+    // override would surface here:
+    //   sessionCount → harness 95 vs insights subtitle "(88 total)"
+    //   commitCount  → harness 47 vs insights narrative "41 commits"
+    //   linesAdded   → harness 12500 vs insights stats row "+9,000/-2,000"
+    //   linesRemoved → harness 3100  vs insights stats row "-2,000"
+    //   fileCount    → harness 142   vs insights stats row "110"
+    //   dayCount     → harness 30    vs insights stats row "28"
+    //   msgsPerDay   → harness 40.0  vs insights stats row "35.0"
+    mockSession("user-1");
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const body = await response.json();
+
+    expect(body.stats.sessionCount).toBe(95);
+    expect(body.stats.commitCount).toBe(47);
+    expect(body.stats.linesAdded).toBe(12500);
+    expect(body.stats.linesRemoved).toBe(3100);
+    expect(body.stats.fileCount).toBe(142);
+    expect(body.stats.dayCount).toBe(30);
+    expect(body.stats.msgsPerDay).toBe(40.0);
+  });
+
+  it("preserves the date range parsed from the embedded /insights subtitle", async () => {
+    mockSession("user-1");
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const body = await response.json();
+    expect(body.stats.dateRangeStart).toBe("2026-03-15");
+    expect(body.stats.dateRangeEnd).toBe("2026-04-14");
+    expect(body.stats.messageCount).toBe(1200);
+  });
+
+  it("returns the full harnessData blob with v2.7.0 fields populated", async () => {
+    mockSession("user-1");
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const body = await response.json();
+
+    expect(body.harnessData).toBeDefined();
+
+    // Top-level scalar tokens — exercise the headline numbers a
+    // regression would most likely break first.
+    expect(body.harnessData.stats.totalTokens).toBe(4500000000);
+    expect(body.harnessData.stats.lifetimeTokens).toBe(9800000000);
+    expect(body.harnessData.stats.durationHours).toBe(220.5);
+    expect(body.harnessData.skillVersion).toBe("2.7.0");
+
+    // Skill inventory — list shape with source labels (custom vs plugin).
+    expect(body.harnessData.skillInventory).toHaveLength(4);
+    expect(body.harnessData.skillInventory[0]).toMatchObject({
+      name: "commit",
+      source: "custom",
+    });
+
+    // Hook definitions — list shape with event + matcher + script.
+    expect(body.harnessData.hookDefinitions).toHaveLength(3);
+    expect(body.harnessData.hookDefinitions[0]).toMatchObject({
+      event: "PreToolUse",
+      matcher: "Bash",
+    });
+
+    // Plugins, featurePills, fileOpStyle, gitPatterns — sanity-check
+    // each major v2.7.0 surface so a parser drift on any one shows up.
+    expect(body.harnessData.plugins).toHaveLength(2);
+    expect(body.harnessData.featurePills.length).toBeGreaterThan(0);
+    expect(body.harnessData.fileOpStyle.style).toBe("Surgical Editor");
+    expect(body.harnessData.gitPatterns.prCount).toBe(134);
+    expect(body.harnessData.writeupSections).toHaveLength(2);
+  });
+
+  it("returns non-empty chartData and detectedSkills derived from the insights view", async () => {
+    // The fixture's #tab-insights has a "Top tools used" .chart-card
+    // with bar rows for Bash/Read/Edit/Agent, and detectSkills keys on
+    // the Agent toolPattern → 'subagents'. Asserting non-empty results
+    // catches a regression where the route drops these calls and falls
+    // back to {} / [] silently.
+    mockSession("user-1");
+    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const body = await response.json();
+
+    expect(Array.isArray(body.chartData.toolUsage)).toBe(true);
+    expect(body.chartData.toolUsage.length).toBeGreaterThan(0);
+    expect(body.chartData.toolUsage[0]).toMatchObject({
+      label: "Bash",
+      value: 5200,
+    });
+
+    expect(Array.isArray(body.detectedSkills)).toBe(true);
+    expect(body.detectedSkills.length).toBeGreaterThan(0);
+    expect(body.detectedSkills).toContain("subagents");
+  });
+});

--- a/src/lib/__tests__/fixtures/insight-harness-v2.7.0.html
+++ b/src/lib/__tests__/fixtures/insight-harness-v2.7.0.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<!--
+  Hand-crafted fixture matching the insight-harness v2.7.0 report shape.
+
+  Why hand-crafted instead of a real scrubbed report:
+    - Real reports are 1.4MB+ which is too large to commit as a test fixture.
+    - This fixture covers every field required by parseHarnessHtml +
+      parseInsightsHtml that the /api/upload route exercises.
+    - All numbers are deliberately synthetic — they encode no real activity.
+
+  v2.7.0 surface covered:
+    - script#insight-harness-integrity (detection trigger)
+    - script#harness-data with full HarnessData JSON shape
+    - skillVersion: "2.7.0"
+    - skillInventory, hookDefinitions, plugins, featurePills,
+      enhancedStats, fileOpStyle, gitPatterns, writeupSections
+    - #tab-insights with .subtitle / .stat row / .narrative so
+      parseInsightsHtml can derive sessionCount, dateRange, commitCount,
+      and enhancedStats from the embedded insights view.
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>insight-harness v2.7.0 fixture</title>
+  </head>
+  <body>
+    <!-- Harness-level integrity manifest. Presence of this script tag is what
+       isHarnessReport() keys on, so it must be intact. -->
+    <script type="application/json" id="insight-harness-integrity">
+      { "hash": "fixture-integrity-2026-04-14" }
+    </script>
+
+    <!-- Embedded /insights tab — this is the slice that parseInsightsHtml runs
+       against (the route extracts #tab-insights and re-wraps it). The selectors
+       below mirror what the real insight-harness template emits.
+
+       IMPORTANT: the scalar numbers below are intentionally DIFFERENT from
+       the harness-data JSON below (sessionCount, commitCount, lines, etc.).
+       This lets the route test prove that /api/upload prefers the harness
+       blob over the embedded insights parse for the merged stats payload —
+       a regression that drops the override would surface immediately. -->
+    <div id="tab-insights" class="tab-content">
+      <div class="header">
+        <h1>Claude Code Insights</h1>
+        <div class="subtitle">
+          1,200 messages across 80 sessions (88 total) | 2026-03-15 to
+          2026-04-14
+        </div>
+      </div>
+
+      <div class="stats-row">
+        <div class="stat">
+          <div class="stat-label">Lines</div>
+          <div class="stat-value">+9,000/-2,000</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Files</div>
+          <div class="stat-value">110</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Days</div>
+          <div class="stat-value">28</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">Msgs/day</div>
+          <div class="stat-value">35.0</div>
+        </div>
+      </div>
+
+      <div class="narrative">
+        Across 28 days of work you landed 41 commits and shipped a steady
+        cadence of small, reviewable changes. The dominant pattern is short
+        turn-taking with the agent on well-scoped tasks. You used a git worktree
+        workflow heavily and configured hooks for formatting.
+      </div>
+
+      <!-- Chart cards — parseChartData keys on .chart-card > .chart-title
+         + .bar-row. Including a "Top tools used" card so the route test
+         can assert toolUsage rows actually came back non-empty. -->
+      <div class="chart-card">
+        <div class="chart-title">Top tools used</div>
+        <div class="bar-row">
+          <span class="bar-label">Bash</span>
+          <span class="bar-value">5,200</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">Read</span>
+          <span class="bar-value">2,400</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">Edit</span>
+          <span class="bar-value">1,800</span>
+        </div>
+        <div class="bar-row">
+          <span class="bar-label">Agent</span>
+          <span class="bar-value">612</span>
+        </div>
+      </div>
+
+      <!-- Minimal section markers so parseInsightsHtml's section walker doesn't
+         crash on missing structure. Empty content is fine — the assertions in
+         the route test only check stats + harnessData, not the deep insights tree. -->
+      <div class="container"></div>
+    </div>
+
+    <!-- Harness data blob — full v2.7.0 HarnessData shape. -->
+    <script type="application/json" id="harness-data">
+      {
+        "stats": {
+          "totalTokens": 4500000000,
+          "lifetimeTokens": 9800000000,
+          "durationHours": 220.5,
+          "avgSessionMinutes": 165.4,
+          "skillsUsedCount": 38,
+          "hooksCount": 7,
+          "prCount": 134,
+          "sessionCount": 95,
+          "commitCount": 47
+        },
+        "autonomy": {
+          "label": "Fire-and-Forget",
+          "description": "1 human turn per 8 Claude turns",
+          "userMessages": 2400,
+          "assistantMessages": 19200,
+          "turnCount": 950,
+          "errorRate": "3.8%"
+        },
+        "featurePills": [
+          { "name": "Status Line", "active": true, "value": "" },
+          { "name": "Task Agents", "active": true, "value": "44%" },
+          { "name": "MCP", "active": true, "value": "5%" },
+          { "name": "Web Search", "active": true, "value": "7%" },
+          { "name": "Sub-Agents", "active": true, "value": "612" },
+          { "name": "Tasks", "active": true, "value": "290" },
+          { "name": "Plan Mode", "active": false, "value": "0" },
+          { "name": "Compactions", "active": true, "value": "4" }
+        ],
+        "toolUsage": {
+          "Bash": 5200,
+          "Read": 2400,
+          "Edit": 1800,
+          "Agent": 612,
+          "Grep": 540,
+          "Write": 480,
+          "Skill": 165,
+          "Glob": 170
+        },
+        "skillInventory": [
+          {
+            "name": "commit",
+            "calls": 22,
+            "source": "custom",
+            "description": "Auto-commit helper"
+          },
+          {
+            "name": "review-pr",
+            "calls": 14,
+            "source": "plugin",
+            "description": "PR reviewer agent"
+          },
+          {
+            "name": "writing-plans",
+            "calls": 9,
+            "source": "plugin",
+            "description": "Plan author"
+          },
+          {
+            "name": "skill-showcase",
+            "calls": 4,
+            "source": "custom",
+            "description": "Skill showcase site builder"
+          }
+        ],
+        "hookDefinitions": [
+          {
+            "event": "PreToolUse",
+            "matcher": "Bash",
+            "script": "validate-bash.sh"
+          },
+          {
+            "event": "PostToolUse",
+            "matcher": "Edit",
+            "script": "format-on-save.sh"
+          },
+          {
+            "event": "SessionStart",
+            "matcher": "*",
+            "script": "load-handoff.sh"
+          }
+        ],
+        "hookFrequency": {
+          "PreToolUse": 320,
+          "PostToolUse": 88,
+          "SessionStart": 42
+        },
+        "plugins": [
+          {
+            "name": "superpowers",
+            "version": "2.1.0",
+            "marketplace": "compound-engineering",
+            "active": true
+          },
+          {
+            "name": "code-review",
+            "version": "0.4.2",
+            "marketplace": "compound-engineering",
+            "active": true
+          }
+        ],
+        "harnessFiles": [
+          "CLAUDE.md",
+          ".claude/settings.json",
+          ".claude/keybindings.json"
+        ],
+        "fileOpStyle": {
+          "readPct": 50,
+          "editPct": 38,
+          "writePct": 12,
+          "grepCount": 540,
+          "globCount": 170,
+          "style": "Surgical Editor"
+        },
+        "agentDispatch": null,
+        "cliTools": { "git": 220, "npm": 45, "gh": 90 },
+        "languages": { "TypeScript": 70, "Python": 18, "Markdown": 12 },
+        "models": { "claude-sonnet-4-5": 80, "claude-opus-4-6": 20 },
+        "permissionModes": { "allowedTools": 12 },
+        "mcpServers": { "playwright": 60, "filesystem": 25 },
+        "gitPatterns": {
+          "prCount": 134,
+          "commitCount": 47,
+          "linesAdded": "12500",
+          "branchPrefixes": { "feat/": 18, "fix/": 22, "test/": 4, "chore/": 3 }
+        },
+        "versions": ["2.1.110", "2.1.111", "2.1.112"],
+        "writeupSections": [
+          {
+            "title": "Workflow Analysis",
+            "contentHtml": "<p>You favor short, surgical edits over large rewrites.</p>"
+          },
+          {
+            "title": "Tool Preferences",
+            "contentHtml": "<p>Strong preference for Edit + Grep over Write.</p>"
+          }
+        ],
+        "workflowData": null,
+        "integrityHash": "fixture-integrity-2026-04-14",
+        "skillVersion": "2.7.0",
+        "enhancedStats": {
+          "linesAdded": 12500,
+          "linesRemoved": 3100,
+          "fileCount": 142,
+          "dayCount": 30,
+          "msgsPerDay": 40.0
+        }
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Closes #106.

## Summary

- Adds the first route-level integration test for `POST /api/upload`, which runs harness HTML through `parseHarnessHtml` + `parseInsightsHtml` and returns the normalized payload the client uses to drive report creation. The route previously had zero coverage at this layer — a parser regression on a new harness format would silently break report creation in production.
- Commits a v2.7.0 insight-harness fixture under `src/lib/__tests__/fixtures/insight-harness-v2.7.0.html` so future tests can reuse it.

## Fixture choice

Hand-crafted, not a real scrubbed report. Real reports run ~1.4MB which is too large to commit as a test fixture, and the relevant signal is in the harness-data JSON shape rather than the surrounding HTML. The fixture:

- Carries the full v2.7.0 `HarnessData` shape (`stats`, `autonomy`, `featurePills`, `skillInventory`, `hookDefinitions`, `plugins`, `fileOpStyle`, `gitPatterns`, `enhancedStats`, `writeupSections`, `skillVersion: "2.7.0"`).
- Includes the `insight-harness-integrity` script tag so `isHarnessReport()` detection fires.
- Embeds a `#tab-insights` div with `.subtitle`, `.stat` row, `.narrative`, and a `.chart-card` so `parseInsightsHtml`, `parseChartData`, and `detectSkills` all have something real to chew on.
- **Deliberately uses divergent scalar values** between the harness JSON and the embedded /insights view (sessionCount 95 vs 88, commitCount 47 vs 41, lines 12500 vs 9000, etc.) so the test can prove the route's harness-prefers-over-insights override behavior — not just that values come through.

## What's tested

- Auth: 401 when no session.
- Validation: 400 for missing file / wrong extension.
- Happy path: 200 + `reportType: "insight-harness"`.
- **Override behavior:** merged stats prefer harness values over insights parse for sessionCount, commitCount, linesAdded/Removed, fileCount, dayCount, msgsPerDay.
- Date range comes through from the embedded /insights subtitle.
- Full `harnessData` blob round-trips with v2.7.0 fields populated.
- `chartData.toolUsage` and `detectedSkills` are non-empty when the input has chart rows + a recognizable tool name (Agent → `subagents`).

The route does NOT touch Prisma (persistence is a downstream route's responsibility — see the scope note on the issue), so this test focuses on the JSON contract.

## Codex review

Ran `codex review --base main` twice. First pass surfaced two real findings:
1. P2: override assertions used identical fixture values on both sides — would not catch a regression that drops the override. Fixed by giving the embedded /insights tab divergent values.
2. P3: `chartData` / `detectedSkills` assertions used `toBeDefined()` which would pass on empty defaults. Fixed by adding a chart-card + Agent tool entry and asserting non-empty contents.

Second pass: clean, no actionable findings.

## Unlocks #107

The legacy-format integration test (#107) is a trivial mutation of this same fixture — strip the `harness-data` script and adjust assertions to expect `reportType: "insights"` and no `harnessData` key.

## Test plan

- [x] `npx vitest run src/app/api/upload/__tests__/route.test.ts` — 8 / 8 pass
- [x] `npx vitest run` full suite — 534 / 534 pass (was 526 before, +8 new)