### PR TITLE
fix(upload): 400 on non-multipart body; lock 4xx boundary with tests (#109)

### DIFF
--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -109,6 +109,46 @@ describe("POST /api/upload — input validation", () => {
     );
     expect(response.status).toBe(400);
   });
+
+  it("returns 400 when the body is not multipart/form-data", async () => {
+    // Passing a JSON body to a route that expects FormData trips
+    // request.formData() → TypeError. Without an inner guard this
+    // bubbles to the outer catch as a 500. Lock it to 4xx so a 5xx
+    // regression never ships for this foot-gun class.
+    mockSession("user-1");
+    const request = new Request("http://localhost/api/upload", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ not: "formData" }),
+    });
+    const response = await uploadPOST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(typeof body.error).toBe("string");
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it("returns 400 when the file exceeds the 10MB cap", async () => {
+    // The route enforces `file.size > 10 * 1024 * 1024` at route.ts
+    // line 78-83. A 10MB+1 payload must bounce with 4xx (documented
+    // as 400 today) — never a 500 from running a giant HTML through
+    // cheerio.
+    mockSession("user-1");
+    const OVERSIZED = "x".repeat(10 * 1024 * 1024 + 1);
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new File([OVERSIZED], "big.html", { type: "text/html" }),
+    );
+    const request = new Request("http://localhost/api/upload", {
+      method: "POST",
+      body: formData,
+    });
+    const response = await uploadPOST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/too large|10MB/i);
+  });
 });
 
 describe("POST /api/upload — v2.7.0 harness fixture happy path", () => {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -57,7 +57,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const formData = await request.formData();
+    let formData: FormData;
+    try {
+      formData = await request.formData();
+    } catch {
+      return NextResponse.json(
+        { error: "Request body must be multipart/form-data" },
+        { status: 400 },
+      );
+    }
     const file = formData.get("file");
 
     if (!file || !(file instanceof File)) {


### PR DESCRIPTION
## Summary

- `request.formData()` previously threw on non-multipart bodies and fell into the outer catch as a 500. Wrapped it in a tight try/catch that returns 400 with a helpful message.
- Added two route-level tests:
  - Non-multipart body (JSON content-type) → 400, non-empty error string
  - 10MB+1 payload → 400 matching `/too large|10MB/i` (existing size-guard at route.ts:78-83)

## Notes

- Bundled fix + tests as one atomic change: both address the issue's explicit intent ("4xx, not 5xx"), and splitting would leave a failing test-only PR against `main`.
- Issue referred to line 60-68 as a "JSON parse guard"; those lines actually run FormData parsing. The fix is at the correct path boundary regardless of the naming.

## Test plan

- [x] `npx vitest run src/app/api/upload/__tests__/route.test.ts` — 10 passed (2 new)
- [x] Full suite `npx vitest run` — 540 passed, no regressions

Closes #109