### PR TITLE
fix(ui): align upload preview + edit page section order (#49)

### DIFF
--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -529,16 +529,6 @@ export default function EditReportPage() {
             <HowIWorkCluster harnessData={harnessData} />
           </HideableCard>
 
-          {Object.keys(harnessData.toolUsage).length > 0 && (
-            <HideableCard
-              title="Tool Usage"
-              hidden={!!hiddenSections["toolUsage"]}
-              onToggle={() => toggleSection("toolUsage")}
-            >
-              <ToolUsageTreemap toolUsage={harnessData.toolUsage} />
-            </HideableCard>
-          )}
-
           {harnessData.workflowData && (
             <HideableCard
               title="Workflow Diagrams"
@@ -634,6 +624,16 @@ export default function EditReportPage() {
                   })}
                 </div>
               </CollapsibleSection>
+            </HideableCard>
+          )}
+
+          {Object.keys(harnessData.toolUsage).length > 0 && (
+            <HideableCard
+              title="Tool Usage"
+              hidden={!!hiddenSections["toolUsage"]}
+              onToggle={() => toggleSection("toolUsage")}
+            >
+              <ToolUsageTreemap toolUsage={harnessData.toolUsage} />
             </HideableCard>
           )}
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1602,17 +1602,6 @@ export default function UploadPage() {
                 <HowIWorkCluster harnessData={parsed.harnessData} />
               </RedactableSection>
 
-              {/* Tool Usage Treemap */}
-              {Object.keys(parsed.harnessData.toolUsage).length > 0 && (
-                <RedactableSection
-                  title="Tool Usage"
-                  enabled={!disabledSections["toolUsage"]}
-                  onToggle={() => toggleSection("toolUsage")}
-                >
-                  <ToolUsageTreemap toolUsage={parsed.harnessData.toolUsage} />
-                </RedactableSection>
-              )}
-
               {/* Workflow Diagrams */}
               {parsed.harnessData.workflowData && (
                 <RedactableSection
@@ -1722,6 +1711,17 @@ export default function UploadPage() {
                       ))}
                     </div>
                   </CollapsibleSection>
+                </RedactableSection>
+              )}
+
+              {/* Tool Usage Treemap */}
+              {Object.keys(parsed.harnessData.toolUsage).length > 0 && (
+                <RedactableSection
+                  title="Tool Usage"
+                  enabled={!disabledSections["toolUsage"]}
+                  onToggle={() => toggleSection("toolUsage")}
+                >
+                  <ToolUsageTreemap toolUsage={parsed.harnessData.toolUsage} />
                 </RedactableSection>
               )}
 


### PR DESCRIPTION
## Summary
- Reorder harness sections on `/upload` preview and `/insights/[username]/[slug]/edit` so they match the live detail page order: **Plugins → Tool Usage → CLI Tools**.
- JSX-only change; no logic, data, or styling differences.
- Fixes visual inconsistency introduced after PR #48 reordered the live page but left preview + edit stale.

## Test plan
- [x] `npx tsc --noEmit` green
- [x] `npx vitest run` green (34 files, 571 tests)
- [ ] Manual: load `/upload` preview and confirm Plugins renders before Tool Usage
- [ ] Manual: open `/insights/[user]/[slug]/edit` and confirm same order

Closes #49