### PR TITLE
fix(format): central number formatter with B/T tier + commas (#121)

### DIFF
--- a/src/app/api/og/[username]/[slug]/route.tsx
+++ b/src/app/api/og/[username]/[slug]/route.tsx
@@ -3,6 +3,14 @@ import { prisma } from "@/lib/db";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { estimateApiCostUsd } from "@/lib/api-cost";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
+import {
+  formatCompactNumber,
+  formatCompactCurrency,
+} from "@/lib/number-format";
+
+const formatNumber = formatCompactNumber;
+const formatLines = formatCompactNumber;
+const formatCost = formatCompactCurrency;
 
 export const runtime = "nodejs";
 
@@ -30,26 +38,6 @@ async function loadFonts() {
   ]);
 
   return { interFont, jetbrainsFont };
-}
-
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
-  return n.toLocaleString();
-}
-
-function formatLines(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return Math.round(n).toLocaleString();
-}
-
-function formatCost(usd: number): string {
-  if (usd >= 1000) return `$${(usd / 1000).toFixed(1)}k`;
-  if (usd >= 100) return `$${Math.round(usd)}`;
-  if (usd >= 10) return `$${usd.toFixed(0)}`;
-  return `$${usd.toFixed(2)}`;
 }
 
 function perWeek(total: number, days: number): number {

--- a/src/app/insights/[username]/[slug]/layout.tsx
+++ b/src/app/insights/[username]/[slug]/layout.tsx
@@ -1,12 +1,7 @@
 import type { Metadata } from "next";
 import { prisma } from "@/lib/db";
 import { buildOgImageUrl } from "@/lib/urls";
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`;
-  return n.toLocaleString();
-}
+import { formatCompactNumber as formatTokens } from "@/lib/number-format";
 
 export async function generateMetadata({
   params,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,10 @@ import { homepage as copy } from "@/content/homepage";
 import { estimateApiCostUsd } from "@/lib/api-cost";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { buildReportUrl } from "@/lib/urls";
+import {
+  formatCompactNumber,
+  formatCompactCurrency,
+} from "@/lib/number-format";
 
 // Parse a skill identifier into its plugin source and short name.
 // Skills are in the form "plugin-name:skill-name" or just "skill-name" (custom).
@@ -111,34 +115,14 @@ interface InsightSummary {
 }
 
 // ── Helpers: formatting ─────────────────────────────────────
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return `${Math.round(n)}`;
-}
-
-function formatCost(n: number): string {
-  if (n === 0) return "$0";
-  if (n >= 100) return `$${Math.round(n)}`;
-  if (n >= 10) return `$${n.toFixed(0)}`;
-  if (n >= 1) return `$${n.toFixed(1)}`;
-  return `$${n.toFixed(2)}`;
-}
+const formatTokens = formatCompactNumber;
+const formatLines = formatCompactNumber;
+const formatCost = formatCompactCurrency;
 
 function formatHours(n: number): string {
   if (n >= 100) return `${Math.round(n)}h`;
   if (n >= 10) return `${n.toFixed(0)}h`;
   return `${n.toFixed(1)}h`;
-}
-
-// Compact formatter for lines-of-code counts. Keeps one decimal in the
-// k-range so values like 18,400 render as "18.4k" (matching the format
-// called out in issue #24) and stay readable in the narrow vanity strip.
-function formatLines(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return Math.round(n).toLocaleString();
 }
 
 function perWeek(

--- a/src/app/top/page.tsx
+++ b/src/app/top/page.tsx
@@ -8,6 +8,7 @@ import { Search, SlidersHorizontal, Sparkles } from "lucide-react";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
 import ShareButton from "@/components/ShareButton";
 import { buildReportUrl } from "@/lib/urls";
+import { formatCompactNumber as formatNumber } from "@/lib/number-format";
 
 interface TopReport {
   slug: string;
@@ -31,20 +32,13 @@ interface TopReport {
   };
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
-}
-
 function perWeek(value: number | null, dayCount: number | null): string | null {
   if (!value || !dayCount || dayCount === 0) return null;
   const weeks = dayCount / 7;
   if (weeks === 0) return null;
   const rate = value / weeks;
-  if (rate >= 1_000_000) return `${(rate / 1_000_000).toFixed(1)}M`;
-  if (rate >= 1_000) return `${(rate / 1_000).toFixed(1)}K`;
-  return rate < 10 ? rate.toFixed(1) : Math.round(rate).toLocaleString();
+  if (rate < 10) return rate.toFixed(1);
+  return formatNumber(rate);
 }
 
 const SORT_OPTIONS = [

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -2,6 +2,10 @@
 
 import React, { useMemo } from "react";
 import { estimateApiCostUsd } from "@/lib/api-cost";
+import {
+  formatCompactNumber,
+  formatCompactCurrency,
+} from "@/lib/number-format";
 
 interface DailyData {
   date: string;
@@ -162,19 +166,12 @@ function generateDailyData(
 }
 
 function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
-  return n.toString();
+  return formatCompactNumber(n);
 }
 
 function formatCost(n: number): string {
   if (n === 0) return "0";
-  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}K`;
-  if (n >= 100) return `$${Math.round(n)}`;
-  if (n >= 10) return `$${n.toFixed(0)}`;
-  if (n >= 1) return `$${n.toFixed(1)}`;
-  return `$${n.toFixed(2)}`;
+  return formatCompactCurrency(n);
 }
 
 // Cost estimation now lives in src/lib/api-cost.ts so it can be shared

