### PR TITLE
chore(gitignore): ignore .claude/worktrees and scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ yarn-error.log*
 
 # git worktrees
 .worktrees/
+.claude/worktrees/
+
+# Claude Code runtime state (locks, ephemeral)
+.claude/scheduled_tasks.lock
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION
Agent worktrees and the scheduler lock file are runtime state — they shouldn't pollute `git status` across sessions or risk accidental commits.

- `.claude/worktrees/` — where some agent harnesses materialize their isolated work dirs
- `.claude/scheduled_tasks.lock` — runtime lock from the scheduler

No code change.