### PR TITLE
feat: Wave 1 — isDraft + harness token/upload models

### DIFF
--- a/prisma/migrations/20260422_add_harness_tokens_and_uploads/migration.sql
+++ b/prisma/migrations/20260422_add_harness_tokens_and_uploads/migration.sql
@@ -1,0 +1,51 @@
+-- Add HarnessToken and HarnessUpload models for the insight-harness direct-POST
+-- upload path. Tokens are split-format (public selector + bcrypt'd secret) and
+-- HarnessUpload backs both X-Upload-Id idempotency and rate-limit counters.
+-- Additive only: existing rows are unaffected.
+
+-- CreateTable HarnessToken
+CREATE TABLE "HarnessToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "selector" TEXT NOT NULL,
+    "hashedSecret" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "HarnessToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable HarnessUpload
+CREATE TABLE "HarnessUpload" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "uploadId" TEXT NOT NULL,
+    "slug" TEXT,
+    "success" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HarnessUpload_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex (unique selector)
+CREATE UNIQUE INDEX "HarnessToken_selector_key" ON "HarnessToken"("selector");
+
+-- CreateIndex
+CREATE INDEX "HarnessToken_userId_revokedAt_idx" ON "HarnessToken"("userId", "revokedAt");
+
+-- CreateIndex
+CREATE INDEX "HarnessToken_userId_createdAt_idx" ON "HarnessToken"("userId", "createdAt");
+
+-- CreateIndex (unique idempotency key)
+CREATE UNIQUE INDEX "HarnessUpload_userId_uploadId_key" ON "HarnessUpload"("userId", "uploadId");
+
+-- CreateIndex
+CREATE INDEX "HarnessUpload_userId_createdAt_idx" ON "HarnessUpload"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "HarnessToken" ADD CONSTRAINT "HarnessToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "HarnessUpload" ADD CONSTRAINT "HarnessUpload_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260422_add_is_draft/migration.sql
+++ b/prisma/migrations/20260422_add_is_draft/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "InsightReport" ADD COLUMN "isDraft" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model InsightReport {
   title       String
   slug        String
   publishedAt DateTime @default(now())
+  isDraft     Boolean  @default(false)
 
   // Stats
   sessionCount   Int?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,11 +24,13 @@ model User {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
 
-  reports    InsightReport[]
-  votes      SectionVote[]
-  highlights SectionHighlight[]
-  comments   Comment[]
-  projects   Project[]
+  reports        InsightReport[]
+  votes          SectionVote[]
+  highlights     SectionHighlight[]
+  comments       Comment[]
+  projects       Project[]
+  harnessTokens  HarnessToken[]
+  harnessUploads HarnessUpload[]
 }
 
 model InsightReport {
@@ -187,4 +189,40 @@ model AuthorAnnotation {
   report InsightReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
 
   @@unique([reportId, sectionKey])
+}
+
+/// Bearer tokens used by the insight-harness skill for direct-POST upload.
+/// `selector` is the public, indexed half (12 hex chars). `hashedSecret` is bcrypt(secret half).
+/// Tokens are reusable; expiresAt is rolled forward to NOW() + 90d on every successful use.
+model HarnessToken {
+  id            String    @id @default(cuid())
+  userId        String
+  selector      String    @unique
+  hashedSecret  String
+  createdAt     DateTime  @default(now())
+  expiresAt     DateTime
+  lastUsedAt    DateTime?
+  revokedAt     DateTime?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt])
+  @@index([userId, createdAt])
+}
+
+/// Idempotency + rate-limit log for direct-POST uploads via /api/upload (bearer path).
+/// Unique (userId, uploadId) backs the X-Upload-Id idempotency contract.
+/// Rows in the last 24h back the rate-limit counters in src/lib/harness-rate-limit.ts.
+model HarnessUpload {
+  id        String   @id @default(cuid())
+  userId    String
+  uploadId  String
+  slug      String?
+  success   Boolean
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, uploadId])
+  @@index([userId, createdAt])
 }

--- a/src/types/api-contracts.ts
+++ b/src/types/api-contracts.ts
@@ -8,6 +8,7 @@ import type { ChartData, SkillKey } from "./insights";
 
 export interface InsightReportListItemContract {
   slug: string;
+  isDraft: boolean;
   detectedSkills: SkillKey[] | string[];
   dayCount: number | null;
   linesAdded: number | null;


### PR DESCRIPTION
## Summary

Wave 1 of the tokenized direct-post plan (`docs/plans/2026-04-22-001-feat-tokenized-direct-post-plan.md`). Two pure-additive Prisma migrations, no runtime code changes.

## Units in this PR

### Unit 1 — `isDraft` column on `InsightReport`
- Maps to requirement **R7** (`docs/brainstorms/2026-04-22-tokenized-direct-post-requirements.md`).
- Adds `isDraft Boolean @default(false)` to `InsightReport` (positioned next to `publishedAt`).
- Migration: `prisma/migrations/20260422_add_is_draft/migration.sql` — single `ALTER TABLE ... ADD COLUMN` with `DEFAULT false`, so existing rows default to non-draft.
- Adds `isDraft: boolean` to `InsightReportListItemContract` in `src/types/api-contracts.ts`. `InsightReportDetailContract` extends the list item, so detail picks it up automatically. Existing routes use Prisma `include` (not `select`) so the field flows through without route changes.

### Unit 4 — `HarnessToken` + `HarnessUpload` models
- Maps to requirements **R1, R2, R3, R12, R13, R14a**.
- New `HarnessToken` model: split-format bearer tokens (public `selector` indexed unique, `hashedSecret` bcrypt'd), reusable with rolling 90-day `expiresAt`, soft-deletable via `revokedAt`. Indexes on `(userId, revokedAt)` and `(userId, createdAt)`.
- New `HarnessUpload` model: idempotency + rate-limit log, with `@@unique([userId, uploadId])` backing the `X-Upload-Id` contract and `(userId, createdAt)` index for 24h rate-limit windows.
- Both models cascade-delete from `User`. Back-relations `harnessTokens` and `harnessUploads` added to the existing `User` model.
- Migration: `prisma/migrations/20260422_add_harness_tokens_and_uploads/migration.sql` mirrors the SQL style of `20260410_add_persistent_projects` — `CREATE TABLE`, indexes, `ADD CONSTRAINT ... FOREIGN KEY`.

## Rollout note

Both migrations are **strictly additive** — no `DROP`, no `ALTER COLUMN ... NOT NULL` against existing columns, no destructive defaults. Per repo invariants (`agent/MEMORY.md`), Prisma migration history is **never reset**; CI runs `prisma migrate deploy` only.

## Verification

- `npx prisma generate` → `Prisma Client generated`
- `npx tsc --noEmit` → `TypeScript: No errors found`
- Migration files exist at the exact paths called out in the plan.

No DB was touched in this PR. Migrations land on `main` and propagate via `prisma migrate deploy` on the next production build.

## Test plan

- [ ] CI green on this branch (build + typecheck).
- [ ] After merge, `prisma migrate deploy` runs cleanly on the production build (the `build` script in `package.json` skips deploy on Vercel preview, so production deploy is the real check).
- [ ] Spot-check `\d "InsightReport"` in production after deploy: `isDraft` column present, `NOT NULL`, default `false`.
- [ ] Spot-check `\d "HarnessToken"` and `\d "HarnessUpload"` in production after deploy: indexes and FKs present as defined.