--- a/src/components/GitPatternsDisplay.tsx
+++ b/src/components/GitPatternsDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { HarnessGitPatterns } from "@/types/insights";
+import { formatInteger } from "@/lib/number-format";
 
 interface GitPatternsDisplayProps {
   gitPatterns: HarnessGitPatterns;
@@ -118,7 +119,7 @@ export default function GitPatternsDisplay({
             {gitPatterns.prCount > 0 && (
               <div className="text-center">
                 <div className="text-[28px] font-extrabold text-blue-500">
-                  {gitPatterns.prCount}
+                  {formatInteger(gitPatterns.prCount)}
                 </div>
                 <div className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
                   PRs
@@ -128,7 +129,7 @@ export default function GitPatternsDisplay({
             {gitPatterns.commitCount > 0 && (
               <div className="text-center">
                 <div className="text-[28px] font-extrabold text-blue-700 dark:text-blue-400">
-                  {gitPatterns.commitCount}
+                  {formatInteger(gitPatterns.commitCount)}
                 </div>
                 <div className="text-[11px] font-medium uppercase tracking-wider text-slate-500">
                   Commits

--- a/src/components/HarnessOverview.tsx
+++ b/src/components/HarnessOverview.tsx
@@ -1,14 +1,11 @@
 import type { HarnessData } from "@/types/insights";
+import { formatCompactNumber, formatInteger } from "@/lib/number-format";
 
 interface HarnessOverviewProps {
   harnessData: HarnessData;
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
-}
+const formatNumber = formatCompactNumber;
 
 function StatCell({ value, label }: { value: string; label: string }) {
   return (
@@ -50,10 +47,10 @@ export default function HarnessOverview({ harnessData }: HarnessOverviewProps) {
             <StatCell value={stats.skillsUsedCount.toString()} label="Skills" />
           )}
           {stats.hooksCount > 0 && (
-            <StatCell value={stats.hooksCount.toString()} label="Hooks" />
+            <StatCell value={formatInteger(stats.hooksCount)} label="Hooks" />
           )}
           {stats.prCount > 0 && (
-            <StatCell value={stats.prCount.toString()} label="PRs" />
+            <StatCell value={formatInteger(stats.prCount)} label="PRs" />
           )}
         </div>
       </div>

--- a/src/components/HarnessSections.tsx
+++ b/src/components/HarnessSections.tsx
@@ -1,15 +1,12 @@
 import type { HarnessData } from "@/types/insights";
 import CollapsibleSection from "./CollapsibleSection";
+import { formatCompactNumber, formatInteger } from "@/lib/number-format";
 
 interface HarnessSectionsProps {
   harnessData: HarnessData;
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
-}
+const formatNumber = formatCompactNumber;
 
 function BarChart({
   data,
@@ -378,13 +375,13 @@ export default function HarnessSections({ harnessData }: HarnessSectionsProps) {
           <div className="mb-3 flex flex-wrap gap-4 text-sm text-slate-600 dark:text-slate-400">
             <span>
               <strong className="text-slate-900 dark:text-slate-100">
-                {gitPatterns.prCount}
+                {formatInteger(gitPatterns.prCount)}
               </strong>{" "}
               PRs
             </span>
             <span>
               <strong className="text-slate-900 dark:text-slate-100">
-                {gitPatterns.commitCount}
+                {formatInteger(gitPatterns.commitCount)}
               </strong>{" "}
               commits
             </span>

--- a/src/components/HeroStats.tsx
+++ b/src/components/HeroStats.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { HarnessStats } from "@/types/insights";
+import { formatCompactNumber } from "@/lib/number-format";
 
 interface HeroStatsProps {
   stats: HarnessStats;
@@ -10,30 +11,13 @@ interface HeroStatsProps {
   linesRemoved?: number | null;
 }
 
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toLocaleString();
-}
-
-// Compact lines-of-code formatter: "18.4k" above a thousand, raw number
-// below. Mirrors the helper used on the homepage ProfileCard so the
-// two surfaces show consistent magnitudes.
-function formatLines(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return Math.round(n).toLocaleString();
-}
-
 function perWeek(value: number, dayCount: number | null): string | null {
   if (!dayCount || dayCount === 0) return null;
   const weeks = dayCount / 7;
   if (weeks === 0) return null;
   const rate = value / weeks;
-  if (rate >= 1_000_000) return `${(rate / 1_000_000).toFixed(1)}M`;
-  if (rate >= 1_000) return `${(rate / 1_000).toFixed(1)}K`;
-  return rate < 10 ? rate.toFixed(1) : Math.round(rate).toLocaleString();
+  if (rate < 10) return rate.toFixed(1);
+  return formatCompactNumber(rate);
 }
 
 function seededSparkline(seed: number, length = 10): number[] {
@@ -162,8 +146,8 @@ function LinesStatCard({
 }) {
   const sparkData = seededSparkline(numericSeed);
   const color = STAT_COLORS["Lines of Code"];
-  const addedStr = `+${formatLines(added)}`;
-  const removedStr = removed != null ? `-${formatLines(removed)}` : null;
+  const addedStr = `+${formatCompactNumber(added)}`;
+  const removedStr = removed != null ? `-${formatCompactNumber(removed)}` : null;
   // Hero card width is the constraint here. Inside `max-w-5xl px-4`
   // the grid switches to four columns at `sm:` (640px), which actually
   // *narrows* each card vs the 2-column mobile layout, so the inline
@@ -240,14 +224,14 @@ export default function HeroStats({
       {lifetimeTokens > 0 && (
         <div className="mb-6 rounded-xl border border-blue-100 bg-gradient-to-br from-blue-50/80 to-cyan-50/60 px-6 py-5 text-center dark:border-blue-900/40 dark:from-blue-950/30 dark:to-cyan-950/20">
           <div className="text-5xl font-extrabold leading-none tracking-tight text-slate-900 sm:text-7xl dark:text-slate-100">
-            {formatNumber(lifetimeTokens)}
+            {formatCompactNumber(lifetimeTokens)}
           </div>
           <div className="mt-2 text-[13px] font-bold uppercase tracking-[0.1em] text-slate-500 dark:text-slate-400">
             Lifetime Tokens
           </div>
           {stats.totalTokens > 0 && stats.totalTokens !== lifetimeTokens && (
             <div className="mt-1.5 text-[13px] font-medium text-slate-400 dark:text-slate-500">
-              {formatNumber(stats.totalTokens)} in last 30 days
+              {formatCompactNumber(stats.totalTokens)} in last 30 days
             </div>
           )}
         </div>
@@ -255,7 +239,7 @@ export default function HeroStats({
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {stats.totalTokens > 0 && (
           <StatCard
-            value={formatNumber(stats.totalTokens)}
+            value={formatCompactNumber(stats.totalTokens)}
             label="Tokens"
             rate={perWeek(stats.totalTokens, dayCount)}
             numericSeed={stats.totalTokens}

--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { Heart, MessageSquare, Calendar, User } from "lucide-react";
 import clsx from "clsx";
 import { buildReportUrl } from "@/lib/urls";
+import { formatCompactNumber as formatTokensCompact } from "@/lib/number-format";
 
 interface InsightCardProps {
   slug: string;
@@ -29,12 +30,6 @@ interface InsightCardProps {
   sectionTags?: string[];
   totalTokens?: number | null;
   lifetimeTokens?: number | null;
-}
-
-function formatTokensCompact(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return `${Math.round(n)}`;
 }
 
 function formatDate(dateStr: string) {

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -5,19 +5,10 @@ import Image from "next/image";
 import clsx from "clsx";
 import { buildProfileUrl } from "@/lib/urls";
 import type { LeaderboardRow as LeaderboardRowData } from "@/app/api/leaderboard/route";
+import { formatCompactNumber } from "@/lib/number-format";
 
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${Math.round(n / 1_000)}K`;
-  return `${Math.round(n)}`;
-}
-
-function formatLines(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 100_000) return `${Math.round(n / 1_000)}k`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return Math.round(n).toLocaleString();
-}
+const formatTokens = formatCompactNumber;
+const formatLines = formatCompactNumber;
 
 function Stat({
   label,

--- a/src/components/ToolUsageTreemap.tsx
+++ b/src/components/ToolUsageTreemap.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { formatCompactNumber as formatNumber } from "@/lib/number-format";
+
 interface ToolUsageTreemapProps {
   toolUsage: Record<string, number>;
 }
@@ -23,11 +25,6 @@ function getToolBg(name: string): string {
 
 function getToolCategory(name: string): string {
   return TOOL_CATEGORIES[name]?.label ?? "other";
-}
-
-function formatNumber(n: number): string {
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return n.toString();
 }
 
 export default function ToolUsageTreemap({ toolUsage }: ToolUsageTreemapProps) {

--- a/src/lib/__tests__/number-format.test.ts
+++ b/src/lib/__tests__/number-format.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatCompactNumber,
+  formatInteger,
+  formatCompactCurrency,
+} from "../number-format";
+
+describe("formatCompactNumber", () => {
+  it("renders values under 1k as raw with commas", () => {
+    expect(formatCompactNumber(0)).toBe("0");
+    expect(formatCompactNumber(42)).toBe("42");
+    expect(formatCompactNumber(999)).toBe("999");
+  });
+
+  it("rolls into the k tier at 1,000", () => {
+    expect(formatCompactNumber(1_000)).toBe("1.0k");
+    expect(formatCompactNumber(12_345)).toBe("12.3k");
+  });
+
+  it("drops the decimal at ≥ 100 within a tier", () => {
+    expect(formatCompactNumber(99_400)).toBe("99.4k");
+    expect(formatCompactNumber(100_000)).toBe("100k");
+    expect(formatCompactNumber(417_200_000)).toBe("417M");
+  });
+
+  it("renders the M tier for 1M – 999M", () => {
+    expect(formatCompactNumber(1_000_000)).toBe("1.0M");
+    expect(formatCompactNumber(12_300_000)).toBe("12.3M");
+    expect(formatCompactNumber(999_000_000)).toBe("999M");
+  });
+
+  it("rolls into the B tier at 1,000,000,000", () => {
+    expect(formatCompactNumber(1_000_000_000)).toBe("1.0B");
+    expect(formatCompactNumber(11_307_500_000)).toBe("11.3B");
+    expect(formatCompactNumber(5_086_539_595)).toBe("5.1B");
+  });
+
+  it("rolls into the T tier at one trillion", () => {
+    expect(formatCompactNumber(1_000_000_000_000)).toBe("1.0T");
+    expect(formatCompactNumber(2_500_000_000_000)).toBe("2.5T");
+  });
+
+  it("handles bigint input (for totalTokens column)", () => {
+    expect(formatCompactNumber(BigInt(11_307_500_000))).toBe("11.3B");
+    expect(formatCompactNumber(BigInt(0))).toBe("0");
+  });
+
+  it("handles negative numbers with a leading minus", () => {
+    expect(formatCompactNumber(-1_200)).toBe("-1.2k");
+    expect(formatCompactNumber(-5_086_539_595)).toBe("-5.1B");
+  });
+
+  it("returns '0' for non-finite input", () => {
+    expect(formatCompactNumber(Number.NaN)).toBe("0");
+    expect(formatCompactNumber(Number.POSITIVE_INFINITY)).toBe("0");
+  });
+});
+
+describe("formatInteger", () => {
+  it("adds thousands separators to raw integers", () => {
+    expect(formatInteger(0)).toBe("0");
+    expect(formatInteger(42)).toBe("42");
+    expect(formatInteger(1_234)).toBe("1,234");
+    expect(formatInteger(5_086_539_595)).toBe("5,086,539,595");
+  });
+
+  it("handles bigint input", () => {
+    expect(formatInteger(BigInt(5_086_539_595))).toBe("5,086,539,595");
+  });
+
+  it("rounds fractional numbers before formatting", () => {
+    expect(formatInteger(1_234.7)).toBe("1,235");
+  });
+});
+
+describe("formatCompactCurrency", () => {
+  it("shows two-decimal precision under $1 so pennies stay visible", () => {
+    expect(formatCompactCurrency(0.04)).toBe("$0.04");
+    expect(formatCompactCurrency(0.5)).toBe("$0.50");
+  });
+
+  it("drops decimals between $1 and $999", () => {
+    expect(formatCompactCurrency(1)).toBe("$1");
+    expect(formatCompactCurrency(123.45)).toBe("$123");
+  });
+
+  it("uses compact tiers for $1k+", () => {
+    expect(formatCompactCurrency(1_234)).toBe("$1.2k");
+    expect(formatCompactCurrency(1_234_567)).toBe("$1.2M");
+  });
+
+  it("handles non-finite input as $0", () => {
+    expect(formatCompactCurrency(Number.NaN)).toBe("$0");
+  });
+});

--- a/src/lib/number-format.ts
+++ b/src/lib/number-format.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared number-formatting helpers used across report renders,
+ * cards, and the leaderboard. Before this util, 11 components
+ * reimplemented K/M formatting inline — none of them knew about
+ * billions, most over-used decimals at high magnitudes, and a few
+ * rendered raw integers without thousands separators. See #121.
+ *
+ * Tier scale (matches Google Docs / Slack / most user-facing apps):
+ *   < 1,000              → raw with commas (e.g. `847`)
+ *   < 1,000,000          → k      (e.g. `12.3k`, `847k`)
+ *   < 1,000,000,000      → M      (e.g. `12.3M`, `847M`)
+ *   < 1,000,000,000,000  → B      (e.g. `12.3B`, `847B`)
+ *   else                 → T      (e.g. `12.3T`)
+ *
+ * Within a tier, the decimal drops once the coefficient is ≥ 100.
+ * This prevents `417.2M` (6 chars) from clipping heatmap cells —
+ * it renders as `417M` (4 chars). See #122.
+ */
+
+function pickTier(abs: number): { divisor: number; suffix: string } {
+  if (abs < 1_000) return { divisor: 1, suffix: "" };
+  if (abs < 1_000_000) return { divisor: 1_000, suffix: "k" };
+  if (abs < 1_000_000_000) return { divisor: 1_000_000, suffix: "M" };
+  if (abs < 1_000_000_000_000) return { divisor: 1_000_000_000, suffix: "B" };
+  return { divisor: 1_000_000_000_000, suffix: "T" };
+}
+
+/**
+ * Compact tiered format: `11307500000 → "11.3B"`, `417200000 → "417M"`,
+ * `847 → "847"`. Accepts bigint to handle totalTokens without loss.
+ * Negative values render with a leading `-`.
+ */
+export function formatCompactNumber(value: number | bigint): string {
+  const n = typeof value === "bigint" ? Number(value) : value;
+  if (!Number.isFinite(n)) return "0";
+
+  const sign = n < 0 ? "-" : "";
+  const abs = Math.abs(n);
+
+  if (abs < 1_000) {
+    return sign + Math.round(abs).toLocaleString("en-US");
+  }
+
+  const { divisor, suffix } = pickTier(abs);
+  const scaled = abs / divisor;
+  const digits = scaled >= 100 ? 0 : 1;
+  return `${sign}${scaled.toFixed(digits)}${suffix}`;
+}
+
+/**
+ * Raw integer with thousands separators: `5086539595 → "5,086,539,595"`.
+ * Use for places that want to show the exact count (session counts,
+ * PR counts, commit counts, etc.) rather than a compact summary.
+ */
+export function formatInteger(value: number | bigint): string {
+  const n = typeof value === "bigint" ? Number(value) : value;
+  if (!Number.isFinite(n)) return "0";
+  return Math.round(n).toLocaleString("en-US");
+}
+
+/**
+ * Currency variant of the compact format: `1234567 → "$1.2M"`.
+ * Sub-dollar values fall through to two-decimal precision so
+ * `$0.04` renders as expected instead of `$0`.
+ */
+export function formatCompactCurrency(value: number): string {
+  if (!Number.isFinite(value)) return "$0";
+  const sign = value < 0 ? "-" : "";
+  const abs = Math.abs(value);
+
+  if (abs < 1) return `${sign}$${abs.toFixed(2)}`;
+  if (abs < 1_000) return `${sign}$${abs.toFixed(0)}`;
+  return `${sign}$${formatCompactNumber(abs)}`;
+}


### PR DESCRIPTION
## Summary

Consolidates 11 duplicated inline K/M formatters into `src/lib/number-format.ts`. Adds the missing B (billions) and T (trillions) tiers, drops the decimal at ≥ 100 within each tier, and fills raw-integer gaps where PR/commit counts rendered without thousand-separators.

## Before / After

| Before | After |
|--------|-------|
| `11307.5M` | `11.3B` |
| `1186.9M/wk` | `1.2B/wk` |
| `417.2M` (clips in heatmap cell) | `417M` |
| `5086539595` (raw) | `5,086,539,595` |

## New util

`src/lib/number-format.ts`:
- `formatCompactNumber(n | bigint)` — tiered K/M/B/T; drops decimal at ≥ 100 within tier
- `formatInteger(n | bigint)` — raw with thousand-separators
- `formatCompactCurrency(n)` — currency variant, sub-\$1 keeps two decimals

16 unit tests at `src/lib/__tests__/number-format.test.ts`.

## Side effect on #122

`417.2M` (6 chars) → `417M` (4 chars) should resolve the heatmap cell clipping from #122. **I could not visually verify in a browser here** — please eyeball the Vercel preview heatmap labels before closing #122.

## Files touched

- New: `src/lib/number-format.ts`, tests
- Edited (formatter consolidation): `HeroStats`, `ActivityHeatmap`, `LeaderboardRow`, `HarnessSections`, `HarnessOverview`, `InsightCard`, `ToolUsageTreemap`, `GitPatternsDisplay`, `src/app/page.tsx`, `src/app/top/page.tsx`, `src/app/api/og/[username]/[slug]/route.tsx`, `src/app/insights/[username]/[slug]/layout.tsx`

## Notes from code review

- The homepage `formatCost(0) = "$0"` case is gated by `> 0` checks at `src/app/page.tsx:652,870`, so the sub-\$1 branch of `formatCompactCurrency` (which would return `"\$0.00"`) is unreachable — not a regression.
- Negative path is safe: lines-of-code renderers in LeaderboardRow and HeroStats guard on `> 0`.
- OG route is `runtime = "nodejs"` — util has no runtime concerns.

## Test plan

- [x] `npx vitest run src/lib/__tests__/number-format.test.ts` — 16 passed
- [x] Full suite — 571 passed, no regressions
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] **Manual browser check** — please verify hero lifetime tokens renders as `11.3B`, heatmap cells fit their labels, and PR/commit counts have commas

Closes #121