### PR TITLE
feat: Wave 2 — draft visibility filter + harness helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@sentry/nextjs": "^10.48.0",
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.101.1",
+        "@types/bcrypt": "^6.0.0",
+        "bcrypt": "^6.0.0",
         "cheerio": "^1.2.0",
         "clsx": "^2.1.1",
         "dotenv": "^17.4.0",
@@ -2744,6 +2746,15 @@
         "tailwindcss": "4.2.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4224,6 +4235,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/boolbase": {
@@ -9346,6 +9371,15 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
@@ -9390,6 +9424,17 @@
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.37",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@sentry/nextjs": "^10.48.0",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.101.1",
+    "@types/bcrypt": "^6.0.0",
+    "bcrypt": "^6.0.0",
     "cheerio": "^1.2.0",
     "clsx": "^2.1.1",
     "dotenv": "^17.4.0",

--- a/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
+++ b/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
@@ -1,0 +1,13 @@
+-- Enforce "at most one active HarnessToken per user" at the database
+-- level. The application code in src/lib/harness-tokens.ts revokes
+-- prior active tokens before inserting a new one, but a transaction
+-- alone cannot prevent two concurrent mints from both finding zero
+-- rows to revoke and then both inserting fresh active rows. A
+-- Postgres partial unique index closes that race.
+--
+-- Prisma 6's schema DSL does not express a `WHERE` clause on
+-- `@@unique`, so this constraint lives in SQL only. The matching
+-- comment in prisma/schema.prisma documents that the DB enforces it.
+CREATE UNIQUE INDEX "HarnessToken_userId_active_unique"
+  ON "HarnessToken" ("userId")
+  WHERE "revokedAt" IS NULL;

--- a/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
+++ b/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
@@ -1,13 +1,23 @@
--- Enforce "at most one active HarnessToken per user" at the database
--- level. The application code in src/lib/harness-tokens.ts revokes
--- prior active tokens before inserting a new one, but a transaction
--- alone cannot prevent two concurrent mints from both finding zero
--- rows to revoke and then both inserting fresh active rows. A
--- Postgres partial unique index closes that race.
---
--- Prisma 6's schema DSL does not express a `WHERE` clause on
--- `@@unique`, so this constraint lives in SQL only. The matching
--- comment in prisma/schema.prisma documents that the DB enforces it.
+-- Defensive dedup: if any environment already has two active tokens for the same user
+-- (the state the prior race could have produced), revoke all but the most recent per user
+-- before adding the partial unique index. This is a no-op in production today since the
+-- HarnessToken model is brand new and empty.
+UPDATE "HarnessToken"
+SET "revokedAt" = NOW()
+WHERE "id" IN (
+  SELECT "id" FROM (
+    SELECT
+      "id",
+      ROW_NUMBER() OVER (PARTITION BY "userId" ORDER BY "createdAt" DESC) AS rn
+    FROM "HarnessToken"
+    WHERE "revokedAt" IS NULL
+  ) t
+  WHERE t.rn > 1
+);
+
+-- At-most-one-active-token-per-user invariant. The schema cannot express the WHERE clause
+-- in Prisma 6.19.3's DSL, so this index lives here only. Do not run `prisma db pull` —
+-- it will silently drop this constraint.
 CREATE UNIQUE INDEX "HarnessToken_userId_active_unique"
   ON "HarnessToken" ("userId")
   WHERE "revokedAt" IS NULL;

--- a/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
+++ b/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
@@ -1,3 +1,8 @@
+-- Take an exclusive lock for the duration of this migration so concurrent mints
+-- cannot slip a new active row in between the dedup UPDATE and the CREATE UNIQUE
+-- INDEX below. Released automatically at end of migration transaction.
+LOCK TABLE "HarnessToken" IN ACCESS EXCLUSIVE MODE;
+
 -- Defensive dedup: if any environment already has two active tokens for the same user
 -- (the state the prior race could have produced), revoke all but the "best" per user
 -- before adding the partial unique index. Ranking prefers the actually-usable token:

--- a/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
+++ b/prisma/migrations/20260428_harness_token_active_partial_unique/migration.sql
@@ -1,14 +1,23 @@
 -- Defensive dedup: if any environment already has two active tokens for the same user
--- (the state the prior race could have produced), revoke all but the most recent per user
--- before adding the partial unique index. This is a no-op in production today since the
--- HarnessToken model is brand new and empty.
+-- (the state the prior race could have produced), revoke all but the "best" per user
+-- before adding the partial unique index. Ranking prefers the actually-usable token:
+--   1. Already-expired rows lose first (CASE puts them at the bottom).
+--   2. Among non-expired, recently-used wins (`lastUsedAt DESC NULLS LAST`).
+--   3. Tie-break on `createdAt DESC` so a fresh-but-unused row beats an older unused one.
+-- This is a no-op in production today since the HarnessToken model is brand new and empty.
 UPDATE "HarnessToken"
 SET "revokedAt" = NOW()
 WHERE "id" IN (
   SELECT "id" FROM (
     SELECT
       "id",
-      ROW_NUMBER() OVER (PARTITION BY "userId" ORDER BY "createdAt" DESC) AS rn
+      ROW_NUMBER() OVER (
+        PARTITION BY "userId"
+        ORDER BY
+          CASE WHEN "expiresAt" < NOW() THEN 1 ELSE 0 END,
+          "lastUsedAt" DESC NULLS LAST,
+          "createdAt" DESC
+      ) AS rn
     FROM "HarnessToken"
     WHERE "revokedAt" IS NULL
   ) t

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,13 @@ model AuthorAnnotation {
 /// Bearer tokens used by the insight-harness skill for direct-POST upload.
 /// `selector` is the public, indexed half (12 hex chars). `hashedSecret` is bcrypt(secret half).
 /// Tokens are reusable; expiresAt is rolled forward to NOW() + 90d on every successful use.
+///
+/// DB-only constraint: a partial unique index "HarnessToken_userId_active_unique"
+/// on (userId) WHERE revokedAt IS NULL enforces "at most one active token per user".
+/// Prisma 6's @@unique DSL does not express a WHERE clause, so the constraint lives
+/// in the SQL migration 20260428_harness_token_active_partial_unique only. Do NOT
+/// `prisma db pull` against this model — it will drop the partial index from the
+/// generated schema.
 model HarnessToken {
   id            String    @id @default(cuid())
   userId        String

--- a/src/app/api/insights/[username]/[slug]/annotations/route.ts
+++ b/src/app/api/insights/[username]/[slug]/annotations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -26,7 +27,12 @@ export async function POST(
     const { username, slug } = await params;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true, authorId: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/comments/route.ts
+++ b/src/app/api/insights/[username]/[slug]/comments/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 export async function GET(
   request: Request,
@@ -8,9 +9,13 @@ export async function GET(
 ) {
   try {
     const { username, slug } = await params;
+    const session = await auth();
+    const viewerId = session?.user?.id ?? null;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [{ slug, author: { username } }, draftVisibilityClause(viewerId)],
+      },
       select: { id: true },
     });
 
@@ -86,7 +91,12 @@ export async function POST(
     }
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/highlight/route.ts
+++ b/src/app/api/insights/[username]/[slug]/highlight/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -35,7 +36,12 @@ export async function POST(
     }
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true },
     });
 
@@ -88,7 +94,12 @@ export async function DELETE(
     }
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/projects/[projectId]/route.ts
+++ b/src/app/api/insights/[username]/[slug]/projects/[projectId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 /**
  * PATCH /api/insights/[slug]/projects/[projectId]
@@ -15,7 +16,9 @@ import { auth } from "@/lib/auth";
  */
 export async function PATCH(
   request: Request,
-  { params }: { params: Promise<{ username: string; slug: string; projectId: string }> },
+  {
+    params,
+  }: { params: Promise<{ username: string; slug: string; projectId: string }> },
 ) {
   try {
     const session = await auth();
@@ -26,7 +29,12 @@ export async function PATCH(
     const { username, slug, projectId } = await params;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true, authorId: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/projects/route.ts
+++ b/src/app/api/insights/[username]/[slug]/projects/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 /**
  * POST /api/insights/[slug]/projects
@@ -26,7 +27,12 @@ export async function POST(
     const { username, slug } = await params;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true, authorId: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/route.ts
+++ b/src/app/api/insights/[username]/[slug]/route.ts
@@ -4,6 +4,7 @@ import { auth } from "@/lib/auth";
 import type { InsightReportDetailContract } from "@/types/api-contracts";
 import { ALLOWED_PUT_FIELDS } from "@/app/api/insights/allowed-fields";
 import { filterReportForResponse } from "@/lib/filter-report-response";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -39,7 +40,9 @@ export async function GET(
     // linesAdded, linesRemoved, fileCount. If you change this to an explicit
     // `select`, you MUST add those fields explicitly, or the UI will silently break.
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [{ slug, author: { username } }, draftVisibilityClause(userId)],
+      },
       include: {
         author: {
           select: {
@@ -165,7 +168,12 @@ export async function PUT(
     const { username, slug } = await params;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true, authorId: true },
     });
 
@@ -226,7 +234,12 @@ export async function DELETE(
     const { username, slug } = await params;
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true, authorId: true },
     });
 

--- a/src/app/api/insights/[username]/[slug]/vote/route.ts
+++ b/src/app/api/insights/[username]/[slug]/vote/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 const SECTION_KEYS = [
   "atAGlance",
@@ -35,7 +36,12 @@ export async function POST(
     }
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true },
     });
 
@@ -93,7 +99,12 @@ export async function DELETE(
     }
 
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [
+          { slug, author: { username } },
+          draftVisibilityClause(session.user.id),
+        ],
+      },
       select: { id: true },
     });
 

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -7,6 +7,7 @@ import { normalizeHarnessData } from "@/types/insights";
 import type { Prisma } from "@prisma/client";
 import { fetchLinkPreview } from "@/lib/link-preview";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 // Optional-nullable scalar helpers used across the POST body schema.
 // Every stat field is nullable in the DB — we reject only garbage
@@ -95,6 +96,10 @@ function generateSlug(): string {
 
 export async function GET(request: Request) {
   try {
+    const session = await auth();
+    const viewerId = session?.user?.id ?? null;
+    const draftWhere = draftVisibilityClause(viewerId);
+
     const { searchParams } = new URL(request.url);
     const sort = searchParams.get("sort") ?? "newest";
     const page = Math.max(1, Number(searchParams.get("page") ?? "1"));
@@ -133,6 +138,7 @@ export async function GET(request: Request) {
     // linesAdded, linesRemoved, fileCount. If you change this to an explicit
     // `select`, you MUST add those fields explicitly, or the UI will silently break.
     const reportsQuery = prisma.insightReport.findMany({
+      where: draftWhere,
       skip: fetchSkip,
       take: fetchLimit,
       orderBy,
@@ -156,7 +162,7 @@ export async function GET(request: Request) {
         },
       },
     });
-    const countQuery = prisma.insightReport.count();
+    const countQuery = prisma.insightReport.count({ where: draftWhere });
 
     const [reports, total] = await Promise.all([reportsQuery, countQuery]);
 

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 export interface LeaderboardRow {
   rank: number;
@@ -40,7 +41,11 @@ export async function GET(request: Request) {
     // author keeping the latest. With hundreds of users this fits easily
     // in memory; when the population grows past a few thousand we'll
     // push this into a materialized view or window function.
+    // Leaderboard ranks public reports only. Drafts are excluded
+    // unconditionally (viewerId: null) so an owner's own draft never
+    // leapfrogs their published ranking.
     const reports = await prisma.insightReport.findMany({
+      where: draftVisibilityClause(null),
       orderBy: { publishedAt: "desc" },
       select: {
         publishedAt: true,

--- a/src/app/api/og/[username]/[slug]/route.tsx
+++ b/src/app/api/og/[username]/[slug]/route.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/db";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { estimateApiCostUsd } from "@/lib/api-cost";
 import { normalizeHarnessData, type HarnessData } from "@/types/insights";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 import {
   formatCompactNumber,
   formatCompactCurrency,
@@ -136,8 +137,13 @@ export async function GET(
   try {
     const { username, slug } = await params;
 
+    // OG images are crawler-facing previews. Never expose drafts —
+    // even to authenticated owners — because the resulting image gets
+    // cached by social previews. Filter as anonymous (viewerId: null).
     const report = await prisma.insightReport.findFirst({
-      where: { slug, author: { username } },
+      where: {
+        AND: [{ slug, author: { username } }, draftVisibilityClause(null)],
+      },
       include: {
         author: {
           select: {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
-import { auth } from "@/lib/auth";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
 import { draftVisibilityClause } from "@/lib/draft-filter";
 
@@ -29,15 +28,14 @@ export async function GET(request: Request) {
 
     const searchTerm = q.toLowerCase();
 
-    // Search results respect draft visibility — owners can find their
-    // own drafts via search; non-owners and anonymous viewers cannot.
-    const session = await auth();
-    const viewerId = session?.user?.id ?? null;
-
+    // Search is presented as "shared insights" in the UI — a public-
+    // discovery surface. Match the leaderboard / top / OG / metadata
+    // routes and hide drafts from EVERYONE, including their author.
+    // Owners surface their drafts via the dashboard, not search.
     // Fetch all reports with their content and author info
     // SQLite doesn't support JSON path queries, so we fetch and filter in-memory
     const allReports = await prisma.insightReport.findMany({
-      where: draftVisibilityClause(viewerId),
+      where: draftVisibilityClause(null),
       include: {
         author: {
           select: {

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 const SEARCHABLE_JSON_FIELDS = [
   "atAGlance",
@@ -27,9 +29,15 @@ export async function GET(request: Request) {
 
     const searchTerm = q.toLowerCase();
 
+    // Search results respect draft visibility — owners can find their
+    // own drafts via search; non-owners and anonymous viewers cannot.
+    const session = await auth();
+    const viewerId = session?.user?.id ?? null;
+
     // Fetch all reports with their content and author info
     // SQLite doesn't support JSON path queries, so we fetch and filter in-memory
     const allReports = await prisma.insightReport.findMany({
+      where: draftVisibilityClause(viewerId),
       include: {
         author: {
           select: {

--- a/src/app/api/top/route.ts
+++ b/src/app/api/top/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import type { Prisma } from "@prisma/client";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 export const SORT_MAP: Record<
   string,
@@ -70,8 +71,10 @@ export async function GET(req: NextRequest) {
   // Limit
   const limit = Math.min(parseInt(params.get("limit") || "50", 10), 100);
 
+  // /top is a public discovery surface — drafts are excluded
+  // unconditionally regardless of viewer.
   const reports = await prisma.insightReport.findMany({
-    where,
+    where: { AND: [where, draftVisibilityClause(null)] },
     orderBy,
     take: limit,
     select: {

--- a/src/app/api/users/[username]/route.ts
+++ b/src/app/api/users/[username]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
 import { normalizeSetup } from "@/lib/profile-setup-normalize";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 export async function GET(
   request: Request,
@@ -8,6 +10,8 @@ export async function GET(
 ) {
   try {
     const { username } = await params;
+    const session = await auth();
+    const viewerId = session?.user?.id ?? null;
 
     const user = await prisma.user.findUnique({
       where: { username },
@@ -24,6 +28,10 @@ export async function GET(
         setup: true,
         createdAt: true,
         reports: {
+          // Filter drafts at the relation level so a non-owner viewing
+          // someone else's profile does not enumerate that user's drafts.
+          // The owner sees their own drafts because the OR branch matches.
+          where: draftVisibilityClause(viewerId),
           orderBy: { publishedAt: "desc" },
           select: {
             id: true,

--- a/src/app/api/users/me/setup-suggestions/route.ts
+++ b/src/app/api/users/me/setup-suggestions/route.ts
@@ -40,6 +40,9 @@ export async function GET(): Promise<
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    // owner-scoped: where.authorId restricts to the caller's own reports,
+    // so the draft-visibility helper would be a no-op. The owner is
+    // entitled to see their own drafts here.
     const report = await prisma.insightReport.findFirst({
       where: { authorId: session.user.id, reportType: "insight-harness" },
       orderBy: { createdAt: "desc" },

--- a/src/app/insights/[username]/[slug]/layout.tsx
+++ b/src/app/insights/[username]/[slug]/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { prisma } from "@/lib/db";
 import { buildOgImageUrl } from "@/lib/urls";
 import { formatCompactNumber as formatTokens } from "@/lib/number-format";
+import { draftVisibilityClause } from "@/lib/draft-filter";
 
 export async function generateMetadata({
   params,
@@ -10,8 +11,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { username, slug } = await params;
 
+  // Page metadata is rendered for crawlers and shareable previews;
+  // never expose draft titles. Filter as anonymous (viewerId: null).
   const report = await prisma.insightReport.findFirst({
-    where: { slug, author: { username } },
+    where: {
+      AND: [{ slug, author: { username } }, draftVisibilityClause(null)],
+    },
     select: {
       totalTokens: true,
       sessionCount: true,

--- a/src/lib/__tests__/draft-filter.test.ts
+++ b/src/lib/__tests__/draft-filter.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { draftVisibilityClause } from "../draft-filter";
+
+describe("draftVisibilityClause", () => {
+  it("returns isDraft: false when the viewer is anonymous", () => {
+    expect(draftVisibilityClause(null)).toEqual({ isDraft: false });
+  });
+
+  it("includes the viewer's own drafts when viewerId is non-null", () => {
+    expect(draftVisibilityClause("user-1")).toEqual({
+      OR: [{ isDraft: false }, { authorId: "user-1" }],
+    });
+  });
+
+  it("returns a distinct object on each call (no shared mutable state)", () => {
+    const a = draftVisibilityClause("user-1");
+    const b = draftVisibilityClause("user-1");
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+
+  it("never returns a clause that would expose drafts to anonymous viewers", () => {
+    const clause = draftVisibilityClause(null);
+    // The shape must be exactly { isDraft: false } — no OR branch
+    // could let a draft through when viewer is unknown.
+    expect(clause).toEqual({ isDraft: false });
+    expect((clause as Record<string, unknown>).OR).toBeUndefined();
+  });
+
+  it("treats empty string viewerId as anonymous (defensive)", () => {
+    // Defensive: an empty string passed by mistake (e.g. `?? ""`) must
+    // not enable any user to see all drafts via authorId === "".
+    expect(draftVisibilityClause("")).toEqual({ isDraft: false });
+  });
+});

--- a/src/lib/__tests__/harness-auth.test.ts
+++ b/src/lib/__tests__/harness-auth.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
+    harnessToken: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/harness-tokens", async () => {
+  const actual =
+    await vi.importActual<typeof import("../harness-tokens")>(
+      "../harness-tokens",
+    );
+  return {
+    ...actual,
+    verifyToken: vi.fn(),
+  };
+});
+
+import { authenticateRequest } from "../harness-auth";
+import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { verifyToken } from "@/lib/harness-tokens";
+
+const mockPrisma = prisma as unknown as {
+  user: { findUnique: Mock };
+};
+const mockAuth = auth as unknown as Mock;
+const mockVerifyToken = verifyToken as unknown as Mock;
+
+function reqWith(headers: Record<string, string>): Request {
+  return new Request("http://localhost/api/upload", {
+    method: "POST",
+    headers,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authenticateRequest", () => {
+  it("returns viaToken: true when a valid bearer token verifies", async () => {
+    const selector = "a".repeat(12);
+    const raw = `ih_${selector}${"b".repeat(64)}`;
+    mockVerifyToken.mockResolvedValue({
+      userId: "user-1",
+      tokenId: "token-1",
+      selector,
+    });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(
+      reqWith({ authorization: `Bearer ${raw}` }),
+    );
+
+    expect(result).toEqual({
+      userId: "user-1",
+      username: "alice",
+      viaToken: true,
+      tokenSelector: selector,
+    });
+    expect(mockAuth).not.toHaveBeenCalled();
+  });
+
+  it("falls through to session when no bearer header is present", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(reqWith({}));
+
+    expect(result).toEqual({
+      userId: "user-1",
+      username: "alice",
+      viaToken: false,
+    });
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("falls through to session when bearer header is malformed (wrong prefix)", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(
+      reqWith({ authorization: `Bearer xx_${"a".repeat(76)}` }),
+    );
+
+    expect(result?.viaToken).toBe(false);
+    // Format-validation must reject before any DB call to verifyToken.
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("falls through to session when bearer is wrong length", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(
+      reqWith({ authorization: `Bearer ih_${"a".repeat(75)}` }),
+    );
+
+    expect(result?.viaToken).toBe(false);
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("falls through to session when bearer contains non-hex characters", async () => {
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(
+      reqWith({ authorization: `Bearer ih_${"g".repeat(76)}` }),
+    );
+
+    expect(result?.viaToken).toBe(false);
+    expect(mockVerifyToken).not.toHaveBeenCalled();
+  });
+
+  it("returns the session identity when bearer fails verification but session is valid", async () => {
+    const raw = `ih_${"a".repeat(76)}`;
+    mockVerifyToken.mockResolvedValue(null);
+    mockAuth.mockResolvedValue({ user: { id: "user-1" } });
+    mockPrisma.user.findUnique.mockResolvedValue({
+      id: "user-1",
+      username: "alice",
+    });
+
+    const result = await authenticateRequest(
+      reqWith({ authorization: `Bearer ${raw}` }),
+    );
+
+    expect(result).toEqual({
+      userId: "user-1",
+      username: "alice",
+      viaToken: false,
+    });
+  });
+
+  it("returns null when neither bearer nor session authenticates", async () => {
+    mockAuth.mockResolvedValue(null);
+
+    const result = await authenticateRequest(reqWith({}));
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/__tests__/harness-idempotency.test.ts
+++ b/src/lib/__tests__/harness-idempotency.test.ts
@@ -5,6 +5,7 @@ vi.mock("@/lib/db", () => ({
     harnessUpload: {
       findUnique: vi.fn(),
       upsert: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -13,7 +14,7 @@ import { prisma } from "@/lib/db";
 import { findIdempotentResult, withIdempotency } from "../harness-idempotency";
 
 const mockPrisma = prisma as unknown as {
-  harnessUpload: { findUnique: Mock; upsert: Mock };
+  harnessUpload: { findUnique: Mock; upsert: Mock; update: Mock };
 };
 
 beforeEach(() => {
@@ -27,7 +28,10 @@ describe("findIdempotentResult", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null on a row with success=false (failed attempt only)", async () => {
+  it("returns null on a row with success=false (prior failure or in-flight)", async () => {
+    // A success=false row should NOT short-circuit the upload route —
+    // otherwise we'd skip the rate limit AND the actual work, leaving
+    // the user permanently stuck on a partial failure (P1.C).
     mockPrisma.harnessUpload.findUnique.mockResolvedValue({
       slug: null,
       success: false,
@@ -47,64 +51,89 @@ describe("findIdempotentResult", () => {
 });
 
 describe("withIdempotency", () => {
-  it("first call runs work, stores slug, returns { replayed: false }", async () => {
-    // No prior row.
-    mockPrisma.harnessUpload.findUnique
-      .mockResolvedValueOnce(null) // pre-flight check
-      .mockResolvedValueOnce({ slug: "new-slug" }); // post-upsert re-read
+  it("first call: claims with success=false, runs work, flips to success=true", async () => {
+    // Upsert creates a fresh success=false row. The post-upsert read
+    // reflects what we just inserted.
     mockPrisma.harnessUpload.upsert.mockResolvedValue({});
-    const work = vi.fn(async () => ({ slug: "new-slug" }));
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: null,
+      success: false,
+    });
+    mockPrisma.harnessUpload.update.mockResolvedValue({});
 
+    const work = vi.fn(async () => ({ slug: "new-slug" }));
     const result = await withIdempotency("user-1", "upload-1", work);
 
     expect(work).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ slug: "new-slug", replayed: false });
+
+    // Claim row inserted with success=false.
     expect(mockPrisma.harnessUpload.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
         create: expect.objectContaining({
           userId: "user-1",
           uploadId: "upload-1",
-          slug: "new-slug",
-          success: true,
+          slug: null,
+          success: false,
         }),
+        update: {},
       }),
     );
+    // Then flipped to success=true with the slug.
+    expect(mockPrisma.harnessUpload.update).toHaveBeenCalledWith({
+      where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
+      data: { slug: "new-slug", success: true },
+    });
   });
 
-  it("second call with same (userId, uploadId) skips work and reports replayed: true", async () => {
-    // Pre-flight returns the prior success; work should NOT run.
-    mockPrisma.harnessUpload.findUnique.mockResolvedValueOnce({
+  it("second call after success: skips work, returns replayed: true", async () => {
+    // Upsert is a no-op (existing row left as-is). Post-upsert read
+    // returns the prior winner's row.
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
       slug: "prior-slug",
       success: true,
     });
-    const work = vi.fn(async () => ({ slug: "should-not-run" }));
 
+    const work = vi.fn(async () => ({ slug: "should-not-run" }));
     const result = await withIdempotency("user-1", "upload-1", work);
 
     expect(work).not.toHaveBeenCalled();
     expect(result).toEqual({ slug: "prior-slug", replayed: true });
-    expect(mockPrisma.harnessUpload.upsert).not.toHaveBeenCalled();
+    // No UPDATE on a replay — the row already has success=true.
+    expect(mockPrisma.harnessUpload.update).not.toHaveBeenCalled();
   });
 
-  it("concurrent race: loser reads winner's slug and reports replayed: true", async () => {
-    // Pre-flight passes (no row yet), work runs and produces a slug,
-    // upsert hits the unique constraint via the no-op update branch,
-    // and the post-upsert re-read returns a DIFFERENT slug — the
-    // winner's. The loser must surface that and mark replayed: true.
-    mockPrisma.harnessUpload.findUnique
-      .mockResolvedValueOnce(null) // pre-flight
-      .mockResolvedValueOnce({ slug: "winner-slug" }); // post-upsert re-read
+  it("retry after prior failure: re-runs work and flips success=false → true (P1.C fix)", async () => {
+    // Earlier attempt's work() threw; row stayed at success=false.
+    // A new call should re-run work and flip the row, NOT silently
+    // leave it stuck at success=false (which was the old upsert
+    // `update: {}` bug that broke this case forever).
     mockPrisma.harnessUpload.upsert.mockResolvedValue({});
-    const work = vi.fn(async () => ({ slug: "loser-slug" }));
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: null,
+      success: false, // prior failure
+    });
+    mockPrisma.harnessUpload.update.mockResolvedValue({});
 
+    const work = vi.fn(async () => ({ slug: "retry-slug" }));
     const result = await withIdempotency("user-1", "upload-1", work);
 
-    expect(result).toEqual({ slug: "winner-slug", replayed: true });
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ slug: "retry-slug", replayed: false });
+    expect(mockPrisma.harnessUpload.update).toHaveBeenCalledWith({
+      where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
+      data: { slug: "retry-slug", success: true },
+    });
   });
 
-  it("propagates errors from the work callback", async () => {
-    mockPrisma.harnessUpload.findUnique.mockResolvedValue(null);
+  it("work() throws: leaves row at success=false; subsequent retry can recover", async () => {
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: null,
+      success: false,
+    });
     const work = vi.fn(async () => {
       throw new Error("parse failed");
     });
@@ -112,6 +141,30 @@ describe("withIdempotency", () => {
     await expect(withIdempotency("user-1", "upload-1", work)).rejects.toThrow(
       "parse failed",
     );
-    expect(mockPrisma.harnessUpload.upsert).not.toHaveBeenCalled();
+    // Crucially, NO update was issued — the row remains success=false
+    // so a later retry will see it and run work() again.
+    expect(mockPrisma.harnessUpload.update).not.toHaveBeenCalled();
+  });
+
+  it("simulated concurrency: two sequential calls where the second sees a prior success=false row", async () => {
+    // Vitest's mocking can't simulate true concurrency, so we model the
+    // collapsed-case path: caller B arrives after caller A's claim row
+    // exists but before A flipped success=true. B's logic re-runs
+    // work() and writes its own slug. (In production this can produce
+    // two drafts; the README and the helper docstring document the
+    // tradeoff. The common retry-after-network-blip case is caught by
+    // findIdempotentResult before this wrapper is invoked.)
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: null,
+      success: false, // A's claim row, not yet flipped
+    });
+    mockPrisma.harnessUpload.update.mockResolvedValue({});
+
+    const work = vi.fn(async () => ({ slug: "B-slug" }));
+    const result = await withIdempotency("user-1", "upload-1", work);
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ slug: "B-slug", replayed: false });
   });
 });

--- a/src/lib/__tests__/harness-idempotency.test.ts
+++ b/src/lib/__tests__/harness-idempotency.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    harnessUpload: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import { findIdempotentResult, withIdempotency } from "../harness-idempotency";
+
+const mockPrisma = prisma as unknown as {
+  harnessUpload: { findUnique: Mock; upsert: Mock };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("findIdempotentResult", () => {
+  it("returns null on a fresh (userId, uploadId)", async () => {
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue(null);
+    const result = await findIdempotentResult("user-1", "upload-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on a row with success=false (failed attempt only)", async () => {
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: null,
+      success: false,
+    });
+    const result = await findIdempotentResult("user-1", "upload-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns { slug } on a prior success", async () => {
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue({
+      slug: "20260422-abc123",
+      success: true,
+    });
+    const result = await findIdempotentResult("user-1", "upload-1");
+    expect(result).toEqual({ slug: "20260422-abc123" });
+  });
+});
+
+describe("withIdempotency", () => {
+  it("first call runs work, stores slug, returns { replayed: false }", async () => {
+    // No prior row.
+    mockPrisma.harnessUpload.findUnique
+      .mockResolvedValueOnce(null) // pre-flight check
+      .mockResolvedValueOnce({ slug: "new-slug" }); // post-upsert re-read
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    const work = vi.fn(async () => ({ slug: "new-slug" }));
+
+    const result = await withIdempotency("user-1", "upload-1", work);
+
+    expect(work).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ slug: "new-slug", replayed: false });
+    expect(mockPrisma.harnessUpload.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
+        create: expect.objectContaining({
+          userId: "user-1",
+          uploadId: "upload-1",
+          slug: "new-slug",
+          success: true,
+        }),
+      }),
+    );
+  });
+
+  it("second call with same (userId, uploadId) skips work and reports replayed: true", async () => {
+    // Pre-flight returns the prior success; work should NOT run.
+    mockPrisma.harnessUpload.findUnique.mockResolvedValueOnce({
+      slug: "prior-slug",
+      success: true,
+    });
+    const work = vi.fn(async () => ({ slug: "should-not-run" }));
+
+    const result = await withIdempotency("user-1", "upload-1", work);
+
+    expect(work).not.toHaveBeenCalled();
+    expect(result).toEqual({ slug: "prior-slug", replayed: true });
+    expect(mockPrisma.harnessUpload.upsert).not.toHaveBeenCalled();
+  });
+
+  it("concurrent race: loser reads winner's slug and reports replayed: true", async () => {
+    // Pre-flight passes (no row yet), work runs and produces a slug,
+    // upsert hits the unique constraint via the no-op update branch,
+    // and the post-upsert re-read returns a DIFFERENT slug — the
+    // winner's. The loser must surface that and mark replayed: true.
+    mockPrisma.harnessUpload.findUnique
+      .mockResolvedValueOnce(null) // pre-flight
+      .mockResolvedValueOnce({ slug: "winner-slug" }); // post-upsert re-read
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    const work = vi.fn(async () => ({ slug: "loser-slug" }));
+
+    const result = await withIdempotency("user-1", "upload-1", work);
+
+    expect(result).toEqual({ slug: "winner-slug", replayed: true });
+  });
+
+  it("propagates errors from the work callback", async () => {
+    mockPrisma.harnessUpload.findUnique.mockResolvedValue(null);
+    const work = vi.fn(async () => {
+      throw new Error("parse failed");
+    });
+
+    await expect(withIdempotency("user-1", "upload-1", work)).rejects.toThrow(
+      "parse failed",
+    );
+    expect(mockPrisma.harnessUpload.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/harness-idempotency.test.ts
+++ b/src/lib/__tests__/harness-idempotency.test.ts
@@ -6,6 +6,7 @@ vi.mock("@/lib/db", () => ({
       findUnique: vi.fn(),
       upsert: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
 }));
@@ -14,7 +15,12 @@ import { prisma } from "@/lib/db";
 import { findIdempotentResult, withIdempotency } from "../harness-idempotency";
 
 const mockPrisma = prisma as unknown as {
-  harnessUpload: { findUnique: Mock; upsert: Mock; update: Mock };
+  harnessUpload: {
+    findUnique: Mock;
+    upsert: Mock;
+    update: Mock;
+    updateMany: Mock;
+  };
 };
 
 beforeEach(() => {
@@ -59,7 +65,7 @@ describe("withIdempotency", () => {
       slug: null,
       success: false,
     });
-    mockPrisma.harnessUpload.update.mockResolvedValue({});
+    mockPrisma.harnessUpload.updateMany.mockResolvedValue({ count: 1 });
 
     const work = vi.fn(async () => ({ slug: "new-slug" }));
     const result = await withIdempotency("user-1", "upload-1", work);
@@ -80,9 +86,10 @@ describe("withIdempotency", () => {
         update: {},
       }),
     );
-    // Then flipped to success=true with the slug.
-    expect(mockPrisma.harnessUpload.update).toHaveBeenCalledWith({
-      where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
+    // Then conditionally flipped to success=true with the slug —
+    // the WHERE clause guards against clobbering a race winner.
+    expect(mockPrisma.harnessUpload.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", uploadId: "upload-1", success: false },
       data: { slug: "new-slug", success: true },
     });
   });
@@ -103,6 +110,7 @@ describe("withIdempotency", () => {
     expect(result).toEqual({ slug: "prior-slug", replayed: true });
     // No UPDATE on a replay — the row already has success=true.
     expect(mockPrisma.harnessUpload.update).not.toHaveBeenCalled();
+    expect(mockPrisma.harnessUpload.updateMany).not.toHaveBeenCalled();
   });
 
   it("retry after prior failure: re-runs work and flips success=false → true (P1.C fix)", async () => {
@@ -115,15 +123,15 @@ describe("withIdempotency", () => {
       slug: null,
       success: false, // prior failure
     });
-    mockPrisma.harnessUpload.update.mockResolvedValue({});
+    mockPrisma.harnessUpload.updateMany.mockResolvedValue({ count: 1 });
 
     const work = vi.fn(async () => ({ slug: "retry-slug" }));
     const result = await withIdempotency("user-1", "upload-1", work);
 
     expect(work).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ slug: "retry-slug", replayed: false });
-    expect(mockPrisma.harnessUpload.update).toHaveBeenCalledWith({
-      where: { userId_uploadId: { userId: "user-1", uploadId: "upload-1" } },
+    expect(mockPrisma.harnessUpload.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", uploadId: "upload-1", success: false },
       data: { slug: "retry-slug", success: true },
     });
   });
@@ -144,6 +152,7 @@ describe("withIdempotency", () => {
     // Crucially, NO update was issued — the row remains success=false
     // so a later retry will see it and run work() again.
     expect(mockPrisma.harnessUpload.update).not.toHaveBeenCalled();
+    expect(mockPrisma.harnessUpload.updateMany).not.toHaveBeenCalled();
   });
 
   it("simulated concurrency: two sequential calls where the second sees a prior success=false row", async () => {
@@ -159,12 +168,32 @@ describe("withIdempotency", () => {
       slug: null,
       success: false, // A's claim row, not yet flipped
     });
-    mockPrisma.harnessUpload.update.mockResolvedValue({});
+    mockPrisma.harnessUpload.updateMany.mockResolvedValue({ count: 1 });
 
     const work = vi.fn(async () => ({ slug: "B-slug" }));
     const result = await withIdempotency("user-1", "upload-1", work);
 
     expect(work).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ slug: "B-slug", replayed: false });
+  });
+
+  it("concurrent race: B's update returns count 0; B's response carries A's slug, not B's", async () => {
+    // Caller B's work() ran but A finished first and already flipped
+    // the row to success=true with A's slug. B's conditional
+    // updateMany matches zero rows (success is no longer false).
+    // B must discard its slug and surface A's slug to the user so
+    // both callers resolve to the same idempotent result.
+    mockPrisma.harnessUpload.upsert.mockResolvedValue({});
+    mockPrisma.harnessUpload.findUnique
+      .mockResolvedValueOnce({ slug: null, success: false }) // post-claim read (B sees A's claim row)
+      .mockResolvedValueOnce({ slug: "A-slug", success: true }); // post-update re-read after race
+    mockPrisma.harnessUpload.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    const work = vi.fn(async () => ({ slug: "B-slug" }));
+    const result = await withIdempotency("user-1", "upload-1", work);
+
+    expect(work).toHaveBeenCalledTimes(1);
+    // Critical: B returns A's slug, with replayed: true.
+    expect(result).toEqual({ slug: "A-slug", replayed: true });
   });
 });

--- a/src/lib/__tests__/harness-logging.test.ts
+++ b/src/lib/__tests__/harness-logging.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logHarnessRequest } from "../harness-logging";
+
+describe("logHarnessRequest", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("emits a single JSON line with all provided fields", () => {
+    logHarnessRequest({
+      uploadId: "upload-1",
+      userId: "user-1",
+      tokenSelectorPrefix: "abcdef12",
+      contentLength: 1024,
+      replayed: false,
+      statusCode: 200,
+      durationMs: 42,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const arg = logSpy.mock.calls[0][0];
+    expect(typeof arg).toBe("string");
+    // Single line: no internal newlines.
+    expect((arg as string).includes("\n")).toBe(false);
+
+    const parsed = JSON.parse(arg as string);
+    expect(parsed).toMatchObject({
+      event: "harness_direct_post",
+      uploadId: "upload-1",
+      userId: "user-1",
+      tokenSelectorPrefix: "abcdef12",
+      contentLength: 1024,
+      replayed: false,
+      statusCode: 200,
+      durationMs: 42,
+    });
+  });
+
+  it("never logs the full token, the secret, or the request body", () => {
+    logHarnessRequest({
+      uploadId: "upload-1",
+      userId: "user-1",
+      tokenSelectorPrefix: "abcdef12",
+      statusCode: 200,
+      durationMs: 1,
+    });
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+    // Selector prefix must be exactly the 8 chars callers passed in.
+    expect(parsed.tokenSelectorPrefix).toBe("abcdef12");
+    expect(parsed.tokenSelectorPrefix.length).toBe(8);
+    // No leakage shapes.
+    expect(parsed).not.toHaveProperty("token");
+    expect(parsed).not.toHaveProperty("rawToken");
+    expect(parsed).not.toHaveProperty("secret");
+    expect(parsed).not.toHaveProperty("hashedSecret");
+    expect(parsed).not.toHaveProperty("body");
+    expect(parsed).not.toHaveProperty("requestBody");
+  });
+
+  it("drops undefined optional fields rather than emitting them as null", () => {
+    logHarnessRequest({
+      statusCode: 401,
+      durationMs: 3,
+    });
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(parsed).not.toHaveProperty("uploadId");
+    expect(parsed).not.toHaveProperty("userId");
+    expect(parsed).not.toHaveProperty("tokenSelectorPrefix");
+    expect(parsed).not.toHaveProperty("replayed");
+    expect(parsed).not.toHaveProperty("rateLimitReason");
+  });
+
+  it("includes rateLimitReason when set on a 429", () => {
+    logHarnessRequest({
+      uploadId: "upload-1",
+      userId: "user-1",
+      statusCode: 429,
+      durationMs: 5,
+      rateLimitReason: "uploads_24h",
+    });
+
+    const parsed = JSON.parse(logSpy.mock.calls[0][0] as string);
+    expect(parsed.rateLimitReason).toBe("uploads_24h");
+    expect(parsed.statusCode).toBe(429);
+  });
+});

--- a/src/lib/__tests__/harness-rate-limit.test.ts
+++ b/src/lib/__tests__/harness-rate-limit.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    harnessUpload: {
+      count: vi.fn(),
+      findFirst: vi.fn(),
+    },
+    harnessToken: {
+      count: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import {
+  checkMintRateLimit,
+  checkUploadRateLimit,
+  MINT_CAP,
+  UPLOAD_ATTEMPT_CAP,
+  UPLOAD_SUCCESS_CAP,
+} from "../harness-rate-limit";
+
+const mockPrisma = prisma as unknown as {
+  harnessUpload: { count: Mock; findFirst: Mock };
+  harnessToken: { count: Mock; findFirst: Mock };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("checkUploadRateLimit", () => {
+  it("returns ok when the user has 0 uploads in the last 24h", async () => {
+    mockPrisma.harnessUpload.count.mockResolvedValue(0);
+    const result = await checkUploadRateLimit("user-1");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns 429 with uploads_24h on the (cap)+1th successful upload", async () => {
+    // First call: success count (>= 20). Second call: attempt count.
+    mockPrisma.harnessUpload.count
+      .mockResolvedValueOnce(UPLOAD_SUCCESS_CAP)
+      .mockResolvedValueOnce(UPLOAD_SUCCESS_CAP);
+    mockPrisma.harnessUpload.findFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 60 * 60 * 1000), // 1h ago
+    });
+    const result = await checkUploadRateLimit("user-1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked");
+    expect(result.reason).toBe("uploads_24h");
+    expect(result.retryAfter).toBeGreaterThan(0);
+    // Oldest row was 1h ago → retry in ~23h.
+    expect(result.retryAfter).toBeLessThanOrEqual(24 * 60 * 60);
+    expect(result.retryAfter).toBeGreaterThan(22 * 60 * 60);
+  });
+
+  it("returns 429 with attempts_24h when only the attempt cap is hit", async () => {
+    // 10 successes (under cap) but 60 total attempts (at cap).
+    mockPrisma.harnessUpload.count
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(UPLOAD_ATTEMPT_CAP);
+    mockPrisma.harnessUpload.findFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 60 * 60 * 1000),
+    });
+    const result = await checkUploadRateLimit("user-1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked");
+    expect(result.reason).toBe("attempts_24h");
+  });
+
+  it("does not count an upload that is older than the 24h window", async () => {
+    // 0 in window means we never reach the cap branches.
+    mockPrisma.harnessUpload.count.mockResolvedValue(0);
+    const result = await checkUploadRateLimit("user-1");
+    expect(result).toEqual({ ok: true });
+
+    // Verify the queries actually used a 24h cutoff.
+    const callArg = mockPrisma.harnessUpload.count.mock.calls[0][0] as {
+      where: { createdAt: { gt: Date } };
+    };
+    const cutoff = callArg.where.createdAt.gt;
+    const cutoffAge = Date.now() - cutoff.getTime();
+    expect(cutoffAge).toBeGreaterThanOrEqual(24 * 60 * 60 * 1000 - 1000);
+    expect(cutoffAge).toBeLessThanOrEqual(24 * 60 * 60 * 1000 + 1000);
+  });
+});
+
+describe("checkMintRateLimit", () => {
+  it("returns ok when the user has 0 mints in the last 24h", async () => {
+    mockPrisma.harnessToken.count.mockResolvedValue(0);
+    const result = await checkMintRateLimit("user-1");
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("returns 429 with mints_24h on the (cap)+1th mint", async () => {
+    mockPrisma.harnessToken.count.mockResolvedValue(MINT_CAP);
+    mockPrisma.harnessToken.findFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 30 * 60 * 1000), // 30m ago
+    });
+    const result = await checkMintRateLimit("user-1");
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("expected blocked");
+    expect(result.reason).toBe("mints_24h");
+    expect(result.retryAfter).toBeGreaterThan(0);
+  });
+
+  it("counts revoked tokens against the mint cap", async () => {
+    // The query should NOT filter on revokedAt — verify by inspecting
+    // the where clause does not narrow it.
+    mockPrisma.harnessToken.count.mockResolvedValue(MINT_CAP);
+    mockPrisma.harnessToken.findFirst.mockResolvedValue({
+      createdAt: new Date(Date.now() - 1000),
+    });
+    await checkMintRateLimit("user-1");
+    const callArg = mockPrisma.harnessToken.count.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(callArg.where).not.toHaveProperty("revokedAt");
+  });
+});

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -120,6 +120,62 @@ describe("mintTokenForUser", () => {
       }),
     });
   });
+
+  it("retries once on a P2002 partial-unique collision, then succeeds (race recovery)", async () => {
+    // Simulate two concurrent mints racing past the transactional
+    // updateMany. The first create() trips the partial-unique index
+    // (P2002), the wrapper retries: the second updateMany now sees
+    // and revokes the winner's row, and the second create() succeeds.
+    const { Prisma } = await import("@prisma/client");
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`userId`)",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["HarnessToken_userId_active_unique"] },
+      },
+    );
+
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
+    // First create throws P2002, second succeeds.
+    mockPrisma.harnessToken.create
+      .mockRejectedValueOnce(p2002)
+      .mockResolvedValueOnce({});
+
+    const { raw } = await mintTokenForUser("user-1");
+
+    expect(raw).toMatch(/^ih_[0-9a-f]{76}$/);
+    // Two attempts → two updateMany calls, two create calls.
+    expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(2);
+    expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(2);
+    // Both updateMany calls target the same partial-unique slot
+    // (userId, revokedAt: null); the second one is what revokes the
+    // winner that beat us in the first race.
+    expect(mockPrisma.harnessToken.updateMany).toHaveBeenNthCalledWith(2, {
+      where: { userId: "user-1", revokedAt: null },
+      data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+    });
+  });
+
+  it("throws if a second P2002 follows the retry (no infinite loop)", async () => {
+    const { Prisma } = await import("@prisma/client");
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`userId`)",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: ["HarnessToken_userId_active_unique"] },
+      },
+    );
+
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.harnessToken.create.mockRejectedValue(p2002);
+
+    await expect(mintTokenForUser("user-1")).rejects.toMatchObject({
+      code: "P2002",
+    });
+    expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("revokeActiveTokensForUser", () => {

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    harnessToken: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      create: vi.fn(),
+    },
+    $transaction: vi.fn(),
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import {
+  generateToken,
+  hashSecret,
+  mintTokenForUser,
+  parseToken,
+  revokeActiveTokensForUser,
+  TOKEN_LENGTH,
+  verifyToken,
+} from "../harness-tokens";
+
+const mockPrisma = prisma as unknown as {
+  harnessToken: {
+    findUnique: Mock;
+    update: Mock;
+    updateMany: Mock;
+    create: Mock;
+  };
+  $transaction: Mock;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Wire $transaction to invoke the callback with the same mocked surface.
+  mockPrisma.$transaction.mockImplementation(
+    async (cb: (tx: typeof mockPrisma) => Promise<unknown>) => cb(mockPrisma),
+  );
+});
+
+describe("generateToken", () => {
+  it("returns a 79-char string matching /^ih_[0-9a-f]{76}$/", () => {
+    for (let i = 0; i < 20; i++) {
+      const { raw } = generateToken();
+      expect(raw).toMatch(/^ih_[0-9a-f]{76}$/);
+      expect(raw.length).toBe(TOKEN_LENGTH);
+    }
+  });
+
+  it("returns selector and secret components", () => {
+    const { raw, selector, secret } = generateToken();
+    expect(selector).toMatch(/^[0-9a-f]{12}$/);
+    expect(secret).toMatch(/^[0-9a-f]{64}$/);
+    expect(raw).toBe(`ih_${selector}${secret}`);
+  });
+});
+
+describe("parseToken", () => {
+  it("extracts selector and secret from a valid raw token", () => {
+    const raw = `ih_${"a".repeat(12)}${"b".repeat(64)}`;
+    expect(parseToken(raw)).toEqual({
+      selector: "a".repeat(12),
+      secret: "b".repeat(64),
+    });
+  });
+
+  it("returns null for wrong prefix", () => {
+    expect(parseToken(`xx_${"a".repeat(76)}`)).toBeNull();
+  });
+
+  it("returns null for wrong length", () => {
+    expect(parseToken(`ih_${"a".repeat(75)}`)).toBeNull();
+    expect(parseToken(`ih_${"a".repeat(77)}`)).toBeNull();
+  });
+
+  it("returns null for non-hex characters", () => {
+    expect(parseToken(`ih_${"g".repeat(76)}`)).toBeNull();
+    expect(parseToken(`ih_${"A".repeat(76)}`)).toBeNull(); // uppercase not allowed
+  });
+});
+
+describe("hashSecret", () => {
+  it("returns a bcrypt hash of the secret", async () => {
+    const hash = await hashSecret("secret");
+    expect(hash).toMatch(/^\$2[aby]\$/);
+    expect(hash.length).toBeGreaterThan(50);
+  });
+});
+
+describe("mintTokenForUser", () => {
+  it("revokes prior active tokens and creates a new one with expiresAt = now + 90d", async () => {
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 1 });
+    mockPrisma.harnessToken.create.mockResolvedValue({});
+
+    const before = Date.now();
+    const { raw, expiresAt } = await mintTokenForUser("user-1");
+    const after = Date.now();
+
+    expect(raw).toMatch(/^ih_[0-9a-f]{76}$/);
+    // Within 90 days +/- the test wall-clock window.
+    const expectedMin = before + 90 * 24 * 60 * 60 * 1000;
+    const expectedMax = after + 90 * 24 * 60 * 60 * 1000;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(expectedMax);
+
+    // Revoke-then-create order matters for R3 invariant.
+    expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+    });
+    expect(mockPrisma.harnessToken.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: "user-1",
+        selector: expect.stringMatching(/^[0-9a-f]{12}$/),
+        hashedSecret: expect.any(String),
+        expiresAt: expect.any(Date),
+      }),
+    });
+  });
+});
+
+describe("revokeActiveTokensForUser", () => {
+  it("calls updateMany to set revokedAt on all active tokens", async () => {
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 1 });
+    await revokeActiveTokensForUser("user-1");
+    expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledWith({
+      where: { userId: "user-1", revokedAt: null },
+      data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+    });
+  });
+});
+
+describe("verifyToken", () => {
+  /**
+   * Mint via the real path so the test exercises bcrypt round-trip.
+   * Returns the raw token plus the row mockPrisma.findUnique should
+   * return.
+   */
+  async function mintAndCaptureRow(): Promise<{
+    raw: string;
+    row: {
+      id: string;
+      userId: string;
+      selector: string;
+      hashedSecret: string;
+      expiresAt: Date;
+      lastUsedAt: Date | null;
+      revokedAt: Date | null;
+    };
+  }> {
+    let captured: {
+      selector: string;
+      hashedSecret: string;
+      expiresAt: Date;
+    } | null = null;
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.harnessToken.create.mockImplementation(
+      async ({
+        data,
+      }: {
+        data: { selector: string; hashedSecret: string; expiresAt: Date };
+      }) => {
+        captured = {
+          selector: data.selector,
+          hashedSecret: data.hashedSecret,
+          expiresAt: data.expiresAt,
+        };
+        return {};
+      },
+    );
+    const { raw } = await mintTokenForUser("user-1");
+    if (!captured) throw new Error("mint did not capture row");
+    const captured2 = captured as {
+      selector: string;
+      hashedSecret: string;
+      expiresAt: Date;
+    };
+    return {
+      raw,
+      row: {
+        id: "token-1",
+        userId: "user-1",
+        selector: captured2.selector,
+        hashedSecret: captured2.hashedSecret,
+        expiresAt: captured2.expiresAt,
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+    };
+  }
+
+  it("returns userId and rolls expiresAt + lastUsedAt forward on success", async () => {
+    const { raw, row } = await mintAndCaptureRow();
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(row);
+    mockPrisma.harnessToken.update.mockResolvedValue({});
+
+    const before = Date.now();
+    const result = await verifyToken(raw);
+    const after = Date.now();
+
+    expect(result).toEqual({
+      userId: "user-1",
+      tokenId: "token-1",
+      selector: row.selector,
+    });
+
+    // The update call should set both lastUsedAt and expiresAt to NOW()+90d.
+    const updateCall = mockPrisma.harnessToken.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: { lastUsedAt: Date; expiresAt: Date };
+    };
+    expect(updateCall.where.id).toBe("token-1");
+    expect(updateCall.data.lastUsedAt).toBeInstanceOf(Date);
+    expect(updateCall.data.expiresAt).toBeInstanceOf(Date);
+    const expectedMin = before + 90 * 24 * 60 * 60 * 1000;
+    const expectedMax = after + 90 * 24 * 60 * 60 * 1000;
+    expect(updateCall.data.expiresAt.getTime()).toBeGreaterThanOrEqual(
+      expectedMin,
+    );
+    expect(updateCall.data.expiresAt.getTime()).toBeLessThanOrEqual(
+      expectedMax,
+    );
+  });
+
+  it("rolls expiresAt to NOW()+90d regardless of prior value", async () => {
+    const { raw, row } = await mintAndCaptureRow();
+    // Simulate a token that was about to expire in 2 days.
+    row.expiresAt = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000);
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(row);
+    mockPrisma.harnessToken.update.mockResolvedValue({});
+
+    await verifyToken(raw);
+
+    const updateCall = mockPrisma.harnessToken.update.mock.calls[0][0] as {
+      data: { expiresAt: Date };
+    };
+    // Should jump back to ~90d, not stay at 2d.
+    const minutesUntilExpiry =
+      (updateCall.data.expiresAt.getTime() - Date.now()) / (60 * 1000);
+    expect(minutesUntilExpiry).toBeGreaterThan(89 * 24 * 60); // > 89d
+  });
+
+  it("returns null for a revoked token without updating lastUsedAt", async () => {
+    const { raw, row } = await mintAndCaptureRow();
+    row.revokedAt = new Date();
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(row);
+
+    const result = await verifyToken(raw);
+    expect(result).toBeNull();
+    expect(mockPrisma.harnessToken.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null for an expired token", async () => {
+    const { raw, row } = await mintAndCaptureRow();
+    row.expiresAt = new Date(Date.now() - 1000);
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(row);
+
+    const result = await verifyToken(raw);
+    expect(result).toBeNull();
+    expect(mockPrisma.harnessToken.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a malformed token without DB lookup", async () => {
+    expect(await verifyToken("nope")).toBeNull();
+    expect(await verifyToken(`ih_${"g".repeat(76)}`)).toBeNull();
+    expect(await verifyToken(`ih_${"a".repeat(75)}`)).toBeNull();
+    expect(mockPrisma.harnessToken.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null when selector is unknown", async () => {
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(null);
+    const result = await verifyToken(`ih_${"a".repeat(76)}`);
+    expect(result).toBeNull();
+    expect(mockPrisma.harnessToken.update).not.toHaveBeenCalled();
+  });
+
+  it("returns null when secret does not match the stored hash", async () => {
+    const { row } = await mintAndCaptureRow();
+    mockPrisma.harnessToken.findUnique.mockResolvedValue(row);
+
+    // Build a token with the right selector but wrong secret.
+    const wrongRaw = `ih_${row.selector}${"f".repeat(64)}`;
+    const result = await verifyToken(wrongRaw);
+    expect(result).toBeNull();
+    expect(mockPrisma.harnessToken.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -16,6 +16,7 @@ import { prisma } from "@/lib/db";
 import {
   generateToken,
   hashSecret,
+  MintConflictError,
   mintTokenForUser,
   parseToken,
   revokeActiveTokensForUser,
@@ -121,11 +122,12 @@ describe("mintTokenForUser", () => {
     });
   });
 
-  it("retries once on a P2002 partial-unique collision, then succeeds (race recovery)", async () => {
-    // Simulate two concurrent mints racing past the transactional
-    // updateMany. The first create() trips the partial-unique index
-    // (P2002), the wrapper retries: the second updateMany now sees
-    // and revokes the winner's row, and the second create() succeeds.
+  it("throws MintConflictError immediately on P2002 (no retry — would silently revoke the winner)", async () => {
+    // Simulate the loser of a concurrent partial-unique race: the
+    // winner's row is now visible via the partial unique index, so
+    // our `create` trips P2002. We must NOT retry — a retry would
+    // re-run `updateMany` against the winner's freshly-created row
+    // and silently revoke their token.
     const { Prisma } = await import("@prisma/client");
     const p2002 = new Prisma.PrismaClientKnownRequestError(
       "Unique constraint failed on the fields: (`userId`)",
@@ -137,44 +139,14 @@ describe("mintTokenForUser", () => {
     );
 
     mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
-    // First create throws P2002, second succeeds.
-    mockPrisma.harnessToken.create
-      .mockRejectedValueOnce(p2002)
-      .mockResolvedValueOnce({});
+    mockPrisma.harnessToken.create.mockRejectedValueOnce(p2002);
 
-    const { raw } = await mintTokenForUser("user-1");
-
-    expect(raw).toMatch(/^ih_[0-9a-f]{76}$/);
-    // Two attempts → two updateMany calls, two create calls.
-    expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(2);
-    expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(2);
-    // Both updateMany calls target the same partial-unique slot
-    // (userId, revokedAt: null); the second one is what revokes the
-    // winner that beat us in the first race.
-    expect(mockPrisma.harnessToken.updateMany).toHaveBeenNthCalledWith(2, {
-      where: { userId: "user-1", revokedAt: null },
-      data: expect.objectContaining({ revokedAt: expect.any(Date) }),
-    });
-  });
-
-  it("throws if a second P2002 follows the retry (no infinite loop)", async () => {
-    const { Prisma } = await import("@prisma/client");
-    const p2002 = new Prisma.PrismaClientKnownRequestError(
-      "Unique constraint failed on the fields: (`userId`)",
-      {
-        code: "P2002",
-        clientVersion: "test",
-        meta: { target: ["HarnessToken_userId_active_unique"] },
-      },
+    await expect(mintTokenForUser("user-1")).rejects.toBeInstanceOf(
+      MintConflictError,
     );
-
-    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
-    mockPrisma.harnessToken.create.mockRejectedValue(p2002);
-
-    await expect(mintTokenForUser("user-1")).rejects.toMatchObject({
-      code: "P2002",
-    });
-    expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(2);
+    // Single attempt only — no retry.
+    expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(1);
+    expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -148,6 +148,30 @@ describe("mintTokenForUser", () => {
     expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(1);
     expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(1);
   });
+
+  it("rethrows non-active-slot P2002 unchanged (e.g. selector collision)", async () => {
+    // A P2002 on the selector key is a separate failure mode (random
+    // collision in the selector space). It must NOT be translated to
+    // MintConflictError, since the caller's recovery path differs:
+    // selector collisions are retryable, active-slot races are not.
+    const { Prisma } = await import("@prisma/client");
+    const p2002 = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`selector`)",
+      {
+        code: "P2002",
+        clientVersion: "test",
+        meta: { target: "HarnessToken_selector_key" },
+      },
+    );
+
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.harnessToken.create.mockRejectedValue(p2002);
+
+    const thrown = await mintTokenForUser("user-1").catch((e: unknown) => e);
+    expect(thrown).toBeInstanceOf(Prisma.PrismaClientKnownRequestError);
+    expect(thrown).not.toBeInstanceOf(MintConflictError);
+    expect((thrown as { code: string }).code).toBe("P2002");
+  });
 });
 
 describe("revokeActiveTokensForUser", () => {

--- a/src/lib/draft-filter.ts
+++ b/src/lib/draft-filter.ts
@@ -1,0 +1,33 @@
+/**
+ * Draft visibility helper (R9, R9a, R11).
+ *
+ * Returns a Prisma WHERE fragment that hides `isDraft: true` reports
+ * from non-owners. Compose with the existing `where` via AND so the
+ * draft filter is the always-applied last guard at every read site.
+ *
+ * Usage:
+ *   const where = {
+ *     AND: [existingWhere, draftVisibilityClause(viewerId)],
+ *   };
+ *
+ * For nested-relation reads (Prisma `include: { reports: { where } }`),
+ * pass the helper directly — Prisma applies it to the relation's row
+ * filter:
+ *   include: { reports: { where: draftVisibilityClause(viewerId), ... } }
+ *
+ * Owner-scoped read paths (e.g. /api/users/me/setup-suggestions) are
+ * exempt — the existing `where` already restricts to the caller's own
+ * reports, and a non-owner cannot reach those rows by definition.
+ * Owner-scoped sites should annotate their decision with a
+ * `// owner-scoped: <reason>` comment instead of composing this helper.
+ */
+import type { Prisma } from "@prisma/client";
+
+export function draftVisibilityClause(
+  viewerId: string | null,
+): Prisma.InsightReportWhereInput {
+  if (viewerId) {
+    return { OR: [{ isDraft: false }, { authorId: viewerId }] };
+  }
+  return { isDraft: false };
+}

--- a/src/lib/harness-auth.ts
+++ b/src/lib/harness-auth.ts
@@ -1,0 +1,88 @@
+/**
+ * Hybrid bearer + session authenticator for routes that accept both
+ * the harness direct-POST flow and the existing browser session flow.
+ *
+ * Bearer path (Decision 3, Decision 2):
+ *   - Reads `Authorization: Bearer ih_<...>` header.
+ *   - Format-validates the token (prefix `ih_`, length 79, all hex
+ *     after prefix) BEFORE any DB call. Malformed headers fall
+ *     through to the session check rather than emitting a 401, so a
+ *     stray header on an otherwise-valid session request still works.
+ *   - On format-pass, calls verifyToken(); on success, returns
+ *     `{ viaToken: true, tokenSelector }`. The selector is the
+ *     plaintext 12-hex selector half — safe to log in trimmed form
+ *     (first 8 chars) but never propagate the full token.
+ *
+ * Session fallback:
+ *   - Calls NextAuth `auth()`. If a session resolves, looks up the
+ *     user record by id to surface the username. Returns
+ *     `{ viaToken: false }`.
+ *
+ * Returns null when neither path authenticates.
+ */
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { parseToken, verifyToken } from "@/lib/harness-tokens";
+
+export interface AuthenticatedRequest {
+  userId: string;
+  username: string;
+  viaToken: boolean;
+  tokenSelector?: string;
+}
+
+/**
+ * Extract the raw bearer token from the request, if any. Returns null
+ * when the header is missing or doesn't start with `Bearer `.
+ */
+function extractBearer(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header) return null;
+  const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+  if (!match) return null;
+  return match[1];
+}
+
+export async function authenticateRequest(
+  req: Request,
+): Promise<AuthenticatedRequest | null> {
+  // Bearer path first. Format-validate before any DB call.
+  const raw = extractBearer(req);
+  if (raw && parseToken(raw)) {
+    const verified = await verifyToken(raw);
+    if (verified) {
+      // verifyToken already touched the token row; we still need the
+      // username for downstream URL composition.
+      const user = await prisma.user.findUnique({
+        where: { id: verified.userId },
+        select: { username: true },
+      });
+      if (user) {
+        return {
+          userId: verified.userId,
+          username: user.username,
+          viaToken: true,
+          tokenSelector: verified.selector,
+        };
+      }
+    }
+  }
+
+  // Session fallback. Bearer that fails verification falls through
+  // here so a logged-in user sending a stale token via a misbehaving
+  // client doesn't lose their session-authed access.
+  const session = await auth();
+  if (!session?.user?.id) return null;
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { id: true, username: true },
+  });
+  if (!user) return null;
+
+  return {
+    userId: user.id,
+    username: user.username,
+    viaToken: false,
+  };
+}

--- a/src/lib/harness-idempotency.ts
+++ b/src/lib/harness-idempotency.ts
@@ -4,19 +4,42 @@
  * Two helpers (Decision 11):
  *
  * 1. findIdempotentResult(userId, uploadId) — pure lookup. Returns
- *    `{ slug }` if a prior successful HarnessUpload exists for this
- *    `(userId, uploadId)` pair, else null. Used by the upload route
- *    to short-circuit replays BEFORE the rate-limit check, so that a
- *    user who hits their 24h cap mid-retry still gets back the
- *    original draft URL (R14a).
+ *    `{ slug }` ONLY if a prior SUCCESSFUL HarnessUpload exists for this
+ *    `(userId, uploadId)` pair. A row at `success: false` returns null
+ *    so the upload route does NOT short-circuit on a half-finished
+ *    prior attempt (which would skip the rate-limit check AND skip the
+ *    actual work, leaving the user stuck on the partial failure).
+ *    Used by the upload route to short-circuit replays BEFORE the
+ *    rate-limit check, so a user who hits their 24h cap mid-retry
+ *    still gets back the original draft URL (R14a).
  *
- * 2. withIdempotency(userId, uploadId, work) — execution wrapper. If a
- *    prior successful row exists, returns the stored slug with
- *    `replayed: true` and does NOT re-run `work`. Otherwise runs
- *    `work`, persists `{ success: true, slug }`, returns
- *    `{ slug, replayed: false }`. Concurrent calls are resolved by the
- *    `(userId, uploadId)` unique constraint — the loser fetches the
- *    winner's slug and reports `replayed: true`.
+ * 2. withIdempotency(userId, uploadId, work) — claim-then-execute
+ *    wrapper. The state machine on HarnessUpload.success:
+ *
+ *      | Pre-existing row              | Action                            |
+ *      |-------------------------------|-----------------------------------|
+ *      | None (we win the insert race) | Run work, UPDATE success=true.    |
+ *      | success=true                  | Replay. Skip work.                |
+ *      | success=false                 | Run work, UPDATE success=true.    |
+ *
+ *    Tradeoff: a `success=false` row can be either a real prior
+ *    failure OR a concurrent first-time call still in flight. We
+ *    collapse the two cases — both re-run `work()`. The collision
+ *    window is tiny (the inner `work()` is ~hundreds of ms, then the
+ *    UPDATE flips success=true), and the practical worst case is two
+ *    drafts created when two first-time calls race. The common
+ *    "skill retried after a network blip" case is caught earlier by
+ *    `findIdempotentResult`, which the upload route calls before the
+ *    rate-limit check.
+ *
+ *    Critically, this wrapper does NOT use Prisma's `upsert` with
+ *    `update: {}` — that pattern silently leaves a stale `success=false`
+ *    row at `success=false` forever, even after a later attempt
+ *    actually succeeds, which broke retry-after-failure (P1.C). Instead
+ *    we INSERT-OR-UPSERT a `success=false` claim row first, run work,
+ *    then explicitly UPDATE the row to `success=true, slug=<result>`
+ *    on success. On work() failure the row stays `success=false` so
+ *    later retries can flip it.
  */
 import { prisma } from "@/lib/db";
 
@@ -50,38 +73,45 @@ export async function withIdempotency(
   uploadId: string,
   work: IdempotentWork,
 ): Promise<IdempotentRunResult> {
-  // Fast-path: a prior success already exists. Skip the work entirely.
-  const existing = await findIdempotentResult(userId, uploadId);
-  if (existing) {
-    return { slug: existing.slug, replayed: true };
+  // Step 1: claim. Try to insert a `success=false` placeholder. If the
+  // row already exists (concurrent first-time call OR prior attempt),
+  // `update: {}` leaves it untouched and the existing row's success
+  // flag tells us which branch to take.
+  //
+  // Note: We need to know whether the existing row already had
+  // success=true. The cheapest way is to read after the upsert.
+  await prisma.harnessUpload.upsert({
+    where: { userId_uploadId: { userId, uploadId } },
+    create: { userId, uploadId, slug: null, success: false },
+    update: {}, // existing row left as-is — we read it next
+  });
+
+  const claimed = await prisma.harnessUpload.findUnique({
+    where: { userId_uploadId: { userId, uploadId } },
+    select: { slug: true, success: true },
+  });
+  if (!claimed) {
+    // Vanishingly unlikely: row was deleted between upsert and read.
+    // Surface as an error rather than silently re-creating.
+    throw new Error(
+      `withIdempotency: claim row disappeared for ${userId}/${uploadId}`,
+    );
   }
 
-  // Race-resolution path: another concurrent caller may insert before
-  // us. We attempt the work; if its INSERT/finalize trips the unique
-  // (userId, uploadId) constraint via the loser path, we re-read the
-  // winner's slug and report replayed: true.
-  try {
-    const result = await work();
-    await prisma.harnessUpload.upsert({
-      where: { userId_uploadId: { userId, uploadId } },
-      create: { userId, uploadId, slug: result.slug, success: true },
-      update: {}, // never overwrite a winner's row
-    });
-    // After the upsert, another caller may have won the race and
-    // stored a different slug. Re-read to be sure we return the
-    // winning slug, not whichever this branch produced locally.
-    const finalRow = await prisma.harnessUpload.findUnique({
-      where: { userId_uploadId: { userId, uploadId } },
-      select: { slug: true },
-    });
-    const finalSlug = finalRow?.slug ?? result.slug;
-    const replayed = finalSlug !== result.slug;
-    return { slug: finalSlug, replayed };
-  } catch (error) {
-    // If the work itself failed, surface the error. Callers are
-    // responsible for recording an attempt-failure HarnessUpload row
-    // outside the wrapper (the unique constraint means we cannot
-    // store both a failure and a later success at the same key).
-    throw error;
+  // Step 2: replay path. Prior success → return the stored slug, do
+  // NOT re-run work().
+  if (claimed.success && claimed.slug) {
+    return { slug: claimed.slug, replayed: true };
   }
+
+  // Step 3: execute path. Either we won the insert race (claimed.success
+  // is false because we just inserted it) or the row was at success=false
+  // from a prior failure / concurrent in-flight call. Both cases run
+  // work() and flip the row to success=true on success.
+  const result = await work();
+  await prisma.harnessUpload.update({
+    where: { userId_uploadId: { userId, uploadId } },
+    data: { slug: result.slug, success: true },
+  });
+  return { slug: result.slug, replayed: false };
 }

--- a/src/lib/harness-idempotency.ts
+++ b/src/lib/harness-idempotency.ts
@@ -1,0 +1,87 @@
+/**
+ * Postgres-backed idempotency for the harness direct-POST flow.
+ *
+ * Two helpers (Decision 11):
+ *
+ * 1. findIdempotentResult(userId, uploadId) — pure lookup. Returns
+ *    `{ slug }` if a prior successful HarnessUpload exists for this
+ *    `(userId, uploadId)` pair, else null. Used by the upload route
+ *    to short-circuit replays BEFORE the rate-limit check, so that a
+ *    user who hits their 24h cap mid-retry still gets back the
+ *    original draft URL (R14a).
+ *
+ * 2. withIdempotency(userId, uploadId, work) — execution wrapper. If a
+ *    prior successful row exists, returns the stored slug with
+ *    `replayed: true` and does NOT re-run `work`. Otherwise runs
+ *    `work`, persists `{ success: true, slug }`, returns
+ *    `{ slug, replayed: false }`. Concurrent calls are resolved by the
+ *    `(userId, uploadId)` unique constraint — the loser fetches the
+ *    winner's slug and reports `replayed: true`.
+ */
+import { prisma } from "@/lib/db";
+
+export interface IdempotentLookupResult {
+  slug: string;
+}
+
+export interface IdempotentRunResult {
+  slug: string;
+  replayed: boolean;
+}
+
+export interface IdempotentWork {
+  (): Promise<{ slug: string }>;
+}
+
+export async function findIdempotentResult(
+  userId: string,
+  uploadId: string,
+): Promise<IdempotentLookupResult | null> {
+  const row = await prisma.harnessUpload.findUnique({
+    where: { userId_uploadId: { userId, uploadId } },
+    select: { slug: true, success: true },
+  });
+  if (!row || !row.success || !row.slug) return null;
+  return { slug: row.slug };
+}
+
+export async function withIdempotency(
+  userId: string,
+  uploadId: string,
+  work: IdempotentWork,
+): Promise<IdempotentRunResult> {
+  // Fast-path: a prior success already exists. Skip the work entirely.
+  const existing = await findIdempotentResult(userId, uploadId);
+  if (existing) {
+    return { slug: existing.slug, replayed: true };
+  }
+
+  // Race-resolution path: another concurrent caller may insert before
+  // us. We attempt the work; if its INSERT/finalize trips the unique
+  // (userId, uploadId) constraint via the loser path, we re-read the
+  // winner's slug and report replayed: true.
+  try {
+    const result = await work();
+    await prisma.harnessUpload.upsert({
+      where: { userId_uploadId: { userId, uploadId } },
+      create: { userId, uploadId, slug: result.slug, success: true },
+      update: {}, // never overwrite a winner's row
+    });
+    // After the upsert, another caller may have won the race and
+    // stored a different slug. Re-read to be sure we return the
+    // winning slug, not whichever this branch produced locally.
+    const finalRow = await prisma.harnessUpload.findUnique({
+      where: { userId_uploadId: { userId, uploadId } },
+      select: { slug: true },
+    });
+    const finalSlug = finalRow?.slug ?? result.slug;
+    const replayed = finalSlug !== result.slug;
+    return { slug: finalSlug, replayed };
+  } catch (error) {
+    // If the work itself failed, surface the error. Callers are
+    // responsible for recording an attempt-failure HarnessUpload row
+    // outside the wrapper (the unique constraint means we cannot
+    // store both a failure and a later success at the same key).
+    throw error;
+  }
+}

--- a/src/lib/harness-idempotency.ts
+++ b/src/lib/harness-idempotency.ts
@@ -1,6 +1,14 @@
 /**
  * Postgres-backed idempotency for the harness direct-POST flow.
  *
+ * NOTE: Under a concurrent first-time race for the same `(userId, uploadId)`,
+ * the loser's `work()` may have produced a real side effect (e.g., a draft
+ * InsightReport) that becomes orphaned. Both callers will return the winner's
+ * slug. Cleaning up the orphan requires coupling this helper to the caller's
+ * work product; deferred to a follow-up. The race window is small (one Prisma
+ * round trip) and the upload route's `findIdempotentResult` short-circuit
+ * covers the common retry-after-success case.
+ *
  * Two helpers (Decision 11):
  *
  * 1. findIdempotentResult(userId, uploadId) — pure lookup. Returns
@@ -107,11 +115,33 @@ export async function withIdempotency(
   // Step 3: execute path. Either we won the insert race (claimed.success
   // is false because we just inserted it) or the row was at success=false
   // from a prior failure / concurrent in-flight call. Both cases run
-  // work() and flip the row to success=true on success.
+  // work() and attempt to flip the row to success=true on success.
   const result = await work();
-  await prisma.harnessUpload.update({
-    where: { userId_uploadId: { userId, uploadId } },
+
+  // Conditional update: only flip success if it's still false. Prisma's
+  // updateMany returns { count }; count === 0 means another caller (the
+  // race winner) already flipped success=true with their own slug. In
+  // that case we discard our slug and return the winner's, preserving
+  // the idempotency contract that retries always resolve to the same
+  // slug as the first successful response.
+  const updateResult = await prisma.harnessUpload.updateMany({
+    where: { userId, uploadId, success: false },
     data: { slug: result.slug, success: true },
   });
+
+  if (updateResult.count === 0) {
+    // Race winner stored their result first. Re-read to surface their slug.
+    const winner = await prisma.harnessUpload.findUnique({
+      where: { userId_uploadId: { userId, uploadId } },
+    });
+    if (!winner || !winner.slug || !winner.success) {
+      // Should be unreachable: count===0 means a winning row exists.
+      throw new Error(
+        "Idempotency invariant violated: row missing after race",
+      );
+    }
+    return { slug: winner.slug, replayed: true };
+  }
+
   return { slug: result.slug, replayed: false };
 }

--- a/src/lib/harness-logging.ts
+++ b/src/lib/harness-logging.ts
@@ -1,0 +1,65 @@
+/**
+ * Structured single-line JSON logger for the harness direct-POST flow.
+ *
+ * Decision 13: every bearer-path response — 2xx, 4xx, or 5xx — emits
+ * one log record. Fields are intentionally fixed so on-call can grep
+ * by `uploadId`, `userId`, or `tokenSelectorPrefix` without spelunking.
+ *
+ * Safety contract:
+ *   - The full bearer token is NEVER logged.
+ *   - The selector is exposed only as its first 8 hex chars
+ *     (`tokenSelectorPrefix`); callers compute the prefix and pass it
+ *     in. The prefix is enough for support to correlate user-reported
+ *     issues with server logs but not enough for any reuse capability.
+ *   - The request body is never logged.
+ */
+
+export type RateLimitReason = "uploads_24h" | "attempts_24h" | "mints_24h";
+
+export interface HarnessLogFields {
+  /** UUID from the X-Upload-Id header. May be undefined for header-validation failures. */
+  uploadId?: string;
+  /** Resolved user id. Undefined when auth failed before lookup. */
+  userId?: string;
+  /**
+   * First 8 hex chars of the bearer-token selector. Derive via
+   * `tokenSelector.slice(0, 8)`. Undefined for session-authed paths
+   * (which shouldn't reach this logger) or auth-failure paths.
+   */
+  tokenSelectorPrefix?: string;
+  /** Raw Content-Length header value, if present. */
+  contentLength?: number;
+  /** True when the request was a replay short-circuit. */
+  replayed?: boolean;
+  /** Set on 429 responses. */
+  rateLimitReason?: RateLimitReason;
+  /** HTTP status returned to the caller. */
+  statusCode: number;
+  /** Wall-clock duration of the handler in milliseconds. */
+  durationMs: number;
+}
+
+export function logHarnessRequest(fields: HarnessLogFields): void {
+  // Build the record explicitly so undefined keys are dropped — keeps
+  // the JSON tight and avoids leaking shape from optional fields.
+  const record: Record<string, unknown> = {
+    event: "harness_direct_post",
+    statusCode: fields.statusCode,
+    durationMs: fields.durationMs,
+  };
+  if (fields.uploadId !== undefined) record.uploadId = fields.uploadId;
+  if (fields.userId !== undefined) record.userId = fields.userId;
+  if (fields.tokenSelectorPrefix !== undefined) {
+    record.tokenSelectorPrefix = fields.tokenSelectorPrefix;
+  }
+  if (fields.contentLength !== undefined) {
+    record.contentLength = fields.contentLength;
+  }
+  if (fields.replayed !== undefined) record.replayed = fields.replayed;
+  if (fields.rateLimitReason !== undefined) {
+    record.rateLimitReason = fields.rateLimitReason;
+  }
+
+   
+  console.log(JSON.stringify(record));
+}

--- a/src/lib/harness-rate-limit.ts
+++ b/src/lib/harness-rate-limit.ts
@@ -1,0 +1,117 @@
+/**
+ * Postgres-backed rate limiters for the harness direct-POST flow.
+ *
+ * Two windows are enforced:
+ *
+ * 1. checkUploadRateLimit — counts HarnessUpload rows in the last 24h
+ *    for `userId`. Successful uploads cap at 20/24h (R12); total
+ *    attempts (success or failure) cap at 60/24h. The attempt cap
+ *    catches a valid token spamming malformed requests.
+ *
+ * 2. checkMintRateLimit — counts HarnessToken rows minted in the last
+ *    24h for `userId`. Cap is 10/day (R13). Revoked tokens still count
+ *    against the cap because a revocation does not erase the mint.
+ *
+ * Both helpers return `{ ok: true }` on pass or
+ * `{ ok: false, retryAfter, reason }` on cap hit. `retryAfter` is the
+ * number of seconds until the oldest counted row falls out of the
+ * 24h rolling window — the soonest moment the user could retry and pass.
+ */
+import { prisma } from "@/lib/db";
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+export const UPLOAD_SUCCESS_CAP = 20;
+export const UPLOAD_ATTEMPT_CAP = 60;
+export const MINT_CAP = 10;
+
+export type UploadRateLimitReason = "uploads_24h" | "attempts_24h";
+export type MintRateLimitReason = "mints_24h";
+
+export type RateLimitResult<TReason extends string> =
+  | { ok: true }
+  | { ok: false; retryAfter: number; reason: TReason };
+
+/**
+ * Returns the seconds-until-retry from the oldest row's timestamp.
+ * Floor at 1 so callers never emit Retry-After: 0 (which clients
+ * treat as "no wait at all").
+ */
+function retryAfterFromOldest(
+  oldestCreatedAt: Date | null | undefined,
+): number {
+  if (!oldestCreatedAt) return 1;
+  const ageMs = Date.now() - oldestCreatedAt.getTime();
+  const remainingMs = TWENTY_FOUR_HOURS_MS - ageMs;
+  return Math.max(1, Math.ceil(remainingMs / 1000));
+}
+
+export async function checkUploadRateLimit(
+  userId: string,
+): Promise<RateLimitResult<UploadRateLimitReason>> {
+  const since = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
+
+  // Two counts: successful uploads and total attempts. We care about
+  // both caps independently; the user could be blocked by either.
+  const [successCount, attemptCount] = await Promise.all([
+    prisma.harnessUpload.count({
+      where: { userId, success: true, createdAt: { gt: since } },
+    }),
+    prisma.harnessUpload.count({
+      where: { userId, createdAt: { gt: since } },
+    }),
+  ]);
+
+  if (successCount >= UPLOAD_SUCCESS_CAP) {
+    const oldest = await prisma.harnessUpload.findFirst({
+      where: { userId, success: true, createdAt: { gt: since } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    });
+    return {
+      ok: false,
+      retryAfter: retryAfterFromOldest(oldest?.createdAt),
+      reason: "uploads_24h",
+    };
+  }
+
+  if (attemptCount >= UPLOAD_ATTEMPT_CAP) {
+    const oldest = await prisma.harnessUpload.findFirst({
+      where: { userId, createdAt: { gt: since } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    });
+    return {
+      ok: false,
+      retryAfter: retryAfterFromOldest(oldest?.createdAt),
+      reason: "attempts_24h",
+    };
+  }
+
+  return { ok: true };
+}
+
+export async function checkMintRateLimit(
+  userId: string,
+): Promise<RateLimitResult<MintRateLimitReason>> {
+  const since = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
+
+  const count = await prisma.harnessToken.count({
+    where: { userId, createdAt: { gt: since } },
+  });
+
+  if (count >= MINT_CAP) {
+    const oldest = await prisma.harnessToken.findFirst({
+      where: { userId, createdAt: { gt: since } },
+      orderBy: { createdAt: "asc" },
+      select: { createdAt: true },
+    });
+    return {
+      ok: false,
+      retryAfter: retryAfterFromOldest(oldest?.createdAt),
+      reason: "mints_24h",
+    };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -144,7 +144,14 @@ export async function mintTokenForUser(
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === "P2002"
+      error.code === "P2002" &&
+      // `meta.target` may be a string (older Prisma) or string[] (newer);
+      // String() flattens both shapes so we only translate the active-slot
+      // partial unique violation. Other P2002s (e.g. selector collisions on
+      // `HarnessToken_selector_key`) bubble up untouched.
+      String(error.meta?.target ?? "").includes(
+        "HarnessToken_userId_active_unique",
+      )
     ) {
       throw new MintConflictError(userId);
     }

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -83,6 +83,22 @@ export function parseToken(
 }
 
 /**
+ * Thrown when a concurrent mint won the partial-unique race for a
+ * user's active token slot. The HTTP layer should translate this to
+ * `409 Conflict` so the client can reload and surface the winning
+ * token. We deliberately do NOT retry: a retry would re-revoke the
+ * winner's freshly-created row and silently break their token.
+ */
+export class MintConflictError extends Error {
+  constructor(userId: string) {
+    super(
+      `Concurrent mint for user ${userId} won the partial-unique race; reload to see the active token.`,
+    );
+    this.name = "MintConflictError";
+  }
+}
+
+/**
  * Mint a new token for `userId`. Implicitly revokes any prior active
  * tokens (R3): a user has at most one active token at a time. Returns
  * the raw token exactly once — callers must surface it immediately
@@ -90,23 +106,26 @@ export function parseToken(
  *
  * Concurrency: the partial unique index
  * `HarnessToken_userId_active_unique ON (userId) WHERE revokedAt IS NULL`
- * is the source of truth for the at-most-one-active invariant. If two
- * mints race past the in-transaction `updateMany` (each seeing zero
- * rows to revoke because the prior winner has not yet committed) and
- * the second `create` trips P2002 on that index, we retry once: the
- * winner's row is now visible, the second attempt's `updateMany`
- * revokes it, and the second `create` succeeds. Cap at one retry — a
- * second P2002 implies a non-race bug we want to surface, not loop on.
+ * is the source of truth for the at-most-one-active invariant. The
+ * in-transaction `updateMany` handles the common (non-racing) case
+ * where a user is rotating their own token deliberately. If two mints
+ * race past their respective `updateMany`s (each seeing zero rows to
+ * revoke because the prior winner has not yet committed) the loser's
+ * `create` trips P2002 on the partial unique index. We translate that
+ * to `MintConflictError` and let the caller decide. We do NOT retry —
+ * a retry would re-run `updateMany` against the winner's row and
+ * silently revoke it, yielding two "successful" responses where the
+ * first user's token is already dead.
  */
 export async function mintTokenForUser(
   userId: string,
 ): Promise<{ raw: string; expiresAt: Date }> {
   const generated = generateToken();
   const hashedSecret = await hashSecret(generated.secret);
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
 
-  const attemptMint = async (): Promise<{ raw: string; expiresAt: Date }> => {
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
+  try {
     await prisma.$transaction(async (tx) => {
       await tx.harnessToken.updateMany({
         where: { userId, revokedAt: null },
@@ -122,18 +141,12 @@ export async function mintTokenForUser(
       });
     });
     return { raw: generated.raw, expiresAt };
-  };
-
-  try {
-    return await attemptMint();
   } catch (error) {
     if (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === "P2002"
     ) {
-      // Concurrent mint won the partial-unique race. Retry once: this
-      // attempt's updateMany will now see + revoke the winner's row.
-      return await attemptMint();
+      throw new MintConflictError(userId);
     }
     throw error;
   }

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -1,0 +1,155 @@
+/**
+ * Harness bearer token primitives.
+ *
+ * Token format (Decision 2 in the Wave 2 plan):
+ *   ih_<12 hex selector><64 hex secret>
+ *   - Total length: 79 chars
+ *   - No internal delimiter — selector is bytes [3, 15) and secret is bytes [15, 79).
+ *   - selector is stored indexed and plaintext for O(1) lookup.
+ *   - secret is bcrypt-hashed (cost factor 10).
+ *
+ * Expiry rolls forward (Decision 12):
+ *   On every successful verifyToken(), the server updates BOTH `lastUsedAt`
+ *   AND `expiresAt = NOW() + 90d`. Inactive tokens fall over the cliff once
+ *   `expiresAt < NOW()`. The verification check is therefore trivial.
+ */
+import * as crypto from "crypto";
+import * as bcrypt from "bcrypt";
+import { prisma } from "@/lib/db";
+
+export const TOKEN_PREFIX = "ih_";
+export const SELECTOR_HEX_LENGTH = 12; // 6 random bytes
+export const SECRET_HEX_LENGTH = 64; // 32 random bytes
+export const TOKEN_LENGTH =
+  TOKEN_PREFIX.length + SELECTOR_HEX_LENGTH + SECRET_HEX_LENGTH; // 79
+
+const TOKEN_REGEX = new RegExp(
+  `^${TOKEN_PREFIX}[0-9a-f]{${SELECTOR_HEX_LENGTH + SECRET_HEX_LENGTH}}$`,
+);
+
+const BCRYPT_COST = 10;
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+export interface GeneratedToken {
+  raw: string;
+  selector: string;
+  secret: string;
+}
+
+export interface VerifiedToken {
+  userId: string;
+  tokenId: string;
+  selector: string;
+}
+
+/**
+ * Generate a fresh random token. Returns the raw string plus the
+ * decomposed parts so callers can persist (selector, hash(secret))
+ * without recomputing.
+ */
+export function generateToken(): GeneratedToken {
+  const selector = crypto.randomBytes(SELECTOR_HEX_LENGTH / 2).toString("hex");
+  const secret = crypto.randomBytes(SECRET_HEX_LENGTH / 2).toString("hex");
+  return {
+    raw: `${TOKEN_PREFIX}${selector}${secret}`,
+    selector,
+    secret,
+  };
+}
+
+/** Bcrypt the secret half. Cost factor 10 per Decision 2. */
+export async function hashSecret(secret: string): Promise<string> {
+  return bcrypt.hash(secret, BCRYPT_COST);
+}
+
+/**
+ * Parse a raw token into selector + secret. Returns null for malformed
+ * input. Format-only check: does not touch the DB.
+ */
+export function parseToken(
+  raw: string,
+): { selector: string; secret: string } | null {
+  if (typeof raw !== "string") return null;
+  if (raw.length !== TOKEN_LENGTH) return null;
+  if (!TOKEN_REGEX.test(raw)) return null;
+  return {
+    selector: raw.slice(
+      TOKEN_PREFIX.length,
+      TOKEN_PREFIX.length + SELECTOR_HEX_LENGTH,
+    ),
+    secret: raw.slice(TOKEN_PREFIX.length + SELECTOR_HEX_LENGTH),
+  };
+}
+
+/**
+ * Mint a new token for `userId`. Implicitly revokes any prior active
+ * tokens (R3): a user has at most one active token at a time. Returns
+ * the raw token exactly once — callers must surface it immediately
+ * because the secret is never recoverable after this call.
+ */
+export async function mintTokenForUser(
+  userId: string,
+): Promise<{ raw: string; expiresAt: Date }> {
+  const generated = generateToken();
+  const hashedSecret = await hashSecret(generated.secret);
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.harnessToken.updateMany({
+      where: { userId, revokedAt: null },
+      data: { revokedAt: now },
+    });
+    await tx.harnessToken.create({
+      data: {
+        userId,
+        selector: generated.selector,
+        hashedSecret,
+        expiresAt,
+      },
+    });
+  });
+
+  return { raw: generated.raw, expiresAt };
+}
+
+/** Revoke every active token for `userId`. Idempotent. */
+export async function revokeActiveTokensForUser(userId: string): Promise<void> {
+  await prisma.harnessToken.updateMany({
+    where: { userId, revokedAt: null },
+    data: { revokedAt: new Date() },
+  });
+}
+
+/**
+ * Validate a raw bearer token. On success returns the resolved
+ * userId/tokenId/selector and rolls expiresAt + lastUsedAt forward
+ * (Decision 12). On any failure returns null without side effects.
+ */
+export async function verifyToken(raw: string): Promise<VerifiedToken | null> {
+  const parsed = parseToken(raw);
+  if (!parsed) return null;
+
+  const token = await prisma.harnessToken.findUnique({
+    where: { selector: parsed.selector },
+  });
+  if (!token) return null;
+  if (token.revokedAt) return null;
+  if (token.expiresAt.getTime() < Date.now()) return null;
+
+  const ok = await bcrypt.compare(parsed.secret, token.hashedSecret);
+  if (!ok) return null;
+
+  const now = new Date();
+  const newExpiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
+  await prisma.harnessToken.update({
+    where: { id: token.id },
+    data: { lastUsedAt: now, expiresAt: newExpiresAt },
+  });
+
+  return {
+    userId: token.userId,
+    tokenId: token.id,
+    selector: token.selector,
+  };
+}

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -15,6 +15,7 @@
  */
 import * as crypto from "crypto";
 import * as bcrypt from "bcrypt";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 
 export const TOKEN_PREFIX = "ih_";
@@ -86,31 +87,56 @@ export function parseToken(
  * tokens (R3): a user has at most one active token at a time. Returns
  * the raw token exactly once — callers must surface it immediately
  * because the secret is never recoverable after this call.
+ *
+ * Concurrency: the partial unique index
+ * `HarnessToken_userId_active_unique ON (userId) WHERE revokedAt IS NULL`
+ * is the source of truth for the at-most-one-active invariant. If two
+ * mints race past the in-transaction `updateMany` (each seeing zero
+ * rows to revoke because the prior winner has not yet committed) and
+ * the second `create` trips P2002 on that index, we retry once: the
+ * winner's row is now visible, the second attempt's `updateMany`
+ * revokes it, and the second `create` succeeds. Cap at one retry — a
+ * second P2002 implies a non-race bug we want to surface, not loop on.
  */
 export async function mintTokenForUser(
   userId: string,
 ): Promise<{ raw: string; expiresAt: Date }> {
   const generated = generateToken();
   const hashedSecret = await hashSecret(generated.secret);
-  const now = new Date();
-  const expiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
 
-  await prisma.$transaction(async (tx) => {
-    await tx.harnessToken.updateMany({
-      where: { userId, revokedAt: null },
-      data: { revokedAt: now },
+  const attemptMint = async (): Promise<{ raw: string; expiresAt: Date }> => {
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + NINETY_DAYS_MS);
+    await prisma.$transaction(async (tx) => {
+      await tx.harnessToken.updateMany({
+        where: { userId, revokedAt: null },
+        data: { revokedAt: now },
+      });
+      await tx.harnessToken.create({
+        data: {
+          userId,
+          selector: generated.selector,
+          hashedSecret,
+          expiresAt,
+        },
+      });
     });
-    await tx.harnessToken.create({
-      data: {
-        userId,
-        selector: generated.selector,
-        hashedSecret,
-        expiresAt,
-      },
-    });
-  });
+    return { raw: generated.raw, expiresAt };
+  };
 
-  return { raw: generated.raw, expiresAt };
+  try {
+    return await attemptMint();
+  } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === "P2002"
+    ) {
+      // Concurrent mint won the partial-unique race. Retry once: this
+      // attempt's updateMany will now see + revoke the winner's row.
+      return await attemptMint();
+    }
+    throw error;
+  }
 }
 
 /** Revoke every active token for `userId`. Idempotent. */


### PR DESCRIPTION
## Summary

Wave 2 of the tokenized direct-POST plan (`docs/plans/2026-04-22-001-feat-tokenized-direct-post-plan.md`), Units 2 and 5. Two atomic commits on this branch:

- **Unit 5 (commit 1) — `feat(harness): add bearer auth, rate limit, idempotency, and logging helpers`**
  Adds `src/lib/harness-{auth,tokens,rate-limit,idempotency,logging}.ts` plus colocated tests. Pure new files — no other surface area touched. Implements Decisions 2 (`ih_<12 hex selector><64 hex secret>`, no internal delimiter), 11 (separate `findIdempotentResult` + `withIdempotency` so replays short-circuit before rate-limit), 12 (token expiry rolls forward to `NOW() + 90d` on every successful verify), and 13 (single-line JSON log shape).
  Adds `bcrypt` + `@types/bcrypt` to `package.json`. Cost factor 10. **Flagging this as a deviation:** the plan said "Add bcrypt to package.json if not already there. Check package.json first" — bcrypt was not there, so I added it. No other deps changed.
  Requirements covered: R1, R2, R3, R6, R12, R13, R14a, R26.

- **Unit 2 (commit 2) — `feat(visibility): filter drafts from all read paths`**
  Adds `src/lib/draft-filter.ts` exporting `draftVisibilityClause(viewerId)`. Composes the clause into all 13 direct-read sites and the one nested-relation site (`/api/users/[username]/route.ts`) via Prisma's filtered-relation `where`. Owner-scoped read at `/api/users/me/setup-suggestions/route.ts` annotated with `// owner-scoped: ...` and left unmodified.
  Requirements covered: R9, R9a, R11.

## Audit method (per the plan's widened verification)

Both greps from the plan ran clean:

- `grep -rn "prisma\.insightReport\.\(find\|count\|aggregate\)" src/` → 20 hits across 14 files. All compose `draftVisibilityClause` except `setup-suggestions` (annotated owner-scoped).
- `grep -rn -B2 -A8 "reports:" src/app/api/` → one nested-relation read in `/api/users/[username]/route.ts`, now using `where: draftVisibilityClause(viewerId)` inside the `select`.

Public/crawler surfaces (OG image, `/insights/[username]/[slug]/layout.tsx` metadata, `/api/leaderboard`, `/api/top`) intentionally pass `viewerId: null` so an owner's own drafts never leak via cached previews or rankings.

## Test plan

- [x] `npx vitest run` → 619 PASS / 0 FAIL (added 5 draft-filter tests, 41 harness-helper tests, all existing tests green)
- [x] `npx tsc --noEmit` → No errors
- [x] Two-grep audit returns no unaccounted-for reads
- [ ] Manual smoke: `curl /api/insights` with no session — drafts excluded
- [ ] Manual smoke: `curl /api/users/<other>` — viewer cannot see other user's drafts
- [ ] Manual smoke: viewing own profile while signed in — drafts visible

## Notes

- `src/app/api/top/route.ts` keeps `buildWhereClause` pure — the draft filter is composed at the call site, so the existing `top-filter.test.ts` did not need changes.
- All existing route tests still pass; only one new test file (`draft-filter.test.ts`) was added for Unit 2.