### PR TITLE
fix(seed): populate lifetimeTokens on demo profiles

### DIFF
--- a/prisma/seed-demos.ts
+++ b/prisma/seed-demos.ts
@@ -164,6 +164,7 @@ function harnessReport(
     linesAdded: number;
     linesRemoved: number;
     tokens: number;
+    lifetimeTokens: number;
     durationHours: number;
     avgSession: number;
     skills: number;
@@ -266,11 +267,14 @@ function harnessReport(
     harnessData: {
       stats: {
         totalTokens: opts.tokens,
+        lifetimeTokens: opts.lifetimeTokens,
         durationHours: opts.durationHours,
         avgSessionMinutes: opts.avgSession,
         skillsUsedCount: opts.skills,
         hooksCount: opts.hooks,
         prCount: opts.prs,
+        sessionCount: opts.sessions,
+        commitCount: opts.commits,
       },
       autonomy: {
         label: opts.autonomyLabel,
@@ -470,6 +474,9 @@ async function seed() {
       // cache_creation). Old value was ~4.2M input+output only; heavy
       // agentic Fire-and-Forget usage pushes that 15-20x with cache traffic.
       tokens: 72_000_000,
+      // Lifetime ≈ 3.3× last-30d — Mika is a long-tenure power user, so
+      // most historical sessions sit behind the 30-day window.
+      lifetimeTokens: 240_000_000,
       durationHours: 86,
       avgSession: 36,
       skills: 18,
@@ -756,6 +763,8 @@ async function seed() {
       linesRemoved: 3800,
       // Directive / SaaS builder — moderate caching, ~15x scale-up.
       tokens: 42_000_000,
+      // Lifetime ≈ 2.7× — consistent focused SaaS work over several months.
+      lifetimeTokens: 115_000_000,
       durationHours: 52,
       avgSession: 47,
       skills: 24,
@@ -1069,6 +1078,9 @@ async function seed() {
       linesRemoved: 8400,
       // Heavy agent work + long-context embeddings → aggressive caching.
       tokens: 65_000_000,
+      // Lifetime ≈ 3.0× — heavy agent + long-context embedding usage
+      // accumulates large cache_read volumes over time.
+      lifetimeTokens: 195_000_000,
       durationHours: 72,
       avgSession: 44,
       skills: 12,
@@ -1328,6 +1340,8 @@ async function seed() {
       linesRemoved: 6800,
       // Infra / incident tooling — collaborative, plenty of context reuse.
       tokens: 48_000_000,
+      // Lifetime ≈ 2.5× — steady collaborative use across incident response work.
+      lifetimeTokens: 120_000_000,
       durationHours: 54,
       avgSession: 28,
       skills: 9,
@@ -1481,6 +1495,9 @@ async function seed() {
       linesRemoved: 3100,
       // Freelance / Rails — collaborative, medium cache ratio.
       tokens: 32_000_000,
+      // Lifetime ≈ 2.25× — part-time freelance cadence, lower tenure than
+      // the heavy full-time personas.
+      lifetimeTokens: 72_000_000,
       durationHours: 38,
       avgSession: 25,
       skills: 7,
@@ -1651,6 +1668,9 @@ async function seed() {
       linesRemoved: 800,
       // New to Claude Code, short exploratory sessions, lighter caching.
       tokens: 9_500_000,
+      // Lifetime ≈ 1.1× — Sam only started recently, so the 30-day window
+      // IS most of his lifetime usage. A "new user" marker visually.
+      lifetimeTokens: 10_500_000,
       durationHours: 18,
       avgSession: 22,
       skills: 4,


### PR DESCRIPTION
## Summary
- Adds `lifetimeTokens`, `sessionCount`, and `commitCount` to the shared `stats` block used by all six demo profiles (seed-demos.ts).
- Sets a plausible per-persona `lifetimeTokens` value on each profile, calibrated to their tenure (power users 3.0-3.3×, part-timers 2.2-2.7×, "new user" Sam at ~1.1×).

## Why
Real uploaded harness reports produce all three fields; the homepage and leaderboard render `lifetimeTokens` prominently as the "Lifetime Tokens" banner. Demo cards were showing zero or falling back to `totalTokens`, which made them look incomplete next to real profiles.

The 4-way `perModelTokens` breakdown (input/output/cache_read/cache_create) was already correctly generated via `computeDefaultPerModelTokens` — no change needed there.

## Per-persona calibration
| Profile | 30d tokens | Lifetime | Multiplier |
|---|---|---|---|
| Mika Tanaka | 72M | 240M | 3.3× |
| Elena Volkov | 65M | 195M | 3.0× |
| Jordan Reeves | 48M | 120M | 2.5× |
| Priya Sharma | 42M | 115M | 2.7× |
| Marcus Chen | 32M | 72M | 2.25× |
| Sam Okafor | 9.5M | 10.5M | 1.1× (new user) |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 573 tests passing (34 files)
- [x] `npx vitest run prisma/__tests__/seed-helpers.test.ts` — 22 tests passing
- [ ] Reviewer: after merge, reseed a dev DB (`npx tsx prisma/seed-demos.ts`) and confirm the Lifetime Tokens banner renders on each demo profile's homepage card with the expected value