### PR TITLE
docs(upload): surface trust signals near install commands

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1088,14 +1088,25 @@ export default function UploadPage() {
               <CommandBlock command="/plugin marketplace add kabirdos/insight-harness" />
               <CommandBlock command="/plugin install insight-harness@kabirdos-insight-harness" />
               <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                Auto-updates when new versions ship. Inspect the source at{" "}
+                Auto-updates when new versions ship. Python stdlib only — no pip
+                installs, no background daemons, no uploads unless you choose to
+                share.{" "}
+                <a
+                  href="https://github.com/kabirdos/insight-harness#how-it-runs-and-what-it-doesnt-do"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-slate-600 underline decoration-slate-300 underline-offset-2 hover:text-slate-900 hover:decoration-slate-500 dark:text-slate-300 dark:decoration-slate-600 dark:hover:text-slate-100 dark:hover:decoration-slate-400"
+                >
+                  See exactly what it runs
+                </a>{" "}
+                or{" "}
                 <a
                   href="https://github.com/kabirdos/insight-harness"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="font-mono text-slate-600 underline decoration-slate-300 underline-offset-2 hover:text-slate-900 hover:decoration-slate-500 dark:text-slate-300 dark:decoration-slate-600 dark:hover:text-slate-100 dark:hover:decoration-slate-400"
                 >
-                  github.com/kabirdos/insight-harness
+                  inspect the source
                 </a>
                 .
               </p>


### PR DESCRIPTION
## Summary
Adds one inline sentence near the `/plugin install` commands stating that insight-harness is Python stdlib only with no pip installs, no background daemons, and no uploads unless the user chooses to share. Replaces the single generic `github.com` link with two labelled links:

- **"See exactly what it runs"** → anchored to the new *How it runs* section of the README
- **"inspect the source"** → repo root (unchanged target)

## Why
Someone deciding whether to run a script that scans `~/.claude` should see the trust posture before copy-pasting the install commands, not have to click through to discover it. The new README section at kabirdos/insight-harness#17 provides the destination.

## Dependency note
The anchor `#how-it-runs-and-what-it-doesnt-do` depends on kabirdos/insight-harness#17 merging. Harmless while pending — GitHub simply drops the anchor and renders the repo root.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 573 tests passing
- [ ] Reviewer: confirm links open in new tabs (`target="_blank"` with `rel="noopener noreferrer"` on both)
- [ ] Reviewer: after merging the README PR upstream, confirm the anchor resolves correctly