### PR TITLE
feat: Wave 3a — edit-page draft 404 + upload status polling

### DIFF
--- a/src/app/api/upload/status/__tests__/route.test.ts
+++ b/src/app/api/upload/status/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for GET /api/upload/status — the browser polling endpoint that
+ * the upload page hits every 3s while waiting for a tokenized direct
+ * POST from the user's harness skill.
+ *
+ * Scope:
+ *   - Auth: session-only (no bearer fallback). Unauthed → 401.
+ *   - Param validation: `since` is required and must parse as a Date.
+ *   - Query: `findFirst` over the caller's drafts created after `since`,
+ *     newest first. Returns `{ editUrl, slug, createdAt }` or
+ *     `{ editUrl: null }`.
+ *   - Cache: every response carries `Cache-Control: no-store` so an
+ *     upstream CDN doesn't memoize a "not ready" response and starve
+ *     the polling loop.
+ *   - Scoping: a different user's newer draft must not leak across.
+ *     The `where: { authorId }` filter enforces this; the test asserts
+ *     the Prisma call shape so a future refactor can't drop it.
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    insightReport: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { GET as statusGET } from "../route";
+
+const mockAuth = auth as unknown as Mock;
+const mockPrisma = prisma as unknown as {
+  insightReport: { findFirst: Mock };
+};
+
+function mockSession(userId: string | null) {
+  if (userId === null) {
+    mockAuth.mockResolvedValue(null);
+  } else {
+    mockAuth.mockResolvedValue({ user: { id: userId } });
+  }
+}
+
+function statusRequest(since: string | null): Request {
+  const url = new URL("http://localhost/api/upload/status");
+  if (since !== null) {
+    url.searchParams.set("since", since);
+  }
+  return new Request(url, { method: "GET" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /api/upload/status — auth", () => {
+  it("returns 401 when unauthed", async () => {
+    mockSession(null);
+    const response = await statusGET(statusRequest("2026-04-21T00:00:00.000Z"));
+    expect(response.status).toBe(401);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockPrisma.insightReport.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/upload/status — param validation", () => {
+  it("returns 400 when `since` is missing", async () => {
+    mockSession("user-1");
+    const response = await statusGET(statusRequest(null));
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockPrisma.insightReport.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when `since` is unparseable", async () => {
+    mockSession("user-1");
+    const response = await statusGET(statusRequest("not-a-date"));
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(mockPrisma.insightReport.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/upload/status — query", () => {
+  it("returns editUrl + slug + createdAt when a fresh draft exists", async () => {
+    mockSession("user-1");
+    const created = new Date("2026-04-21T01:00:00.000Z");
+    mockPrisma.insightReport.findFirst.mockResolvedValue({
+      slug: "20260421-abc123",
+      createdAt: created,
+      author: { username: "craig" },
+    });
+
+    const response = await statusGET(statusRequest("2026-04-21T00:00:00.000Z"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    const body = await response.json();
+    expect(body).toEqual({
+      editUrl: "/insights/craig/20260421-abc123/edit",
+      slug: "20260421-abc123",
+      createdAt: created.toISOString(),
+    });
+
+    // Lock down the Prisma call shape — authorId scope, isDraft filter,
+    // and the createdAt > since cutoff. A future refactor that drops
+    // any of these would silently leak other users' drafts.
+    expect(mockPrisma.insightReport.findFirst).toHaveBeenCalledTimes(1);
+    const call = mockPrisma.insightReport.findFirst.mock.calls[0][0];
+    expect(call.where.authorId).toBe("user-1");
+    expect(call.where.isDraft).toBe(true);
+    expect(call.where.createdAt).toEqual({
+      gt: new Date("2026-04-21T00:00:00.000Z"),
+    });
+    expect(call.orderBy).toEqual({ createdAt: "desc" });
+  });
+
+  it("returns { editUrl: null } when only older drafts exist", async () => {
+    mockSession("user-1");
+    // The handler relies on Prisma's `createdAt: { gt: sinceDate }`
+    // filter to exclude older drafts. We assert the contract by having
+    // the mock return null (mimicking "no rows match the filter").
+    mockPrisma.insightReport.findFirst.mockResolvedValue(null);
+
+    const response = await statusGET(statusRequest("2026-04-21T00:00:00.000Z"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(await response.json()).toEqual({ editUrl: null });
+  });
+
+  it("returns { editUrl: null } when the user has no drafts at all", async () => {
+    mockSession("user-1");
+    mockPrisma.insightReport.findFirst.mockResolvedValue(null);
+
+    const response = await statusGET(statusRequest("2026-04-21T00:00:00.000Z"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ editUrl: null });
+  });
+
+  it("scopes to the caller — a different user's fresh draft does not leak", async () => {
+    mockSession("user-1");
+    // Simulate Prisma honoring the `authorId: 'user-1'` filter by
+    // returning null even though user-2 has a fresh draft.
+    mockPrisma.insightReport.findFirst.mockResolvedValue(null);
+
+    const response = await statusGET(statusRequest("2026-04-21T00:00:00.000Z"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ editUrl: null });
+
+    // Belt-and-braces: assert authorId is wired from the session, not
+    // pulled from a query param or header.
+    const call = mockPrisma.insightReport.findFirst.mock.calls[0][0];
+    expect(call.where.authorId).toBe("user-1");
+  });
+});

--- a/src/app/api/upload/status/route.ts
+++ b/src/app/api/upload/status/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { auth } from "@/lib/auth";
+import { buildReportEditUrl } from "@/lib/urls";
+
+/**
+ * GET /api/upload/status?since=<ISO timestamp>
+ *
+ * Browser-side polling endpoint for the upload page (R24). Returns the
+ * caller's most recent draft created after `since`, or null if none.
+ *
+ * Auth: session-only. The harness skill posts via bearer auth on
+ * `/api/upload/direct`; this endpoint is what the user's browser polls
+ * while waiting for that post to land. There is no reason to allow
+ * bearer auth here — bearer-auth callers don't have a browser tab open
+ * waiting for a redirect.
+ *
+ * Rate limit: none. The query is a single indexed `findFirst` on
+ * `authorId + createdAt` (covered by `User_reports` FK index +
+ * row-level filter). Per codex review on the parent plan, an in-memory
+ * debounce was rejected because Vercel's serverless instances don't
+ * share state — debounce would either no-op (each instance debounces
+ * independently) or behave inconsistently (depending on which instance
+ * a request lands on). Accept the 3s client cadence as-is. If a
+ * durable limiter becomes necessary, back it with Postgres at that
+ * point.
+ *
+ * Cache: `Cache-Control: no-store` so an upstream CDN doesn't memoize
+ * a "not ready yet" response and starve the polling loop.
+ */
+export async function GET(request: Request) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const sinceParam = searchParams.get("since");
+    if (!sinceParam) {
+      return NextResponse.json(
+        { error: "Missing required query param: since" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    const sinceDate = new Date(sinceParam);
+    if (Number.isNaN(sinceDate.getTime())) {
+      return NextResponse.json(
+        { error: "Invalid `since` timestamp" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    const draft = await prisma.insightReport.findFirst({
+      where: {
+        authorId: session.user.id,
+        isDraft: true,
+        createdAt: { gt: sinceDate },
+      },
+      orderBy: { createdAt: "desc" },
+      select: {
+        slug: true,
+        createdAt: true,
+        author: { select: { username: true } },
+      },
+    });
+
+    if (!draft) {
+      return NextResponse.json(
+        { editUrl: null },
+        { headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        editUrl: buildReportEditUrl(draft.author.username, draft.slug),
+        slug: draft.slug,
+        createdAt: draft.createdAt.toISOString(),
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (error) {
+    console.error("GET /api/upload/status failed", error);
+    return NextResponse.json(
+      { error: "Failed to check upload status" },
+      { status: 500, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { notFound, useParams, useRouter } from "next/navigation";
 import {
   buildReportApiUrl,
   buildReportSubResourceApiUrl,
@@ -58,6 +58,7 @@ interface ReportData {
   slug: string;
   title: string;
   authorId: string;
+  isDraft: boolean;
   reportType: string;
   sessionCount: number | null;
   messageCount: number | null;
@@ -144,6 +145,13 @@ export default function EditReportPage() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // R9b: when the report is missing (404) or it's a draft the viewer
+  // doesn't own, surface Next's notFound() instead of the read-only
+  // "you can only edit your own reports" message. The 404 path covers
+  // anonymous viewers and non-owners of drafts (the API filters those
+  // out via draftVisibilityClause). The render-time guard below covers
+  // the defense-in-depth case where a draft slips through.
+  const [reportNotFound, setReportNotFound] = useState(false);
   const [hiddenSections, setHiddenSections] = useState<Record<string, boolean>>(
     {},
   );
@@ -158,8 +166,19 @@ export default function EditReportPage() {
     // the owner can toggle them back on. The server enforces
     // ownership before honoring the flag.
     fetch(`${buildReportApiUrl(username, slug)}?includeHidden=true`)
-      .then((r) => r.json())
-      .then((data) => {
+      .then(async (response) => {
+        // 404 covers: report doesn't exist; the viewer is anonymous /
+        // non-owner and the report is a draft (API hides drafts from
+        // non-owners via draftVisibilityClause). Render-side this
+        // becomes a Next.js notFound() instead of the read-only
+        // message. Any other error code falls through to the error
+        // state. (R9b)
+        if (response.status === 404) {
+          setReportNotFound(true);
+          setLoading(false);
+          return;
+        }
+        const data = await response.json();
         if (data.error) {
           setError(data.error);
         } else {
@@ -389,6 +408,16 @@ export default function EditReportPage() {
     );
   }
 
+  // R9b: when the API responded 404, surface Next's notFound() rather
+  // than rendering an inline error. This happens for: (a) the report
+  // genuinely doesn't exist, (b) a non-owner / anonymous viewer hitting
+  // a draft's edit URL — drafts are filtered from non-owner reads by
+  // `draftVisibilityClause`, so the API returns 404 from this page's
+  // perspective.
+  if (reportNotFound) {
+    notFound();
+  }
+
   if (error && !report) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-8 text-center">
@@ -417,8 +446,18 @@ export default function EditReportPage() {
     );
   }
 
-  // Check ownership
+  // Check ownership. Drafts are not addressable by non-owners (R9b):
+  // the API already filters them out via draftVisibilityClause, so
+  // hitting this branch with `report.isDraft` would only happen if the
+  // API filter regressed. Fail closed with notFound() rather than
+  // exposing the read-only message that would tip off a guesser to the
+  // existence of someone else's draft. Public reports keep their
+  // existing read-only behavior so non-owners with the URL still see a
+  // helpful message.
   if (session?.user?.id !== report.author.id) {
+    if (report.isDraft) {
+      notFound();
+    }
     return (
       <div className="mx-auto max-w-4xl px-4 py-8 text-center">
         <p className="text-slate-600 dark:text-slate-400">

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -140,7 +140,7 @@ function HideableCard({
 export default function EditReportPage() {
   const { username, slug } = useParams<{ username: string; slug: string }>();
   const router = useRouter();
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const [report, setReport] = useState<ReportData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -400,7 +400,12 @@ export default function EditReportPage() {
     setPendingSave(null);
   };
 
-  if (loading) {
+  // Hold the spinner until BOTH the report fetch and the next-auth
+  // session have resolved. Without the sessionStatus guard the
+  // ownership branch below can fire `notFound()` for the legitimate
+  // owner of a draft if the API fetch resolves before next-auth's
+  // initial session call (codex P1 on the prior commit).
+  if (loading || sessionStatus === "loading") {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />


### PR DESCRIPTION
Implements Units 3 and 8 of the tokenized direct-post plan
(`docs/plans/2026-04-22-001-feat-tokenized-direct-post-plan.md`).
Both units are independent and shipped as separate commits on this
branch.

## Unit 3 — Edit page 404 for non-owner / anonymous drafts (R9b)

`src/app/insights/[username]/[slug]/edit/page.tsx` used to render a
generic "you can only edit your own reports" message for any
non-owner. For drafts that text leaks the existence of someone
else's unpublished work — a guesser hitting a draft URL learns it's
real.

Two-layer fix:

- Detect the API's 404 response (drafts are filtered out of
  non-owner reads via `draftVisibilityClause`, so non-owners and
  anonymous viewers get 404 from `/api/insights/[username]/[slug]`).
  Set a flag and call `notFound()` during render.
- Defense-in-depth: in the existing ownership branch, if
  `report.isDraft` and the viewer isn't the author, also
  `notFound()`. Guards against a future API regression that drops
  the draft filter.

Public reports preserve the existing read-only message — they're
already addressable, so hiding them via 404 would just confuse
legitimate viewers who followed an `/edit` link.

Codex P1 follow-up commit `300e1e9`: hold the spinner until both
the report fetch and `useSession()` resolve, so the legitimate
owner doesn't get 404'd while next-auth is still loading.

No new test file: per the plan, the existing draft-filter test
suite already exercises the visibility helper, and the page-level
guard is a four-line render-time check.

## Unit 8 — `GET /api/upload/status` polling endpoint (R24)

The upload page (Unit 9, future) polls this every 3s while waiting
for the user's harness skill to POST a draft via bearer auth.

- Session-only auth (no bearer fallback): bearer callers don't
  have a browser tab waiting for a redirect.
- Query: `prisma.insightReport.findFirst` scoped to `authorId`,
  `isDraft: true`, `createdAt > since`. Returns
  `{ editUrl, slug, createdAt }` or `{ editUrl: null }`.
- `Cache-Control: no-store` on every response so a CDN doesn't
  memoize a "not ready yet" and starve the polling loop.
- No in-memory debounce (per codex review on the parent plan):
  serverless instances don't share state.

Tests cover all six scenarios: happy path, only-older-drafts,
no-drafts-at-all, missing `since`, invalid `since`, unauthed, and
the authorId-scoping defense.

## Codex review

- Commit `f82d2dc` (Unit 8): 2 P2 findings, both rejected.
  - "Correlate status checks to the upload being polled" —
    documented design choice (Decision 6 in the plan):
    `?since=<page load timestamp>` plus newest-first matches the
    plan's explicit query spec. Per-upload correlation belongs to
    Unit 7's `HarnessUpload` model, out of scope for Wave 3a.
  - "Avoid using a client clock as the success cutoff" — also a
    documented design choice: the plan specifies
    `?since=<ISO timestamp>` from the browser. Any clock-skew
    buffer belongs in Unit 9's upload page, out of scope here.
- Commit `53b54c1` (Unit 3): 1 P1 finding, fixed in `300e1e9`.
- Commit `300e1e9` (P1 fix): clean.

## Test plan

- [x] `npx vitest run` — 630 passed, 0 failed.
- [x] `npx tsc --noEmit` — no errors.
- [ ] Manual: anonymous user visits `/insights/<owner>/<draft-slug>/edit` → Next 404 page renders.
- [ ] Manual: signed-in non-owner visits same URL → Next 404 page renders.
- [ ] Manual: draft owner visits same URL → edit page renders normally.
- [ ] Manual: non-owner visits a public report's edit URL → existing read-only message renders.
- [ ] Manual: `curl -s -b "<session-cookie>" "http://localhost:3000/api/upload/status?since=<iso>"` returns the expected shape.