### PR TITLE
fix(insights): accept fractional durationHours, round at Prisma write

### DIFF
--- a/src/app/api/insights/__tests__/route.test.ts
+++ b/src/app/api/insights/__tests__/route.test.ts
@@ -180,6 +180,20 @@ describe("POST /api/insights — body-level validation", () => {
     const response = await insightsPOST(postRequest({ sessionCount: null }));
     expect(response.status).not.toBe(400);
   });
+
+  it("accepts fractional durationHours (extract.py emits 220.5; DB is Int)", async () => {
+    // Hot-bug regression: the v2.7.0 extractor produces fractional
+    // hours (the fixture has 220.5). Before this fix the schema
+    // required int and rejected real reports with 400 'Invalid
+    // request body: durationHours — Invalid input: expected int,
+    // received number'. The save site now rounds to satisfy the Int
+    // column.
+    mockSessionAndUser("user-1");
+    const response = await insightsPOST(
+      postRequest({ sessionCount: 1, durationHours: 220.5 }),
+    );
+    expect(response.status).not.toBe(400);
+  });
 });
 
 // ── #119: save-side integration ─────────────────────────────────────
@@ -239,6 +253,18 @@ describe("POST /api/insights — save-side happy path", () => {
     expect(createArgs.data.reportType).toBe("insights");
     expect(typeof createArgs.data.slug).toBe("string");
     expect(createArgs.data.slug.length).toBeGreaterThan(0);
+  });
+
+  it("rounds fractional durationHours before writing to the Int column", async () => {
+    mockSessionAndUser("user-1");
+    wireTransaction();
+    seedReportMock();
+
+    await insightsPOST(postRequest({ sessionCount: 1, durationHours: 220.5 }));
+
+    const createArgs = mockPrisma.insightReport.create.mock.calls[0][0];
+    expect(createArgs.data.durationHours).toBe(221);
+    expect(Number.isInteger(createArgs.data.durationHours)).toBe(true);
   });
 
   it("auto-generates a title when the body omits one", async () => {

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -65,7 +65,11 @@ const createInsightReportSchema = z.object({
   projectIds: z.array(z.string()).optional(),
   reportType: z.string().optional(),
   totalTokens: z.number().int().nonnegative().nullable().optional(),
-  durationHours: optionalNullableInt,
+  // durationHours comes from extract.py as fractional hours (e.g. 220.5);
+  // the DB column is Int, so we accept a float here and round at the
+  // Prisma write site. Widening the column isn't worth a migration for
+  // what's a vanity metric.
+  durationHours: optionalNullableNumber,
   avgSessionMinutes: optionalNullableNumber,
   prCount: optionalNullableInt,
   autonomyLabel: optionalNullableString,
@@ -487,7 +491,10 @@ export async function POST(request: Request) {
           reportType: reportType ?? "insights",
           totalTokens:
             typeof totalTokens === "number" ? BigInt(totalTokens) : null,
-          durationHours: durationHours ?? null,
+          durationHours:
+            typeof durationHours === "number"
+              ? Math.round(durationHours)
+              : null,
           avgSessionMinutes: avgSessionMinutes ?? null,
           prCount: prCount ?? null,
           autonomyLabel: autonomyLabel ?? null,


### PR DESCRIPTION
## Bug

Publishing a real report today fails with:

\`\`\`
Invalid request body: durationHours — Invalid input: expected int, received number
\`\`\`

The zod schema shipped in #128 required \`durationHours\` to be an integer. The extractor (extract.py) produces **fractional hours** (the v2.7.0 fixture literally has 220.5). The DB column is \`Int\`, so the save path used to coerce or error silently — zod made the type mismatch loud.

## Fix

- Schema: \`durationHours: optionalNullableNumber\` (drop \`.int()\`).
- Prisma write site: \`Math.round(durationHours)\` before insert to keep the \`Int\` column happy.
- Not worth a migration to widen the column — it's a vanity metric (total hours of Claude Code use).

## Tests

Two regression cases in \`src/app/api/insights/__tests__/route.test.ts\`:
- Validation accepts \`durationHours: 220.5\` (not 400)
- Save-side test: \`durationHours: 220.5\` lands as \`221\` in the Prisma create payload (integer, rounded)

## Test plan

- [x] \`npx vitest run src/app/api/insights/__tests__/route.test.ts\` — 16 passed (2 new)
- [x] \`npx tsc --noEmit\` — clean