### PR TITLE
feat(insights): zod-validate POST /api/insights body (#112)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "remark-gfm": "^4.0.1",
         "sanitize-html": "^2.17.2",
         "slugify": "^1.6.9",
-        "unfurl.js": "^6.4.0"
+        "unfurl.js": "^6.4.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -852,6 +853,111 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
+      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
+      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
+      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
+      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
+      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
+      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
+      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -12470,7 +12576,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -12497,111 +12602,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
-      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
-      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
-      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
-      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
-      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
-      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
-      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "remark-gfm": "^4.0.1",
     "sanitize-html": "^2.17.2",
     "slugify": "^1.6.9",
-    "unfurl.js": "^6.4.0"
+    "unfurl.js": "^6.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/insights/__tests__/route.test.ts
+++ b/src/app/api/insights/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for POST /api/insights request-body validation (#112).
+ *
+ * Scope: the zod schema at the top of route.ts. Confirms that the
+ * handler rejects malformed/typed-wrong bodies at 400 before doing
+ * any DB work. Full happy-path save-side integration lives in #119.
+ *
+ * Prisma and link-preview are mocked defensively so a validation
+ * regression that leaks past the guard (and tries to call Prisma)
+ * will blow up with a clear mock-usage error rather than silently
+ * returning 201.
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    insightReport: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/link-preview", () => ({
+  fetchLinkPreview: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { POST as insightsPOST } from "../route";
+
+const mockAuth = auth as unknown as Mock;
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: Mock };
+  insightReport: { create: Mock; findUnique: Mock };
+  $transaction: Mock;
+};
+
+function mockSessionAndUser(userId: string | null) {
+  if (userId === null) {
+    mockAuth.mockResolvedValue(null);
+    return;
+  }
+  mockAuth.mockResolvedValue({ user: { id: userId } });
+  mockPrisma.user.findUnique.mockResolvedValue({
+    id: userId,
+    username: "testuser",
+  });
+}
+
+function postRequest(body: unknown, options: { raw?: string } = {}): Request {
+  return new Request("http://localhost/api/insights", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: options.raw ?? JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/insights — auth", () => {
+  it("returns 401 before validation when unauthed", async () => {
+    mockSessionAndUser(null);
+    const response = await insightsPOST(postRequest({}));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /api/insights — body-level validation", () => {
+  it("returns 400 when the body is not valid JSON", async () => {
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest(null, { raw: "not-json-at-all" }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/valid JSON/i);
+  });
+
+  it("returns 400 when sessionCount has the wrong type", async () => {
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest({ sessionCount: "fourty-two" }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/sessionCount/);
+    expect(Array.isArray(body.issues)).toBe(true);
+    expect(
+      body.issues.some(
+        (i: { path: Array<string | number> }) => i.path[0] === "sessionCount",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns 400 when linesAdded is a negative number", async () => {
+    // Pin type-level validation for optional stat fields so a future
+    // "I'll just pass -1 for unknown" client regression gets a 400,
+    // not a silently persisted negative counter.
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest({ sessionCount: 1, linesAdded: -42 }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/linesAdded/);
+  });
+
+  it("returns 400 when totalTokens is negative", async () => {
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest({ sessionCount: 1, totalTokens: -5 }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/totalTokens/);
+  });
+
+  it("returns 400 when totalTokens is a non-integer number", async () => {
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest({ sessionCount: 1, totalTokens: 3.14 }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/totalTokens/);
+  });
+
+  it("does not call Prisma when validation fails", async () => {
+    mockSessionAndUser("user-1");
+    // Clear the user-lookup mock afterwards so the assertion below
+    // only speaks to the WRITE path, not the initial user read.
+    await insightsPOST(postRequest({ sessionCount: "bad" }));
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    expect(mockPrisma.insightReport.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts a body with sessionCount: null (plain /insights upload path)", async () => {
+    // Regression lock: the upload UI sends `sessionCount: null` when
+    // the parser can't extract a count from plain /insights HTML
+    // (src/app/upload/page.tsx:777). The schema must NOT reject
+    // those bodies at validation. We don't assert 201 here — full
+    // save-path is covered in #119 — only that validation doesn't
+    // bounce the request.
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(postRequest({ sessionCount: null }));
+    expect(response.status).not.toBe(400);
+  });
+});

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import type { InsightReportListItemContract } from "@/types/api-contracts";
@@ -6,6 +7,71 @@ import { normalizeHarnessData } from "@/types/insights";
 import type { Prisma } from "@prisma/client";
 import { fetchLinkPreview } from "@/lib/link-preview";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
+
+// Optional-nullable scalar helpers used across the POST body schema.
+// Every stat field is nullable in the DB — we reject only garbage
+// *types* (e.g. string where number is expected), never omission.
+const optionalNullableInt = z
+  .number()
+  .int()
+  .nonnegative()
+  .nullable()
+  .optional();
+const optionalNullableNumber = z.number().nonnegative().nullable().optional();
+const optionalNullableString = z.string().nullable().optional();
+const optionalJsonObject = z
+  .record(z.string(), z.unknown())
+  .nullable()
+  .optional();
+
+const projectLinkSchema = z.object({
+  name: z.string().min(1),
+  githubUrl: z.string().optional(),
+  liveUrl: z.string().optional(),
+  description: z.string().optional(),
+});
+
+/**
+ * Validation schema for POST /api/insights. Required fields are only
+ * those a published report cannot meaningfully exist without; every
+ * other scalar is type-checked when present but may be omitted or
+ * null. `title` is optional because the handler falls back to a
+ * server-generated default when absent. totalTokens used to have an
+ * ad-hoc guard at the top of the handler; it's expressed here.
+ */
+const createInsightReportSchema = z.object({
+  title: z.string().min(1).optional(),
+  sessionCount: optionalNullableInt,
+  messageCount: optionalNullableInt,
+  commitCount: optionalNullableInt,
+  dateRangeStart: optionalNullableString,
+  dateRangeEnd: optionalNullableString,
+  linesAdded: optionalNullableInt,
+  linesRemoved: optionalNullableInt,
+  fileCount: optionalNullableInt,
+  dayCount: optionalNullableInt,
+  msgsPerDay: optionalNullableNumber,
+  atAGlance: optionalJsonObject,
+  interactionStyle: optionalJsonObject,
+  projectAreas: optionalJsonObject,
+  impressiveWorkflows: optionalJsonObject,
+  frictionAnalysis: optionalJsonObject,
+  suggestions: optionalJsonObject,
+  onTheHorizon: optionalJsonObject,
+  funEnding: optionalJsonObject,
+  chartData: optionalJsonObject,
+  detectedSkills: z.array(z.string()).optional(),
+  projectLinks: z.array(projectLinkSchema).optional(),
+  projectIds: z.array(z.string()).optional(),
+  reportType: z.string().optional(),
+  totalTokens: z.number().int().nonnegative().nullable().optional(),
+  durationHours: optionalNullableInt,
+  avgSessionMinutes: optionalNullableNumber,
+  prCount: optionalNullableInt,
+  autonomyLabel: optionalNullableString,
+  harnessData: z.unknown().optional(),
+  hiddenHarnessSections: z.array(z.string()).optional(),
+});
 const SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
@@ -203,7 +269,31 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
-    const body = await request.json();
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Request body must be valid JSON" },
+        { status: 400 },
+      );
+    }
+
+    const parsed = createInsightReportSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const first = parsed.error.issues[0];
+      const field = first.path.join(".") || "(root)";
+      return NextResponse.json(
+        {
+          error: `Invalid request body: ${field} — ${first.message}`,
+          issues: parsed.error.issues.map((i) => ({
+            path: i.path,
+            message: i.message,
+          })),
+        },
+        { status: 400 },
+      );
+    }
 
     const {
       title: providedTitle,
@@ -229,7 +319,6 @@ export async function POST(request: Request) {
       projectIds,
       chartData,
       detectedSkills,
-      // v3: Harness fields
       reportType,
       totalTokens,
       durationHours,
@@ -238,27 +327,7 @@ export async function POST(request: Request) {
       autonomyLabel,
       harnessData,
       hiddenHarnessSections,
-    } = body;
-
-    // Validate totalTokens — must be a non-negative safe integer if provided.
-    // Reject 400 instead of silently coercing bad input to null, which would
-    // hide a client/extractor bug behind a quiet stat loss.
-    if (totalTokens !== undefined && totalTokens !== null) {
-      if (
-        typeof totalTokens !== "number" ||
-        !Number.isFinite(totalTokens) ||
-        !Number.isSafeInteger(totalTokens) ||
-        totalTokens < 0
-      ) {
-        return NextResponse.json(
-          {
-            error:
-              "totalTokens must be a non-negative safe integer (or null/omitted)",
-          },
-          { status: 400 },
-        );
-      }
-    }
+    } = parsed.data;
 
     // Auto-generate title if not provided
     const title =
@@ -402,15 +471,18 @@ export async function POST(request: Request) {
           fileCount: fileCount ?? null,
           dayCount: dayCount ?? null,
           msgsPerDay: msgsPerDay ?? null,
-          atAGlance: atAGlance ?? undefined,
-          interactionStyle: interactionStyle ?? undefined,
-          projectAreas: projectAreas ?? undefined,
-          impressiveWorkflows: impressiveWorkflows ?? undefined,
-          frictionAnalysis: frictionAnalysis ?? undefined,
-          suggestions: suggestions ?? undefined,
-          onTheHorizon: onTheHorizon ?? undefined,
-          funEnding: funEnding ?? undefined,
-          chartData: chartData ?? undefined,
+          atAGlance: (atAGlance as Prisma.InputJsonValue) ?? undefined,
+          interactionStyle:
+            (interactionStyle as Prisma.InputJsonValue) ?? undefined,
+          projectAreas: (projectAreas as Prisma.InputJsonValue) ?? undefined,
+          impressiveWorkflows:
+            (impressiveWorkflows as Prisma.InputJsonValue) ?? undefined,
+          frictionAnalysis:
+            (frictionAnalysis as Prisma.InputJsonValue) ?? undefined,
+          suggestions: (suggestions as Prisma.InputJsonValue) ?? undefined,
+          onTheHorizon: (onTheHorizon as Prisma.InputJsonValue) ?? undefined,
+          funEnding: (funEnding as Prisma.InputJsonValue) ?? undefined,
+          chartData: (chartData as Prisma.InputJsonValue) ?? undefined,
           detectedSkills: detectedSkills ?? [],
           reportType: reportType ?? "insights",
           totalTokens:


### PR DESCRIPTION
## Summary

- Adds a zod schema for the `POST /api/insights` request body and parses via `safeParse()` at the top of the handler.
- Invalid bodies now return 400 with `{ error: "Invalid request body: <field> — <message>", issues: [{path, message}...] }`.
- JSON-parse failures → 400 (previously 500 via outer catch).
- Replaces the ad-hoc `totalTokens` guard with the equivalent schema rule (non-negative safe integer or null).
- All stat fields remain optional and nullable, matching the DB schema and the upload UI's existing `?? null` fallbacks (src/app/upload/page.tsx:777). No valid client regresses.

## Added `zod ^4.3.6` to dependencies.

## Test plan

- [x] `npx vitest run src/app/api/insights/__tests__/route.test.ts` — 8 passed (new file)
- [x] Full suite — 546 passed, no regressions
- [x] `npx tsc --noEmit` — clean
- [x] Review flagged a sessionCount-required regression against src/app/upload/page.tsx:777 (plain /insights reports send `null`); fixed by making sessionCount optional+nullable and added a regression test

## Notes for #109 follow-up

The #109 scope note mentions a missing-required-fields assertion was deferred pending this PR. In practice, no field is strictly required at the schema level (the DB permits null for every body-fed column, and `title` has a server fallback). The zod schema instead guarantees **type correctness** on every field — that's the form the deferred assertion should take when someone picks it up next.

Closes #112