### PR TITLE
fix(build): skip prisma migrate deploy on Vercel preview deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && prisma migrate deploy && next build",
+    "build": "prisma generate && if [ \"$VERCEL_ENV\" != \"preview\" ]; then prisma migrate deploy; fi && next build",
     "start": "next start",
     "lint": "eslint",
     "db:seed": "npx tsx prisma/seed.ts",


### PR DESCRIPTION
## Root cause of today's outage

When PR #133 (Prisma baseline attempt) opened, Vercel auto-built its preview. Preview deploys share the prod `DATABASE_URL`. The preview ran `prisma migrate deploy`, tried to apply the new baseline against prod, every `CREATE TABLE` hit `already exists`, migration failed partway, and prod's `_prisma_migrations` got a failed row for `00000000_baseline`.

From that point on, error **P3009** blocked every subsequent production deploy — including the durationHours hotfix (#134), which didn't touch migrations at all. Recovery took a manual `prisma migrate resolve --rolled-back` against prod.

## Fix

One-line change to the `build` script:

```diff
- "build": "prisma generate && prisma migrate deploy && next build",
+ "build": "prisma generate && if [ \"$VERCEL_ENV\" != \"preview\" ]; then prisma migrate deploy; fi && next build",
```

## Behavior

| Env                          | `VERCEL_ENV`  | Runs migrate? |
| ---------------------------- | ------------- | ------------- |
| Vercel Production            | `production`  | yes           |
| Vercel Preview               | `preview`     | **no**        |
| Vercel Development           | `development` | yes           |
| Local (`npm run build`)      | unset         | yes           |

Only preview skips — everywhere else migrate still runs.

## Tradeoff

Preview builds now run against prod's *current* schema rather than the branch's expected schema. For the ~90% of preview work that's UI/logic changes, this is fine and in fact safer (no risk of preview mutating prod). For PRs that genuinely test a migration, test against a local or throwaway DB instead.

Longer-term: Supabase Branching would give per-PR preview DBs. Out of scope for this PR.

## Test plan

- [x] Verified shell condition with `VERCEL_ENV=preview`, `=production`, and unset — skips only on preview
- [x] No code changes beyond `package.json`; no test suite change