### PR TITLE
feat: Wave 3b — token mint/revoke + bearer-auth direct-POST upload

### DIFF
--- a/src/app/api/harness-tokens/__tests__/route.test.ts
+++ b/src/app/api/harness-tokens/__tests__/route.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for POST/DELETE /api/harness-tokens (Unit 6 of Wave 3b plan).
+ *
+ * The route delegates to two helpers we've already covered in their own
+ * unit tests (`mintTokenForUser`, `revokeActiveTokensForUser`,
+ * `checkMintRateLimit`). These tests focus on HTTP-layer concerns:
+ *   - session-required auth, both endpoints
+ *   - 429 wiring (Retry-After + reason)
+ *   - 409 wiring on MintConflictError
+ *   - 204 contract on DELETE (always idempotent)
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+// ── Mocks (declared before route import) ────────────────────────────
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/harness-rate-limit", () => ({
+  checkMintRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/harness-tokens", () => ({
+  // MintConflictError is a class; the route imports it for `instanceof`
+  // checks. We re-export a class that mirrors the real one so the
+  // instanceof branch fires when the mocked mintTokenForUser rejects
+  // with `new MintConflictError(...)`.
+  MintConflictError: class MintConflictError extends Error {
+    constructor(userId: string) {
+      super(`Concurrent mint for user ${userId}`);
+      this.name = "MintConflictError";
+    }
+  },
+  mintTokenForUser: vi.fn(),
+  revokeActiveTokensForUser: vi.fn(),
+}));
+
+// ── Imports after mocks ─────────────────────────────────────────────
+
+import { auth } from "@/lib/auth";
+import { checkMintRateLimit } from "@/lib/harness-rate-limit";
+import {
+  MintConflictError,
+  mintTokenForUser,
+  revokeActiveTokensForUser,
+} from "@/lib/harness-tokens";
+import {
+  DELETE as harnessTokensDELETE,
+  POST as harnessTokensPOST,
+} from "../route";
+
+const mockAuth = auth as unknown as Mock;
+const mockMintLimit = checkMintRateLimit as unknown as Mock;
+const mockMint = mintTokenForUser as unknown as Mock;
+const mockRevoke = revokeActiveTokensForUser as unknown as Mock;
+
+function setSession(userId: string | null) {
+  if (userId === null) {
+    mockAuth.mockResolvedValue(null);
+  } else {
+    mockAuth.mockResolvedValue({ user: { id: userId } });
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── POST tests ──────────────────────────────────────────────────────
+
+describe("POST /api/harness-tokens", () => {
+  it("returns 401 when there is no session", async () => {
+    setSession(null);
+    const response = await harnessTokensPOST();
+    expect(response.status).toBe(401);
+    expect(mockMintLimit).not.toHaveBeenCalled();
+    expect(mockMint).not.toHaveBeenCalled();
+  });
+
+  it("mints a token for the session user and returns { token, expiresAt }", async () => {
+    setSession("user-1");
+    mockMintLimit.mockResolvedValue({ ok: true });
+    const expiresAt = new Date("2027-04-21T00:00:00.000Z");
+    mockMint.mockResolvedValue({
+      raw: `ih_${"a".repeat(76)}`,
+      expiresAt,
+    });
+
+    const response = await harnessTokensPOST();
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body).toEqual({
+      token: `ih_${"a".repeat(76)}`,
+      expiresAt: expiresAt.toISOString(),
+    });
+    expect(mockMint).toHaveBeenCalledWith("user-1");
+  });
+
+  it("returns 429 with Retry-After + mints_24h reason when the rate limiter blocks", async () => {
+    setSession("user-1");
+    mockMintLimit.mockResolvedValue({
+      ok: false,
+      reason: "mints_24h",
+      retryAfter: 12345,
+    });
+
+    const response = await harnessTokensPOST();
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("12345");
+    const body = await response.json();
+    expect(body.reason).toBe("mints_24h");
+    expect(body.retryAfter).toBe(12345);
+    expect(mockMint).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 with mint_conflict body on MintConflictError", async () => {
+    setSession("user-1");
+    mockMintLimit.mockResolvedValue({ ok: true });
+    mockMint.mockRejectedValue(new MintConflictError("user-1"));
+
+    const response = await harnessTokensPOST();
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.error).toBe("mint_conflict");
+    expect(typeof body.message).toBe("string");
+    expect(body.message.length).toBeGreaterThan(0);
+  });
+
+  it("returns 500 on unexpected mint errors", async () => {
+    setSession("user-1");
+    mockMintLimit.mockResolvedValue({ ok: true });
+    mockMint.mockRejectedValue(new Error("boom"));
+
+    // Suppress the route's console.error for the duration of this test.
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await harnessTokensPOST();
+    consoleSpy.mockRestore();
+
+    expect(response.status).toBe(500);
+  });
+});
+
+// ── DELETE tests ────────────────────────────────────────────────────
+
+describe("DELETE /api/harness-tokens", () => {
+  it("returns 401 when there is no session", async () => {
+    setSession(null);
+    const response = await harnessTokensDELETE();
+    expect(response.status).toBe(401);
+    expect(mockRevoke).not.toHaveBeenCalled();
+  });
+
+  it("revokes the user's active tokens and returns 204", async () => {
+    setSession("user-1");
+    mockRevoke.mockResolvedValue(undefined);
+
+    const response = await harnessTokensDELETE();
+    expect(response.status).toBe(204);
+    // 204 has no body — verify
+    expect(await response.text()).toBe("");
+    expect(mockRevoke).toHaveBeenCalledWith("user-1");
+  });
+
+  it("is idempotent — returns 204 even when no active token exists", async () => {
+    setSession("user-1");
+    // revokeActiveTokensForUser is implemented via updateMany → resolves
+    // even when nothing matched. Mirror that here.
+    mockRevoke.mockResolvedValue(undefined);
+
+    const response = await harnessTokensDELETE();
+    expect(response.status).toBe(204);
+  });
+});

--- a/src/app/api/harness-tokens/__tests__/route.test.ts
+++ b/src/app/api/harness-tokens/__tests__/route.test.ts
@@ -22,14 +22,22 @@ vi.mock("@/lib/harness-rate-limit", () => ({
 }));
 
 vi.mock("@/lib/harness-tokens", () => ({
-  // MintConflictError is a class; the route imports it for `instanceof`
-  // checks. We re-export a class that mirrors the real one so the
-  // instanceof branch fires when the mocked mintTokenForUser rejects
-  // with `new MintConflictError(...)`.
+  // MintConflictError + MintRateLimitError are classes; the route imports
+  // them for `instanceof` checks. Re-export shape-compatible doubles so
+  // the instanceof branches fire when the mocked mintTokenForUser
+  // rejects with `new MintConflictError(...)` / `new MintRateLimitError(...)`.
   MintConflictError: class MintConflictError extends Error {
     constructor(userId: string) {
       super(`Concurrent mint for user ${userId}`);
       this.name = "MintConflictError";
+    }
+  },
+  MintRateLimitError: class MintRateLimitError extends Error {
+    readonly oldestCreatedAt: Date;
+    constructor(userId: string, oldestCreatedAt: Date) {
+      super(`Mint cap reached for user ${userId}`);
+      this.name = "MintRateLimitError";
+      this.oldestCreatedAt = oldestCreatedAt;
     }
   },
   mintTokenForUser: vi.fn(),
@@ -42,6 +50,7 @@ import { auth } from "@/lib/auth";
 import { checkMintRateLimit } from "@/lib/harness-rate-limit";
 import {
   MintConflictError,
+  MintRateLimitError,
   mintTokenForUser,
   revokeActiveTokensForUser,
 } from "@/lib/harness-tokens";
@@ -125,6 +134,42 @@ describe("POST /api/harness-tokens", () => {
     expect(body.error).toBe("mint_conflict");
     expect(typeof body.message).toBe("string");
     expect(body.message.length).toBeGreaterThan(0);
+  });
+
+  it("returns 429 with mints_24h reason when the in-tx rate-limit fires", async () => {
+    // Race scenario: soft check passes, but by the time the transaction
+    // ran, a concurrent burst pushed the count to cap. The helper throws
+    // MintRateLimitError; the route translates to 429 with Retry-After
+    // computed from the oldest counted row.
+    setSession("user-1");
+    mockMintLimit.mockResolvedValue({ ok: true });
+    const oldest = new Date(Date.now() - 60 * 60 * 1000); // 1h ago
+    mockMint.mockRejectedValue(new MintRateLimitError("user-1", oldest));
+
+    const response = await harnessTokensPOST();
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.reason).toBe("mints_24h");
+    expect(body.retryAfter).toBeGreaterThan(0);
+    // Oldest row is 1h ago in a 24h window → ~23h remaining.
+    expect(body.retryAfter).toBeLessThanOrEqual(24 * 60 * 60);
+    expect(body.retryAfter).toBeGreaterThan(22 * 60 * 60);
+    expect(response.headers.get("Retry-After")).toBe(String(body.retryAfter));
+  });
+
+  it("returns 500 (with JSON body) when auth() throws unexpectedly", async () => {
+    // If `auth()` blows up (NextAuth crash, DB error in jwt callback),
+    // the route must still emit a structured 500 — falling through to
+    // Next's generic error page would break fetch clients on the
+    // upload page.
+    mockAuth.mockRejectedValue(new Error("auth crash"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const response = await harnessTokensPOST();
+    consoleSpy.mockRestore();
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(typeof body.error).toBe("string");
   });
 
   it("returns 500 on unexpected mint errors", async () => {

--- a/src/app/api/harness-tokens/route.ts
+++ b/src/app/api/harness-tokens/route.ts
@@ -14,41 +14,67 @@
  * here — this endpoint mints credentials, not consumes them, and accepting
  * a bearer would let a leaked token rotate itself.
  *
- * Rate limit: POST hits checkMintRateLimit (10/24h per user, R13). DELETE
- * is unrate-limited; revocation is fast and incentive-aligned with safety.
+ * Rate limit: POST is gated by both a soft pre-check (`checkMintRateLimit`,
+ * gives the most accurate Retry-After) AND a hard per-transaction count
+ * inside `mintTokenForUser` (`MintRateLimitError`, prevents concurrent
+ * bursts from blowing past the cap). DELETE is unrate-limited.
  */
 import { NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { checkMintRateLimit } from "@/lib/harness-rate-limit";
 import {
   MintConflictError,
+  MintRateLimitError,
   mintTokenForUser,
   revokeActiveTokensForUser,
 } from "@/lib/harness-tokens";
 
+const TWENTY_FOUR_HOURS_S = 24 * 60 * 60;
+
+/**
+ * Translate a MintRateLimitError's `oldestCreatedAt` to a Retry-After
+ * second count. Floor at 1 — emitting `Retry-After: 0` tells clients
+ * they may retry immediately, which is exactly the loop we want to
+ * avoid.
+ */
+function retryAfterFromOldest(oldestCreatedAt: Date): number {
+  const ageMs = Date.now() - oldestCreatedAt.getTime();
+  const remainingMs = TWENTY_FOUR_HOURS_S * 1000 - ageMs;
+  return Math.max(1, Math.ceil(remainingMs / 1000));
+}
+
 export async function POST() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  const userId = session.user.id;
-
-  const limit = await checkMintRateLimit(userId);
-  if (!limit.ok) {
-    return NextResponse.json(
-      {
-        error: "rate_limited",
-        reason: limit.reason,
-        retryAfter: limit.retryAfter,
-      },
-      {
-        status: 429,
-        headers: { "Retry-After": String(limit.retryAfter) },
-      },
-    );
-  }
-
+  // Wrap the whole handler so any failure in `auth()` or the soft
+  // rate-limit query still emits a structured 500. Without this, an
+  // upstream NextAuth or DB error would fall through to Next.js's
+  // generic error page, breaking the JSON API contract for the upload
+  // page that calls this from a fetch().
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
+
+    // Soft check first: gives an accurate Retry-After in the common
+    // (non-racing) case. The hard check sits inside the transaction in
+    // `mintTokenForUser` so two concurrent POSTs can't each pass the
+    // soft check and serialize through to mint, exceeding the cap.
+    const limit = await checkMintRateLimit(userId);
+    if (!limit.ok) {
+      return NextResponse.json(
+        {
+          error: "rate_limited",
+          reason: limit.reason,
+          retryAfter: limit.retryAfter,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(limit.retryAfter) },
+        },
+      );
+    }
+
     const { raw, expiresAt } = await mintTokenForUser(userId);
     return NextResponse.json(
       { token: raw, expiresAt: expiresAt.toISOString() },
@@ -65,6 +91,20 @@ export async function POST() {
         { status: 409 },
       );
     }
+    if (error instanceof MintRateLimitError) {
+      const retryAfter = retryAfterFromOldest(error.oldestCreatedAt);
+      return NextResponse.json(
+        {
+          error: "rate_limited",
+          reason: "mints_24h",
+          retryAfter,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(retryAfter) },
+        },
+      );
+    }
     console.error("POST /api/harness-tokens error:", error);
     return NextResponse.json(
       { error: "Failed to mint token" },
@@ -74,12 +114,11 @@ export async function POST() {
 }
 
 export async function DELETE() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
     await revokeActiveTokensForUser(session.user.id);
     return new NextResponse(null, { status: 204 });
   } catch (error) {

--- a/src/app/api/harness-tokens/route.ts
+++ b/src/app/api/harness-tokens/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Harness token mint + revoke endpoints (Unit 6 of Wave 3b plan).
+ *
+ * POST   /api/harness-tokens — mint a fresh token for the session user.
+ *                              Implicitly revokes any prior active token
+ *                              (one-active-token invariant per Decision 2).
+ *                              Body: none. Returns: `{ token, expiresAt }`.
+ *
+ * DELETE /api/harness-tokens — revoke every active token for the session
+ *                              user. Idempotent — 204 even if there's
+ *                              nothing to revoke. Returns: 204 No Content.
+ *
+ * Auth: NextAuth session only. We deliberately do NOT accept bearer auth
+ * here — this endpoint mints credentials, not consumes them, and accepting
+ * a bearer would let a leaked token rotate itself.
+ *
+ * Rate limit: POST hits checkMintRateLimit (10/24h per user, R13). DELETE
+ * is unrate-limited; revocation is fast and incentive-aligned with safety.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { checkMintRateLimit } from "@/lib/harness-rate-limit";
+import {
+  MintConflictError,
+  mintTokenForUser,
+  revokeActiveTokensForUser,
+} from "@/lib/harness-tokens";
+
+export async function POST() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const userId = session.user.id;
+
+  const limit = await checkMintRateLimit(userId);
+  if (!limit.ok) {
+    return NextResponse.json(
+      {
+        error: "rate_limited",
+        reason: limit.reason,
+        retryAfter: limit.retryAfter,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(limit.retryAfter) },
+      },
+    );
+  }
+
+  try {
+    const { raw, expiresAt } = await mintTokenForUser(userId);
+    return NextResponse.json(
+      { token: raw, expiresAt: expiresAt.toISOString() },
+      { status: 201 },
+    );
+  } catch (error) {
+    if (error instanceof MintConflictError) {
+      return NextResponse.json(
+        {
+          error: "mint_conflict",
+          message:
+            "Another token mint just succeeded for this user. Reload the page to see the active token.",
+        },
+        { status: 409 },
+      );
+    }
+    console.error("POST /api/harness-tokens error:", error);
+    return NextResponse.json(
+      { error: "Failed to mint token" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    await revokeActiveTokensForUser(session.user.id);
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    console.error("DELETE /api/harness-tokens error:", error);
+    return NextResponse.json(
+      { error: "Failed to revoke token" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -1,50 +1,97 @@
 /**
- * Integration test for POST /api/upload — the route that runs harness
- * HTML through parseHarnessHtml + parseInsightsHtml and returns the
- * structured payload the client uses to drive report creation.
+ * Integration tests for POST /api/upload.
  *
- * Why this exists (#106):
- *   - The route has zero existing route-level coverage. A parser
- *     regression on a new harness format silently breaks report
- *     creation in production.
- *   - This test feeds a real-shaped v2.7.0 fixture end-to-end so the
- *     happy path is locked in. Future format changes that break the
- *     parser will show up here before they ship.
+ * Two paths under test:
+ *   1. Multipart browser path — parses HTML and returns a structured
+ *      payload to the React upload page (legacy behavior).
+ *   2. Bearer-auth direct-POST path — parses HTML AND persists a draft
+ *      InsightReport in one round trip (Unit 7 of Wave 3b plan).
  *
- * Note on Prisma: this route does NOT touch the database. It parses,
- * normalizes, and returns JSON. Persistence happens in a separate
- * route the client calls afterwards. So the issue's "report row
- * created" assertion is covered by that downstream route's tests, not
- * here. We still mock @/lib/db to follow the established pattern and
- * to defend against accidental future Prisma calls in this handler.
+ * The bearer path's correctness depends on a strict pipeline order
+ * (Decision 11): authenticate → validate X-Upload-Id → idempotency
+ * lookup → rate-limit → parse + persist. Tests below assert that
+ * order, including the critical "idempotency beats rate limit"
+ * scenario (R14a).
  */
 import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 
-// ── Mock @/lib/db to match the repo route-test pattern ──────────────
+// ── Mocks (declared before the route imports) ───────────────────────
 
 vi.mock("@/lib/db", () => ({
   prisma: {
-    report: {
+    insightReport: {
       create: vi.fn(),
       findUnique: vi.fn(),
     },
+    project: {
+      findMany: vi.fn(),
+    },
+    reportProject: {
+      createMany: vi.fn(),
+    },
+    harnessUpload: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
   },
 }));
-
-// ── Mock next-auth ──────────────────────────────────────────────────
 
 vi.mock("@/lib/auth", () => ({
   auth: vi.fn(),
 }));
 
+vi.mock("@/lib/harness-auth", () => ({
+  authenticateRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/harness-rate-limit", () => ({
+  checkUploadRateLimit: vi.fn(),
+}));
+
+vi.mock("@/lib/harness-idempotency", () => ({
+  findIdempotentResult: vi.fn(),
+  withIdempotency: vi.fn(),
+}));
+
+vi.mock("@/lib/publish-report", () => ({
+  publishReport: vi.fn(),
+}));
+
+// Spy on the structured logger so tests can assert one log line per
+// terminal response without actually emitting JSON to stdout.
+vi.mock("@/lib/harness-logging", () => ({
+  logHarnessRequest: vi.fn(),
+}));
+
 // ── Imports after mocks ─────────────────────────────────────────────
 
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { authenticateRequest } from "@/lib/harness-auth";
+import { checkUploadRateLimit } from "@/lib/harness-rate-limit";
+import {
+  findIdempotentResult,
+  withIdempotency,
+} from "@/lib/harness-idempotency";
+import { logHarnessRequest } from "@/lib/harness-logging";
+import { publishReport } from "@/lib/publish-report";
 import { POST as uploadPOST } from "../route";
 
 const mockAuth = auth as unknown as Mock;
+const mockAuthenticate = authenticateRequest as unknown as Mock;
+const mockUploadLimit = checkUploadRateLimit as unknown as Mock;
+const mockFindIdempotent = findIdempotentResult as unknown as Mock;
+const mockWithIdempotency = withIdempotency as unknown as Mock;
+const mockPublish = publishReport as unknown as Mock;
+const mockLog = logHarnessRequest as unknown as Mock;
+const mockPrisma = prisma as unknown as {
+  harnessUpload: { create: Mock };
+};
 
 // ── Fixture loader ──────────────────────────────────────────────────
 
@@ -53,6 +100,7 @@ const FIXTURE_PATH = resolve(
   "../../../../lib/__tests__/fixtures/insight-harness-v2.7.0.html",
 );
 const FIXTURE_HTML = readFileSync(FIXTURE_PATH, "utf-8");
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -64,7 +112,7 @@ function mockSession(userId: string | null) {
   }
 }
 
-function uploadRequest(
+function multipartRequest(
   html: string,
   filename = "insight-harness.html",
 ): Request {
@@ -76,21 +124,78 @@ function uploadRequest(
   });
 }
 
+interface BearerOptions {
+  uploadId?: string | null;
+  authResult?:
+    | {
+        userId: string;
+        username: string;
+        viaToken: true;
+        tokenSelector: string;
+      }
+    | { viaToken: false }
+    | null;
+  body?: string;
+  contentType?: string;
+}
+
+function bearerRequest(opts: BearerOptions = {}): Request {
+  const headers: Record<string, string> = {
+    "content-type": opts.contentType ?? "application/octet-stream",
+    authorization: `Bearer ih_${"a".repeat(76)}`,
+  };
+  if (opts.uploadId !== null) {
+    headers["x-upload-id"] = opts.uploadId ?? VALID_UUID;
+  }
+  return new Request("http://localhost/api/upload", {
+    method: "POST",
+    headers,
+    body: opts.body ?? FIXTURE_HTML,
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Defaults so an authed bearer request flows through the happy path
+  // unless a test overrides one of these.
+  mockAuthenticate.mockResolvedValue({
+    userId: "user-1",
+    username: "alice",
+    viaToken: true,
+    tokenSelector: "abcdef012345",
+  });
+  mockFindIdempotent.mockResolvedValue(null);
+  mockUploadLimit.mockResolvedValue({ ok: true });
+  mockWithIdempotency.mockImplementation(
+    async (
+      _userId: string,
+      _uploadId: string,
+      work: () => Promise<{ slug: string }>,
+    ) => {
+      const r = await work();
+      return { slug: r.slug, replayed: false };
+    },
+  );
+  mockPublish.mockResolvedValue({
+    id: "report-1",
+    slug: "20260421-abc123",
+    authorId: "user-1",
+    isDraft: true,
+  });
+  mockPrisma.harnessUpload.create.mockResolvedValue({});
 });
 
-// ── Tests ───────────────────────────────────────────────────────────
+// ── Multipart path (legacy browser flow — regression guards) ────────
 
-describe("POST /api/upload — auth", () => {
+describe("POST /api/upload — multipart auth", () => {
   it("returns 401 when there is no session", async () => {
     mockSession(null);
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const response = await uploadPOST(multipartRequest(FIXTURE_HTML));
     expect(response.status).toBe(401);
   });
 });
 
-describe("POST /api/upload — input validation", () => {
+describe("POST /api/upload — multipart input validation", () => {
   it("returns 400 when no file field is present", async () => {
     mockSession("user-1");
     const formData = new FormData();
@@ -105,34 +210,12 @@ describe("POST /api/upload — input validation", () => {
   it("returns 400 when filename does not end in .html or .htm", async () => {
     mockSession("user-1");
     const response = await uploadPOST(
-      uploadRequest(FIXTURE_HTML, "report.pdf"),
+      multipartRequest(FIXTURE_HTML, "report.pdf"),
     );
     expect(response.status).toBe(400);
   });
 
-  it("returns 400 when the body is not multipart/form-data", async () => {
-    // Passing a JSON body to a route that expects FormData trips
-    // request.formData() → TypeError. Without an inner guard this
-    // bubbles to the outer catch as a 500. Lock it to 4xx so a 5xx
-    // regression never ships for this foot-gun class.
-    mockSession("user-1");
-    const request = new Request("http://localhost/api/upload", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ not: "formData" }),
-    });
-    const response = await uploadPOST(request);
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(typeof body.error).toBe("string");
-    expect(body.error.length).toBeGreaterThan(0);
-  });
-
   it("returns 400 when the file exceeds the 10MB cap", async () => {
-    // The route enforces `file.size > 10 * 1024 * 1024` at route.ts
-    // line 78-83. A 10MB+1 payload must bounce with 4xx (documented
-    // as 400 today) — never a 500 from running a giant HTML through
-    // cheerio.
     mockSession("user-1");
     const OVERSIZED = "x".repeat(10 * 1024 * 1024 + 1);
     const formData = new FormData();
@@ -151,13 +234,7 @@ describe("POST /api/upload — input validation", () => {
   });
 });
 
-describe("POST /api/upload — legacy harness format (pre-2.5.0)", () => {
-  // A pre-2.5.0 harness report has the integrity script tag (so it's
-  // detected as a harness report) but its embedded JSON is missing the
-  // required `stats` / `autonomy` / `featurePills` keys that
-  // normalizeHarnessData enforces. parseHarnessHtml throws; the route's
-  // try/catch around parseHarnessHtml (route.ts:115-128) translates that
-  // into a 400, not a 500. This locks that boundary in.
+describe("POST /api/upload — multipart legacy harness format (pre-2.5.0)", () => {
   const LEGACY_HARNESS_HTML = `<!doctype html>
 <html>
   <body>
@@ -173,114 +250,250 @@ describe("POST /api/upload — legacy harness format (pre-2.5.0)", () => {
 
   it("returns 400 (not 500) with a schema-mismatch error message", async () => {
     mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(LEGACY_HARNESS_HTML));
+    const response = await uploadPOST(multipartRequest(LEGACY_HARNESS_HTML));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toMatch(/required fields|HarnessData/i);
   });
 });
 
-describe("POST /api/upload — v2.7.0 harness fixture happy path", () => {
-  it("parses the fixture end-to-end and returns reportType=insight-harness", async () => {
+describe("POST /api/upload — multipart v2.7.0 happy path", () => {
+  it("parses end-to-end and returns reportType=insight-harness", async () => {
     mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const response = await uploadPOST(multipartRequest(FIXTURE_HTML));
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.reportType).toBe("insight-harness");
   });
 
-  it("prefers harness-level stats over embedded /insights values (override behavior)", async () => {
-    // The route MUST prefer harnessData.stats over the parse of the
-    // embedded /insights tab for sessionCount + commitCount, and MUST
-    // prefer harnessData.enhancedStats over the .stat-row scrape for
-    // lines/files/days/msgs-per-day. The fixture deliberately carries
-    // DIFFERENT values in each source so a regression that drops the
-    // override would surface here:
-    //   sessionCount → harness 95 vs insights subtitle "(88 total)"
-    //   commitCount  → harness 47 vs insights narrative "41 commits"
-    //   linesAdded   → harness 12500 vs insights stats row "+9,000/-2,000"
-    //   linesRemoved → harness 3100  vs insights stats row "-2,000"
-    //   fileCount    → harness 142   vs insights stats row "110"
-    //   dayCount     → harness 30    vs insights stats row "28"
-    //   msgsPerDay   → harness 40.0  vs insights stats row "35.0"
+  it("preserves enhanced stats override behavior", async () => {
     mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+    const response = await uploadPOST(multipartRequest(FIXTURE_HTML));
     const body = await response.json();
-
     expect(body.stats.sessionCount).toBe(95);
-    expect(body.stats.commitCount).toBe(47);
     expect(body.stats.linesAdded).toBe(12500);
-    expect(body.stats.linesRemoved).toBe(3100);
-    expect(body.stats.fileCount).toBe(142);
-    expect(body.stats.dayCount).toBe(30);
-    expect(body.stats.msgsPerDay).toBe(40.0);
+  });
+});
+
+// ── Bearer-auth direct-POST path ────────────────────────────────────
+
+describe("POST /api/upload — bearer auth", () => {
+  it("returns 401 when authenticateRequest returns null", async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(401);
+    expect(mockPrisma.harnessUpload.create).not.toHaveBeenCalled();
+    // Logger fires once; no userId attribution because auth failed.
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(mockLog.mock.calls[0][0]).toMatchObject({ statusCode: 401 });
   });
 
-  it("preserves the date range parsed from the embedded /insights subtitle", async () => {
-    mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
-    const body = await response.json();
-    expect(body.stats.dateRangeStart).toBe("2026-03-15");
-    expect(body.stats.dateRangeEnd).toBe("2026-04-14");
-    expect(body.stats.messageCount).toBe(1200);
+  it("returns 401 when the request was authed by session, not bearer", async () => {
+    mockAuthenticate.mockResolvedValue({
+      userId: "user-1",
+      username: "alice",
+      viaToken: false,
+    });
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(401);
+  });
+});
+
+describe("POST /api/upload — bearer X-Upload-Id validation", () => {
+  it("returns 400 + records HarnessUpload {success:false} when X-Upload-Id is missing", async () => {
+    const response = await uploadPOST(bearerRequest({ uploadId: null }));
+    expect(response.status).toBe(400);
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          success: false,
+        }),
+      }),
+    );
+    // Synthetic upload id used so the row stores something unique per
+    // attempt for rate-limit accounting.
+    const arg = mockPrisma.harnessUpload.create.mock.calls[0][0];
+    expect(arg.data.uploadId).toMatch(/^bad-upload-id:/);
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-1", statusCode: 400 }),
+    );
   });
 
-  it("returns the full harnessData blob with v2.7.0 fields populated", async () => {
-    mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
+  it("returns 400 + records HarnessUpload {success:false} when X-Upload-Id is malformed", async () => {
+    const response = await uploadPOST(
+      bearerRequest({ uploadId: "not-a-uuid" }),
+    );
+    expect(response.status).toBe(400);
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/upload — bearer idempotency", () => {
+  it("short-circuits with replayed:true on a prior successful uploadId", async () => {
+    mockFindIdempotent.mockResolvedValue({ slug: "20260421-prior" });
+
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(200);
     const body = await response.json();
-
-    expect(body.harnessData).toBeDefined();
-
-    // Top-level scalar tokens — exercise the headline numbers a
-    // regression would most likely break first.
-    expect(body.harnessData.stats.totalTokens).toBe(4500000000);
-    expect(body.harnessData.stats.lifetimeTokens).toBe(9800000000);
-    expect(body.harnessData.stats.durationHours).toBe(220.5);
-    expect(body.harnessData.skillVersion).toBe("2.7.0");
-
-    // Skill inventory — list shape with source labels (custom vs plugin).
-    expect(body.harnessData.skillInventory).toHaveLength(4);
-    expect(body.harnessData.skillInventory[0]).toMatchObject({
-      name: "commit",
-      source: "custom",
+    expect(body).toMatchObject({
+      replayed: true,
+      slug: "20260421-prior",
+      uploadId: VALID_UUID,
+      status: "draft",
     });
-
-    // Hook definitions — list shape with event + matcher + script.
-    expect(body.harnessData.hookDefinitions).toHaveLength(3);
-    expect(body.harnessData.hookDefinitions[0]).toMatchObject({
-      event: "PreToolUse",
-      matcher: "Bash",
-    });
-
-    // Plugins, featurePills, fileOpStyle, gitPatterns — sanity-check
-    // each major v2.7.0 surface so a parser drift on any one shows up.
-    expect(body.harnessData.plugins).toHaveLength(2);
-    expect(body.harnessData.featurePills.length).toBeGreaterThan(0);
-    expect(body.harnessData.fileOpStyle.style).toBe("Surgical Editor");
-    expect(body.harnessData.gitPatterns.prCount).toBe(134);
-    expect(body.harnessData.writeupSections).toHaveLength(2);
+    expect(body.editUrl).toBe("/insights/alice/20260421-prior/edit");
+    // CRITICAL: no rate-limit check on replays (R14a).
+    expect(mockUploadLimit).not.toHaveBeenCalled();
+    expect(mockPublish).not.toHaveBeenCalled();
   });
 
-  it("returns non-empty chartData and detectedSkills derived from the insights view", async () => {
-    // The fixture's #tab-insights has a "Top tools used" .chart-card
-    // with bar rows for Bash/Read/Edit/Agent, and detectSkills keys on
-    // the Agent toolPattern → 'subagents'. Asserting non-empty results
-    // catches a regression where the route drops these calls and falls
-    // back to {} / [] silently.
-    mockSession("user-1");
-    const response = await uploadPOST(uploadRequest(FIXTURE_HTML));
-    const body = await response.json();
-
-    expect(Array.isArray(body.chartData.toolUsage)).toBe(true);
-    expect(body.chartData.toolUsage.length).toBeGreaterThan(0);
-    expect(body.chartData.toolUsage[0]).toMatchObject({
-      label: "Bash",
-      value: 5200,
+  it("idempotency beats rate limit — replay returns 200 even when user is at cap", async () => {
+    // R14a contract: even if the user is rate-limited, a replay of a
+    // prior successful uploadId must return the original slug, not 429.
+    // The order of these mocks reflects the route's actual call order:
+    // findIdempotentResult is consulted BEFORE checkUploadRateLimit.
+    mockFindIdempotent.mockResolvedValue({ slug: "20260421-prior" });
+    mockUploadLimit.mockResolvedValue({
+      ok: false,
+      retryAfter: 3600,
+      reason: "uploads_24h",
     });
 
-    expect(Array.isArray(body.detectedSkills)).toBe(true);
-    expect(body.detectedSkills.length).toBeGreaterThan(0);
-    expect(body.detectedSkills).toContain("subagents");
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.replayed).toBe(true);
+    expect(body.slug).toBe("20260421-prior");
+    // Rate-limit check must NOT have been called.
+    expect(mockUploadLimit).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/upload — bearer rate limit", () => {
+  it("returns 429 with Retry-After + uploads_24h when at success cap", async () => {
+    mockUploadLimit.mockResolvedValue({
+      ok: false,
+      retryAfter: 7200,
+      reason: "uploads_24h",
+    });
+
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("7200");
+    const body = await response.json();
+    expect(body.reason).toBe("uploads_24h");
+    expect(body.retryAfter).toBe(7200);
+    // A failed-attempt row is recorded for the attempt cap.
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          uploadId: VALID_UUID,
+          success: false,
+        }),
+      }),
+    );
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 429,
+        rateLimitReason: "uploads_24h",
+      }),
+    );
+    // Publish never called on rate limit.
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 with attempts_24h reason when the attempt cap is hit", async () => {
+    mockUploadLimit.mockResolvedValue({
+      ok: false,
+      retryAfter: 60,
+      reason: "attempts_24h",
+    });
+
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(429);
+    const body = await response.json();
+    expect(body.reason).toBe("attempts_24h");
+  });
+});
+
+describe("POST /api/upload — bearer happy path", () => {
+  it("parses, publishes a draft, and returns editUrl + slug + uploadId + status", async () => {
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      slug: "20260421-abc123",
+      uploadId: VALID_UUID,
+      status: "draft",
+      replayed: false,
+    });
+    expect(body.editUrl).toBe("/insights/alice/20260421-abc123/edit");
+    // publishReport called with isDraft:true, redactions/projectIds
+    // empty (the user redacts on the edit page).
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        username: "alice",
+        isDraft: true,
+        redactions: [],
+        projectIds: [],
+      }),
+    );
+    // Logger emits one structured 200 line for the bearer flow with
+    // the full Decision-13 field set (sans full token).
+    expect(mockLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uploadId: VALID_UUID,
+        userId: "user-1",
+        tokenSelectorPrefix: "abcdef01",
+        statusCode: 200,
+        replayed: false,
+      }),
+    );
+    // Selector is logged in 8-char trimmed form, never the full 12.
+    const logArg = mockLog.mock.calls.at(-1)?.[0];
+    expect(logArg.tokenSelectorPrefix.length).toBe(8);
+  });
+});
+
+describe("POST /api/upload — bearer parse failure", () => {
+  it("returns 400 + records HarnessUpload {success:false} on malformed harness JSON", async () => {
+    const LEGACY = `<!doctype html>
+<html>
+  <body>
+    <script type="application/json" id="insight-harness-integrity">
+      { "hash": "x" }
+    </script>
+    <script type="application/json" id="harness-data">
+      { "skillVersion": "2.4.0" }
+    </script>
+    <div id="tab-insights"></div>
+  </body>
+</html>`;
+    const response = await uploadPOST(bearerRequest({ body: LEGACY }));
+    expect(response.status).toBe(400);
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ success: false }),
+      }),
+    );
+    // Publish never reached on parse failure.
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/upload — bearer selectors never log the full token", () => {
+  it("logHarnessRequest receives only the trimmed selector prefix", async () => {
+    await uploadPOST(bearerRequest());
+    // Find every call to the logger and assert no field contains the
+    // raw bearer token from the Authorization header.
+    for (const call of mockLog.mock.calls) {
+      const fields = call[0];
+      const flat = JSON.stringify(fields);
+      expect(flat).not.toContain("a".repeat(20));
+      expect(flat).not.toMatch(/Bearer/i);
+    }
   });
 });

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -555,6 +555,35 @@ describe("POST /api/upload — bearer failure-attempt accounting", () => {
   });
 });
 
+describe("POST /api/upload — bearer rejects bodies that aren't HTML", () => {
+  it("returns 400 when body is octet-stream but content is JSON-like", async () => {
+    // Even with the allowed Content-Type, a non-HTML body (e.g. `{}`)
+    // would otherwise reach parseInsightsHtml as text and silently
+    // produce an all-empty draft. Pre-parse check rejects it.
+    const response = await uploadPOST(
+      bearerRequest({
+        contentType: "application/octet-stream",
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/HTML/i);
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when body is plain text without any HTML markers", async () => {
+    const response = await uploadPOST(
+      bearerRequest({
+        contentType: "text/html",
+        body: "this is just some text without tags",
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /api/upload — bearer parse failure", () => {
   it("returns 400 + records HarnessUpload {success:false} on malformed harness JSON", async () => {
     const LEGACY = `<!doctype html>

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -582,6 +582,21 @@ describe("POST /api/upload — bearer rejects bodies that aren't HTML", () => {
     expect(response.status).toBe(400);
     expect(mockPublish).not.toHaveBeenCalled();
   });
+
+  it("returns 400 when body has HTML wrappers but parses as an empty report", async () => {
+    // looksLikeHtml() passes (the body has <html>/<body>) but the
+    // post-parse content check rejects it because no real report data
+    // landed in the parsed structure. Without this gate, parseInsightsHtml
+    // would silently produce an all-empty report that becomes a junk draft.
+    const response = await uploadPOST(
+      bearerRequest({
+        contentType: "text/html",
+        body: "<html><body>{}</body></html>",
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /api/upload — bearer parse failure", () => {

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -299,6 +299,66 @@ describe("POST /api/upload — bearer auth", () => {
   });
 });
 
+describe("POST /api/upload — bearer Content-Type validation", () => {
+  it("rejects application/json with 415 + records an attempt against the cap", async () => {
+    // Without this gate, a `{}` body would reach parseInsightsHtml and
+    // land as an empty draft. We require octet-stream or text/html.
+    const response = await uploadPOST(
+      bearerRequest({
+        contentType: "application/json",
+        body: "{}",
+      }),
+    );
+    expect(response.status).toBe(415);
+    // Synthetic id used because the X-Upload-Id wasn't validated yet.
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalled();
+    const args = mockPrisma.harnessUpload.create.mock.calls[0][0];
+    expect(args.data.success).toBe(false);
+    expect(args.data.uploadId).toMatch(/^bad-upload-id:/);
+    // Publish path never reached.
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+
+  it("accepts text/html as a valid bearer Content-Type", async () => {
+    const response = await uploadPOST(
+      bearerRequest({ contentType: "text/html" }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockPublish).toHaveBeenCalled();
+  });
+
+  it("strips Content-Type parameters before matching (e.g. charset)", async () => {
+    const response = await uploadPOST(
+      bearerRequest({ contentType: "text/html; charset=utf-8" }),
+    );
+    expect(response.status).toBe(200);
+  });
+});
+
+describe("POST /api/upload — bearer body size cap", () => {
+  it("returns 400 when Content-Length exceeds the 10MB cap (byte size, not UTF-16 length)", async () => {
+    // Use a Content-Length that exceeds the cap. We don't actually
+    // need to send an oversize body — the route quick-rejects on
+    // the header before buffering.
+    const headers: Record<string, string> = {
+      "content-type": "application/octet-stream",
+      authorization: `Bearer ih_${"a".repeat(76)}`,
+      "x-upload-id": VALID_UUID,
+      "content-length": String(11 * 1024 * 1024),
+    };
+    const response = await uploadPOST(
+      new Request("http://localhost/api/upload", {
+        method: "POST",
+        headers,
+        body: "x", // body content unused — header alone trips the gate
+      }),
+    );
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/too large/i);
+  });
+});
+
 describe("POST /api/upload — bearer X-Upload-Id validation", () => {
   it("returns 400 + records HarnessUpload {success:false} when X-Upload-Id is missing", async () => {
     const response = await uploadPOST(bearerRequest({ uploadId: null }));
@@ -455,6 +515,43 @@ describe("POST /api/upload — bearer happy path", () => {
     // Selector is logged in 8-char trimmed form, never the full 12.
     const logArg = mockLog.mock.calls.at(-1)?.[0];
     expect(logArg.tokenSelectorPrefix.length).toBe(8);
+  });
+});
+
+describe("POST /api/upload — bearer failure-attempt accounting", () => {
+  it("records a synthetic-id row when the (userId, uploadId) row already exists at success=false", async () => {
+    // Token holder spamming retries with the same uploadId. The first
+    // attempt's failure row exists; the second attempt's recordFailure
+    // hits P2002 on the unique constraint and falls back to a synthetic
+    // id, ensuring the attempt counter still increments toward R12's
+    // cap.
+    mockUploadLimit.mockResolvedValue({
+      ok: false,
+      retryAfter: 60,
+      reason: "attempts_24h",
+    });
+    // First create call (real id) trips P2002; second (synthetic) succeeds.
+    let calls = 0;
+    mockPrisma.harnessUpload.create.mockImplementation(async (arg) => {
+      calls += 1;
+      if (calls === 1) {
+        const err = new Error("unique constraint violation") as Error & {
+          code: string;
+        };
+        err.code = "P2002";
+        throw err;
+      }
+      return arg;
+    });
+
+    const response = await uploadPOST(bearerRequest());
+    expect(response.status).toBe(429);
+    // Two create calls: real id (P2002) + synthetic id (success).
+    expect(mockPrisma.harnessUpload.create).toHaveBeenCalledTimes(2);
+    const realIdCall = mockPrisma.harnessUpload.create.mock.calls[0][0];
+    const synthCall = mockPrisma.harnessUpload.create.mock.calls[1][0];
+    expect(realIdCall.data.uploadId).toBe(VALID_UUID);
+    expect(synthCall.data.uploadId).toMatch(/^bad-upload-id:/);
   });
 });
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -258,12 +258,27 @@ async function handleMultipart(request: Request): Promise<NextResponse> {
  * raw HTML body and persists a draft InsightReport in one round trip,
  * with idempotency, rate-limit, and structured logging.
  */
+/**
+ * Allowed Content-Types on the bearer-auth path. Anything else (e.g.
+ * application/json, text/plain) is rejected with 400 BEFORE we run
+ * the parser, so a malformed payload never lands as a "{}-empty"
+ * draft in InsightReport.
+ */
+const ALLOWED_BEARER_CONTENT_TYPES = new Set([
+  "application/octet-stream",
+  "text/html",
+]);
+
 async function handleBearer(request: Request): Promise<NextResponse> {
   const startedAt = Date.now();
   const contentLengthHeader = request.headers.get("content-length");
   const contentLength = contentLengthHeader
     ? Number(contentLengthHeader)
     : undefined;
+  const contentType = (request.headers.get("content-type") ?? "")
+    .toLowerCase()
+    .split(";")[0]
+    .trim();
 
   // ── 1. Authenticate ────────────────────────────────────────────────
   const authResult = await authenticateRequest(request);
@@ -280,25 +295,38 @@ async function handleBearer(request: Request): Promise<NextResponse> {
   const { userId, username, tokenSelector } = authResult;
   const tokenSelectorPrefix = tokenSelector?.slice(0, 8);
 
+  // ── 1b. Validate Content-Type ──────────────────────────────────────
+  // Reject unsupported content types BEFORE rate-limit / idempotency
+  // so a malformed payload (e.g. application/json with body `{}`) can
+  // never land as an all-empty draft. Treat it as a "reached past auth
+  // but failed validation" attempt so it counts toward R12's cap, with
+  // a synthetic uploadId because we haven't validated the X-Upload-Id
+  // yet either.
+  if (!ALLOWED_BEARER_CONTENT_TYPES.has(contentType)) {
+    await recordFailureWithSyntheticId(userId);
+    logHarnessRequest({
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 415,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      {
+        error: "Unsupported Content-Type",
+        message: "Send the report as application/octet-stream or text/html.",
+      },
+      { status: 415 },
+    );
+  }
+
   // ── 2. Validate X-Upload-Id ────────────────────────────────────────
   const rawUploadId = request.headers.get("x-upload-id");
   if (!rawUploadId || !UUID_REGEX.test(rawUploadId)) {
     // Synthetic id so the row still records (R12 needs every reach
-    // beyond auth to count toward the attempt cap).
-    await prisma.harnessUpload
-      .create({
-        data: {
-          userId,
-          uploadId: syntheticUploadId(),
-          slug: null,
-          success: false,
-        },
-      })
-      .catch((e) => {
-        // Don't fail the request just because we couldn't log the
-        // attempt; the user already saw a 400 coming. Bubble to logs.
-        console.error("Failed to record bad-upload-id HarnessUpload:", e);
-      });
+    // beyond auth to count toward the attempt cap, even when the
+    // client never gave us a valid id).
+    await recordFailureWithSyntheticId(userId);
     logHarnessRequest({
       userId,
       tokenSelectorPrefix,
@@ -337,19 +365,10 @@ async function handleBearer(request: Request): Promise<NextResponse> {
   // ── 4. Rate limit ──────────────────────────────────────────────────
   const limit = await checkUploadRateLimit(userId);
   if (!limit.ok) {
-    await prisma.harnessUpload
-      .create({
-        data: { userId, uploadId, slug: null, success: false },
-      })
-      .catch((e) => {
-        // Surfacing this in logs is enough — the user already gets a
-        // 429 from the rate-limiter check. A duplicate row from an
-        // earlier 4xx for the same uploadId trips the unique
-        // constraint; that's fine, we're done counting.
-        if (!isUniqueViolation(e)) {
-          console.error("Failed to record rate-limited HarnessUpload row:", e);
-        }
-      });
+    // recordFailure will fall back to a synthetic id if the (userId,
+    // uploadId) row already exists, so a token holder repeatedly
+    // retrying with the same uploadId still ticks the attempt cap.
+    await recordFailure(userId, uploadId);
     logHarnessRequest({
       uploadId,
       userId,
@@ -373,9 +392,28 @@ async function handleBearer(request: Request): Promise<NextResponse> {
   }
 
   // ── 5. Read body, parse, publish (under withIdempotency) ───────────
-  let html: string;
+  // Quick reject on Content-Length BEFORE buffering — clients that
+  // send a >10MB body have advertised the size and we don't need to
+  // read it to know.
+  if (typeof contentLength === "number" && contentLength > MAX_UPLOAD_BYTES) {
+    await recordFailure(userId, uploadId);
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 400,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      { error: "File too large (max 10MB)" },
+      { status: 400 },
+    );
+  }
+
+  let bodyBytes: ArrayBuffer;
   try {
-    html = await request.text();
+    bodyBytes = await request.arrayBuffer();
   } catch {
     await recordFailure(userId, uploadId);
     logHarnessRequest({
@@ -392,7 +430,10 @@ async function handleBearer(request: Request): Promise<NextResponse> {
     );
   }
 
-  if (html.length > MAX_UPLOAD_BYTES) {
+  // Hard byte-size cap. arrayBuffer().byteLength counts actual bytes
+  // on the wire, so multibyte HTML cannot bypass the limit by virtue
+  // of UTF-16 string-length being smaller than the UTF-8 byte length.
+  if (bodyBytes.byteLength > MAX_UPLOAD_BYTES) {
     await recordFailure(userId, uploadId);
     logHarnessRequest({
       uploadId,
@@ -407,6 +448,8 @@ async function handleBearer(request: Request): Promise<NextResponse> {
       { status: 400 },
     );
   }
+
+  const html = new TextDecoder("utf-8").decode(bodyBytes);
 
   let parsed: ParsedInsightsReport;
   try {
@@ -481,18 +524,54 @@ async function handleBearer(request: Request): Promise<NextResponse> {
   });
 }
 
-/** Best-effort attempt to record a failed bearer-path upload row. The
- *  unique constraint on (userId, uploadId) means a duplicate failure
- *  for the same id throws; we treat that as already-recorded. */
+/**
+ * Record a failed bearer-path upload attempt. The unique constraint
+ * on (userId, uploadId) means a literal retry of the same uploadId
+ * cannot create another row at that key — so on P2002 we fall back to
+ * inserting a row with a synthetic id. This preserves R12's
+ * "every reach beyond auth counts toward the attempt cap" invariant
+ * even when a token holder spams retries with the same uploadId.
+ */
 async function recordFailure(userId: string, uploadId: string): Promise<void> {
   try {
     await prisma.harnessUpload.create({
       data: { userId, uploadId, slug: null, success: false },
     });
   } catch (e) {
-    if (!isUniqueViolation(e)) {
-      console.error("Failed to record HarnessUpload failure row:", e);
+    if (isUniqueViolation(e)) {
+      // Original (userId, uploadId) row already exists — this is a
+      // retry of a previously-failed attempt. Insert under a synthetic
+      // id so the attempt-cap counter still increments for this hit.
+      await recordFailureWithSyntheticId(userId);
+      return;
     }
+    console.error("Failed to record HarnessUpload failure row:", e);
+  }
+}
+
+/**
+ * Record a failed attempt under a synthetic uploadId. Used in two
+ * cases: (a) the request's X-Upload-Id was missing/malformed so we
+ * never had a real id, and (b) a retry of an already-failed (userId,
+ * uploadId) tripped the unique constraint above. In both cases the
+ * synthetic id is unique-per-row so the attempt counter ticks
+ * forward, even when the same client keeps misbehaving.
+ */
+async function recordFailureWithSyntheticId(userId: string): Promise<void> {
+  try {
+    await prisma.harnessUpload.create({
+      data: {
+        userId,
+        uploadId: syntheticUploadId(),
+        slug: null,
+        success: false,
+      },
+    });
+  } catch (e) {
+    console.error(
+      "Failed to record HarnessUpload synthetic-id failure row:",
+      e,
+    );
   }
 }
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -110,7 +110,34 @@ class ParseError extends Error {
   }
 }
 
+/**
+ * Cheap pre-parse check: does this body look like an HTML document?
+ * `parseInsightsHtml` accepts arbitrary text and silently falls back
+ * to an all-empty report shape, which on the bearer path would land
+ * as a junk draft. Reject inputs that don't contain any of the
+ * tell-tale tags before they hit the parser.
+ */
+function looksLikeHtml(html: string): boolean {
+  // A real Insight report always has at least one of the document
+  // wrappers OR our integrity script. Whitespace and case-insensitive
+  // match — be liberal in what we accept, strict about rejecting
+  // obviously-non-HTML payloads like `{}`.
+  const lower = html.slice(0, 4096).toLowerCase();
+  if (lower.includes("<!doctype html")) return true;
+  if (lower.includes("<html")) return true;
+  if (lower.includes("<body")) return true;
+  if (lower.includes("insight-harness-integrity")) return true;
+  if (lower.includes("harness-data")) return true;
+  return false;
+}
+
 function parseUploadHtml(html: string): ParsedUpload {
+  if (!looksLikeHtml(html)) {
+    throw new ParseError(
+      "Request body does not appear to be an HTML report.",
+      400,
+    );
+  }
   const isHarness = isHarnessReport(html);
 
   // For harness reports, parse the embedded /insights tab — the

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,15 +1,61 @@
+/**
+ * POST /api/upload — accepts an HTML report and (a) for the existing
+ * multipart browser flow, parses it and returns the structured payload
+ * the upload-page React state machine consumes, or (b) for the new
+ * bearer-auth direct-POST flow (Unit 7 of Wave 3b plan), parses it AND
+ * persists a draft InsightReport in one round trip, returning the
+ * editUrl/slug for the skill to print.
+ *
+ * Flow selection is by `Content-Type`:
+ *   - `multipart/form-data`        → legacy browser path (parse-only).
+ *   - `application/octet-stream`   → bearer-auth direct-POST path.
+ *   - `text/html`                  → bearer-auth direct-POST path.
+ *
+ * The bearer path is sequenced per Decision 11:
+ *   1. authenticate → require viaToken, else 401.
+ *   2. validate X-Upload-Id is a UUID, else record HarnessUpload
+ *      {success: false} and return 400.
+ *   3. findIdempotentResult → if a prior success exists, short-circuit
+ *      with the original slug. **Idempotency beats rate-limit (R14a).**
+ *   4. checkUploadRateLimit → on cap, record failed attempt + return.
+ *   5. parse + publishReport via withIdempotency.
+ *   6. emit logHarnessRequest on every terminal response.
+ */
 import { NextResponse } from "next/server";
+import * as cheerio from "cheerio";
 import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/db";
 import { parseInsightsHtml } from "@/lib/parser";
 import { isHarnessReport, parseHarnessHtml } from "@/lib/harness-parser";
 import { detectRedactions } from "@/lib/redaction";
 import { parseChartData } from "@/lib/chart-parser";
 import { detectSkills } from "@/lib/skill-detector";
-import * as cheerio from "cheerio";
+import { authenticateRequest } from "@/lib/harness-auth";
+import { checkUploadRateLimit } from "@/lib/harness-rate-limit";
+import {
+  findIdempotentResult,
+  withIdempotency,
+} from "@/lib/harness-idempotency";
+import { logHarnessRequest } from "@/lib/harness-logging";
+import { publishReport } from "@/lib/publish-report";
+import { buildReportEditUrl } from "@/lib/urls";
+import type { ParsedInsightsReport } from "@/types/insights";
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB — matches the multipart cap.
+
+/** Synthetic upload id used when the request lacks a valid X-Upload-Id.
+ *  Prefixed so it can never collide with a real client UUID, and we
+ *  still record a HarnessUpload row for rate-limit accounting. */
+function syntheticUploadId(): string {
+  return `bad-upload-id:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+}
 
 /**
- * Extract enhanced stats (linesAdded, linesRemoved, fileCount, dayCount, msgsPerDay)
- * from the stats row in the HTML report.
+ * Extract enhanced stats (linesAdded, linesRemoved, fileCount,
+ * dayCount, msgsPerDay) from the .stat row in the HTML report.
  */
 function extractEnhancedStats(html: string) {
   const $ = cheerio.load(html);
@@ -20,7 +66,6 @@ function extractEnhancedStats(html: string) {
     statValues[label] = value;
   });
 
-  // Parse lines: "+47,313/-2,967"
   let linesAdded: number | null = null;
   let linesRemoved: number | null = null;
   const linesValue = statValues["lines"];
@@ -32,17 +77,12 @@ function extractEnhancedStats(html: string) {
     }
   }
 
-  // Parse files
   const fileCount = statValues["files"]
     ? parseInt(statValues["files"].replace(/,/g, ""), 10)
     : null;
-
-  // Parse days
   const dayCount = statValues["days"]
     ? parseInt(statValues["days"].replace(/,/g, ""), 10)
     : null;
-
-  // Parse msgs/day
   const msgsPerDay = statValues["msgs/day"]
     ? parseFloat(statValues["msgs/day"].replace(/,/g, ""))
     : null;
@@ -50,121 +90,95 @@ function extractEnhancedStats(html: string) {
   return { linesAdded, linesRemoved, fileCount, dayCount, msgsPerDay };
 }
 
-export async function POST(request: Request) {
-  try {
-    const session = await auth();
-    if (!session?.user?.id) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+interface ParsedUpload {
+  parsed: ParsedInsightsReport;
+  responseBody: Record<string, unknown>;
+}
+
+/**
+ * Shared parse pipeline used by both the multipart and bearer-auth
+ * paths. Throws an Error subclass with a `status` field on validation
+ * failure so the calling handler can surface a 400 with the right
+ * message.
+ */
+class ParseError extends Error {
+  readonly status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "ParseError";
+    this.status = status;
+  }
+}
+
+function parseUploadHtml(html: string): ParsedUpload {
+  const isHarness = isHarnessReport(html);
+
+  // For harness reports, parse the embedded /insights tab — the
+  // top-level page has harness-specific selectors that would confuse
+  // the insights parser.
+  let insightsHtml = html;
+  if (isHarness) {
+    const $doc = cheerio.load(html);
+    const insightsTab = $doc("#tab-insights");
+    if (insightsTab.length) {
+      insightsHtml = `<html><body>${insightsTab.html()}</body></html>`;
     }
+  }
 
-    let formData: FormData;
-    try {
-      formData = await request.formData();
-    } catch {
-      return NextResponse.json(
-        { error: "Request body must be multipart/form-data" },
-        { status: 400 },
-      );
-    }
-    const file = formData.get("file");
+  const parsed = parseInsightsHtml(insightsHtml);
+  const chartData = parseChartData(insightsHtml);
+  const detectedSkills = detectSkills(parsed.data, chartData);
+  const detectedRedactions = detectRedactions(parsed.data);
 
-    if (!file || !(file instanceof File)) {
-      return NextResponse.json(
-        { error: "HTML file is required" },
-        { status: 400 },
-      );
-    }
+  let harnessData: ReturnType<typeof parseHarnessHtml> | undefined;
+  if (isHarness) {
+    // parseHarnessHtml throws on schema mismatch; let the caller
+    // translate to 400 so the message reaches the user.
+    harnessData = parseHarnessHtml(html);
+  }
 
-    if (!file.name.endsWith(".html") && !file.name.endsWith(".htm")) {
-      return NextResponse.json(
-        { error: "File must be an HTML file" },
-        { status: 400 },
-      );
-    }
-
-    // 10MB limit
-    if (file.size > 10 * 1024 * 1024) {
-      return NextResponse.json(
-        { error: "File too large (max 10MB)" },
-        { status: 400 },
-      );
-    }
-
-    const html = await file.text();
-
-    // Detect report type
-    const isHarness = isHarnessReport(html);
-
-    // For harness reports, extract the embedded /insights tab content
-    // and parse that — the top-level HTML has harness-specific selectors
-    // that would confuse the insights parser (wrong .stat/.subtitle elements).
-    let insightsHtml = html;
-    if (isHarness) {
-      const $doc = cheerio.load(html);
-      const insightsTab = $doc("#tab-insights");
-      if (insightsTab.length) {
-        // Wrap in minimal HTML so the parser can find selectors
-        insightsHtml = `<html><body>${insightsTab.html()}</body></html>`;
+  const enhancedStats = harnessData?.enhancedStats
+    ? {
+        linesAdded: harnessData.enhancedStats.linesAdded,
+        linesRemoved: harnessData.enhancedStats.linesRemoved,
+        fileCount: harnessData.enhancedStats.fileCount,
+        dayCount: harnessData.enhancedStats.dayCount,
+        msgsPerDay: harnessData.enhancedStats.msgsPerDay,
       }
-    }
+    : extractEnhancedStats(insightsHtml);
 
-    // Parse the /insights data from the appropriate HTML source
-    const parsed = parseInsightsHtml(insightsHtml);
-
-    // Extract chart data and detect skills from the insights HTML
-    const chartData = parseChartData(insightsHtml);
-    const detectedSkills = detectSkills(parsed.data, chartData);
-
-    // Detect sensitive data using the redaction engine
-    const detectedRedactions = detectRedactions(parsed.data);
-
-    // Parse harness-specific data if applicable
-    let harnessData: ReturnType<typeof parseHarnessHtml> | undefined;
-    if (isHarness) {
-      try {
-        harnessData = parseHarnessHtml(html);
-      } catch (e) {
-        return NextResponse.json(
-          {
-            error:
-              e instanceof Error
-                ? e.message
-                : "Failed to parse harness report data",
-          },
-          { status: 400 },
-        );
-      }
-    }
-
-    // Extract enhanced stats — for harness reports, source from JSON blob;
-    // for plain insights, scrape from the insights stats row
-    const enhancedStats = harnessData?.enhancedStats
+  const stats = {
+    ...parsed.stats,
+    ...enhancedStats,
+    ...(harnessData
       ? {
-          linesAdded: harnessData.enhancedStats.linesAdded,
-          linesRemoved: harnessData.enhancedStats.linesRemoved,
-          fileCount: harnessData.enhancedStats.fileCount,
-          dayCount: harnessData.enhancedStats.dayCount,
-          msgsPerDay: harnessData.enhancedStats.msgsPerDay,
+          sessionCount:
+            harnessData.stats.sessionCount ?? parsed.stats.sessionCount ?? 0,
+          commitCount:
+            harnessData.stats.commitCount ?? parsed.stats.commitCount ?? 0,
+          dayCount: enhancedStats.dayCount ?? 30,
         }
-      : extractEnhancedStats(insightsHtml);
+      : {}),
+  };
 
-    // For harness reports, override stats with harness-level data
-    // since the embedded insights tab may have stale/different stats
-    const stats = {
+  // Compose the ParsedInsightsReport that publishReport expects. Layer
+  // chartData / detectedSkills / harnessData / reportType onto the
+  // shape the parser already returned.
+  const composed: ParsedInsightsReport = {
+    ...parsed,
+    stats: {
       ...parsed.stats,
-      ...enhancedStats,
-      ...(harnessData
-        ? {
-            sessionCount:
-              harnessData.stats.sessionCount ?? parsed.stats.sessionCount ?? 0,
-            commitCount:
-              harnessData.stats.commitCount ?? parsed.stats.commitCount ?? 0,
-            dayCount: enhancedStats.dayCount ?? 30,
-          }
-        : {}),
-    };
+      ...stats,
+    },
+    chartData,
+    detectedSkills,
+    reportType: isHarness ? "insight-harness" : "insights",
+    harnessData,
+  };
 
-    return NextResponse.json({
+  return {
+    parsed: composed,
+    responseBody: {
       stats,
       data: parsed.data,
       detectedRedactions,
@@ -172,7 +186,331 @@ export async function POST(request: Request) {
       detectedSkills,
       reportType: isHarness ? "insight-harness" : "insights",
       harnessData,
+    },
+  };
+}
+
+/**
+ * Multipart browser path — unchanged behavior. Parse-only; the client
+ * receives the structured payload and POSTs to /api/insights to
+ * actually persist (until Unit 9 unifies the flow).
+ */
+async function handleMultipart(request: Request): Promise<NextResponse> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "Request body must be multipart/form-data" },
+      { status: 400 },
+    );
+  }
+  const file = formData.get("file");
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json(
+      { error: "HTML file is required" },
+      { status: 400 },
+    );
+  }
+
+  if (!file.name.endsWith(".html") && !file.name.endsWith(".htm")) {
+    return NextResponse.json(
+      { error: "File must be an HTML file" },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "File too large (max 10MB)" },
+      { status: 400 },
+    );
+  }
+
+  const html = await file.text();
+  try {
+    const { responseBody } = parseUploadHtml(html);
+    return NextResponse.json(responseBody);
+  } catch (e) {
+    if (e instanceof ParseError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    return NextResponse.json(
+      {
+        error:
+          e instanceof Error
+            ? e.message
+            : "Failed to parse harness report data",
+      },
+      { status: 400 },
+    );
+  }
+}
+
+/**
+ * Bearer-auth direct-POST path — Unit 7's primary flow. Parses the
+ * raw HTML body and persists a draft InsightReport in one round trip,
+ * with idempotency, rate-limit, and structured logging.
+ */
+async function handleBearer(request: Request): Promise<NextResponse> {
+  const startedAt = Date.now();
+  const contentLengthHeader = request.headers.get("content-length");
+  const contentLength = contentLengthHeader
+    ? Number(contentLengthHeader)
+    : undefined;
+
+  // ── 1. Authenticate ────────────────────────────────────────────────
+  const authResult = await authenticateRequest(request);
+  if (!authResult || !authResult.viaToken) {
+    // No HarnessUpload row written: we don't know which user this came
+    // from, so we cannot accurately attribute the attempt for R12.
+    logHarnessRequest({
+      contentLength,
+      statusCode: 401,
+      durationMs: Date.now() - startedAt,
     });
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { userId, username, tokenSelector } = authResult;
+  const tokenSelectorPrefix = tokenSelector?.slice(0, 8);
+
+  // ── 2. Validate X-Upload-Id ────────────────────────────────────────
+  const rawUploadId = request.headers.get("x-upload-id");
+  if (!rawUploadId || !UUID_REGEX.test(rawUploadId)) {
+    // Synthetic id so the row still records (R12 needs every reach
+    // beyond auth to count toward the attempt cap).
+    await prisma.harnessUpload
+      .create({
+        data: {
+          userId,
+          uploadId: syntheticUploadId(),
+          slug: null,
+          success: false,
+        },
+      })
+      .catch((e) => {
+        // Don't fail the request just because we couldn't log the
+        // attempt; the user already saw a 400 coming. Bubble to logs.
+        console.error("Failed to record bad-upload-id HarnessUpload:", e);
+      });
+    logHarnessRequest({
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 400,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      { error: "X-Upload-Id header is required and must be a UUID" },
+      { status: 400 },
+    );
+  }
+  const uploadId = rawUploadId.toLowerCase();
+
+  // ── 3. Idempotency lookup BEFORE rate limit (R14a) ─────────────────
+  const replay = await findIdempotentResult(userId, uploadId);
+  if (replay) {
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      replayed: true,
+      statusCode: 200,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json({
+      editUrl: buildReportEditUrl(username, replay.slug),
+      slug: replay.slug,
+      uploadId,
+      status: "draft",
+      replayed: true,
+    });
+  }
+
+  // ── 4. Rate limit ──────────────────────────────────────────────────
+  const limit = await checkUploadRateLimit(userId);
+  if (!limit.ok) {
+    await prisma.harnessUpload
+      .create({
+        data: { userId, uploadId, slug: null, success: false },
+      })
+      .catch((e) => {
+        // Surfacing this in logs is enough — the user already gets a
+        // 429 from the rate-limiter check. A duplicate row from an
+        // earlier 4xx for the same uploadId trips the unique
+        // constraint; that's fine, we're done counting.
+        if (!isUniqueViolation(e)) {
+          console.error("Failed to record rate-limited HarnessUpload row:", e);
+        }
+      });
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      rateLimitReason: limit.reason,
+      statusCode: 429,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      {
+        error: "rate_limited",
+        reason: limit.reason,
+        retryAfter: limit.retryAfter,
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(limit.retryAfter) },
+      },
+    );
+  }
+
+  // ── 5. Read body, parse, publish (under withIdempotency) ───────────
+  let html: string;
+  try {
+    html = await request.text();
+  } catch {
+    await recordFailure(userId, uploadId);
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 400,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      { error: "Failed to read request body" },
+      { status: 400 },
+    );
+  }
+
+  if (html.length > MAX_UPLOAD_BYTES) {
+    await recordFailure(userId, uploadId);
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 400,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      { error: "File too large (max 10MB)" },
+      { status: 400 },
+    );
+  }
+
+  let parsed: ParsedInsightsReport;
+  try {
+    ({ parsed } = parseUploadHtml(html));
+  } catch (e) {
+    await recordFailure(userId, uploadId);
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 400,
+      durationMs: Date.now() - startedAt,
+    });
+    return NextResponse.json(
+      {
+        error:
+          e instanceof Error
+            ? e.message
+            : "Failed to parse harness report data",
+      },
+      { status: 400 },
+    );
+  }
+
+  let result: { slug: string; replayed: boolean };
+  try {
+    result = await withIdempotency(userId, uploadId, async () => {
+      const created = await publishReport({
+        userId,
+        username,
+        parsed,
+        redactions: [],
+        projectIds: [],
+        hiddenHarnessSections: [],
+        isDraft: true,
+      });
+      return { slug: created.slug };
+    });
+  } catch (e) {
+    await recordFailure(userId, uploadId);
+    logHarnessRequest({
+      uploadId,
+      userId,
+      tokenSelectorPrefix,
+      contentLength,
+      statusCode: 500,
+      durationMs: Date.now() - startedAt,
+    });
+    console.error("POST /api/upload bearer publish failed:", e);
+    return NextResponse.json(
+      { error: "Failed to publish draft report" },
+      { status: 500 },
+    );
+  }
+
+  logHarnessRequest({
+    uploadId,
+    userId,
+    tokenSelectorPrefix,
+    contentLength,
+    replayed: result.replayed,
+    statusCode: 200,
+    durationMs: Date.now() - startedAt,
+  });
+  return NextResponse.json({
+    editUrl: buildReportEditUrl(username, result.slug),
+    slug: result.slug,
+    uploadId,
+    status: "draft",
+    replayed: result.replayed,
+  });
+}
+
+/** Best-effort attempt to record a failed bearer-path upload row. The
+ *  unique constraint on (userId, uploadId) means a duplicate failure
+ *  for the same id throws; we treat that as already-recorded. */
+async function recordFailure(userId: string, uploadId: string): Promise<void> {
+  try {
+    await prisma.harnessUpload.create({
+      data: { userId, uploadId, slug: null, success: false },
+    });
+  } catch (e) {
+    if (!isUniqueViolation(e)) {
+      console.error("Failed to record HarnessUpload failure row:", e);
+    }
+  }
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  if (typeof e !== "object" || e === null) return false;
+  const code = (e as { code?: unknown }).code;
+  return code === "P2002";
+}
+
+export async function POST(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  const isMultipart = contentType.toLowerCase().startsWith("multipart/");
+
+  try {
+    if (isMultipart) {
+      return await handleMultipart(request);
+    }
+    return await handleBearer(request);
   } catch (error) {
     console.error("POST /api/upload error:", error);
     return NextResponse.json(

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -111,23 +111,60 @@ class ParseError extends Error {
 }
 
 /**
- * Cheap pre-parse check: does this body look like an HTML document?
- * `parseInsightsHtml` accepts arbitrary text and silently falls back
- * to an all-empty report shape, which on the bearer path would land
- * as a junk draft. Reject inputs that don't contain any of the
- * tell-tale tags before they hit the parser.
+ * Cheap pre-parse check: does this body LOOK like an HTML document?
+ * Used as a fast-fail before invoking the full HTML parser. Real
+ * acceptance is determined post-parse by hasParsedContent() — this is
+ * just a wallet-of-tags fence to short-circuit the obviously-bogus
+ * `{}` payload before we spin up cheerio.
  */
 function looksLikeHtml(html: string): boolean {
-  // A real Insight report always has at least one of the document
-  // wrappers OR our integrity script. Whitespace and case-insensitive
-  // match — be liberal in what we accept, strict about rejecting
-  // obviously-non-HTML payloads like `{}`.
   const lower = html.slice(0, 4096).toLowerCase();
   if (lower.includes("<!doctype html")) return true;
   if (lower.includes("<html")) return true;
   if (lower.includes("<body")) return true;
-  if (lower.includes("insight-harness-integrity")) return true;
-  if (lower.includes("harness-data")) return true;
+  if (lower.includes("<script")) return true;
+  return false;
+}
+
+/**
+ * After parsing, confirm the report has at least one signal of real
+ * content. Without this check, parseInsightsHtml silently produces
+ * an all-empty report shape for any text that happens to slip past
+ * looksLikeHtml() (e.g. `<body>{}</body>`), which on the bearer path
+ * would land as a junk draft.
+ *
+ * The bar is low: any non-zero stat OR any non-empty section field
+ * passes. A true insight-harness report always has at least one
+ * positive `messageCount` / `sessionCount`; a true /insights report
+ * always has narrative text in `interaction_style` or one of the
+ * sections. Plain `{}` produces all zeros + all empty strings, which
+ * is unambiguously the empty-report fallback.
+ */
+function hasParsedContent(parsed: ParsedInsightsReport): boolean {
+  const s = parsed.stats;
+  if (
+    (typeof s.sessionCount === "number" && s.sessionCount > 0) ||
+    (typeof s.messageCount === "number" && s.messageCount > 0) ||
+    (typeof s.commitCount === "number" && s.commitCount > 0) ||
+    (typeof s.dayCount === "number" && (s.dayCount ?? 0) > 0) ||
+    (s.dateRangeStart && s.dateRangeStart.length > 0) ||
+    (s.dateRangeEnd && s.dateRangeEnd.length > 0)
+  ) {
+    return true;
+  }
+  const d = parsed.data;
+  if (
+    d.interaction_style?.narrative ||
+    d.interaction_style?.key_pattern ||
+    (d.project_areas?.areas?.length ?? 0) > 0 ||
+    (d.what_works?.impressive_workflows?.length ?? 0) > 0 ||
+    (d.friction_analysis?.categories?.length ?? 0) > 0 ||
+    (d.on_the_horizon?.opportunities?.length ?? 0) > 0 ||
+    d.at_a_glance?.whats_working ||
+    d.at_a_glance?.whats_hindering
+  ) {
+    return true;
+  }
   return false;
 }
 
@@ -202,6 +239,19 @@ function parseUploadHtml(html: string): ParsedUpload {
     reportType: isHarness ? "insight-harness" : "insights",
     harnessData,
   };
+
+  // Post-parse content check. parseInsightsHtml accepts arbitrary
+  // text and silently falls back to an all-empty report; without this
+  // gate, any string that scraped past looksLikeHtml() but contained
+  // no real report data would persist as a junk draft on the bearer
+  // path. Belt-and-suspenders pairing: looksLikeHtml() is fast-fail,
+  // hasParsedContent() is the truth-check.
+  if (!isHarness && !hasParsedContent(composed)) {
+    throw new ParseError(
+      "Request body parsed as an empty report — verify it is a valid insights or insight-harness HTML.",
+      400,
+    );
+  }
 
   return {
     parsed: composed,

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -51,6 +51,10 @@ beforeEach(() => {
   // Default: zero prior mints in the 24h window so the in-tx rate-limit
   // check passes. Tests that exercise the cap override this.
   mockPrisma.harnessToken.count.mockResolvedValue(0);
+  // Default: no recent active token in the conflict-freshness window
+  // so the conflict-detection branch in mintTokenForUser stays inert
+  // for tests that aren't exercising it.
+  mockPrisma.harnessToken.findFirst.mockResolvedValue(null);
   // `pg_advisory_xact_lock` is a void SQL call; resolve it as 0 so the
   // helper's await goes through.
   mockPrisma.$executeRaw.mockResolvedValue(0);
@@ -182,6 +186,22 @@ describe("mintTokenForUser", () => {
     // fragments; the second is the lock-key string.
     expect(String(callArgs[0])).toContain("pg_advisory_xact_lock");
     expect(callArgs[1]).toBe("mint:user-1");
+  });
+
+  it("throws MintConflictError when a recent active token already exists", async () => {
+    // Concurrent-mint scenario: caller A's POST committed milliseconds
+    // ago and is the active token. Caller B (double-click, retry, or
+    // racing browser) acquires the lock next. Without conflict
+    // detection, B's updateMany would silently revoke A's freshly-
+    // returned token and B would mint its own. Detect the recent
+    // active row and surface MintConflictError so B's HTTP layer 409s.
+    mockPrisma.harnessToken.findFirst.mockResolvedValueOnce({ id: "tok-A" });
+
+    const thrown = await mintTokenForUser("user-1").catch((e: unknown) => e);
+    expect(thrown).toBeInstanceOf(MintConflictError);
+    // Crucially: no updateMany / create call (would have revoked the winner).
+    expect(mockPrisma.harnessToken.updateMany).not.toHaveBeenCalled();
+    expect(mockPrisma.harnessToken.create).not.toHaveBeenCalled();
   });
 
   it("throws MintRateLimitError when the in-transaction count is at cap", async () => {

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -11,7 +11,7 @@ vi.mock("@/lib/db", () => ({
       count: vi.fn(),
     },
     $transaction: vi.fn(),
-    $executeRaw: vi.fn(),
+    $queryRaw: vi.fn(),
   },
 }));
 
@@ -39,7 +39,7 @@ const mockPrisma = prisma as unknown as {
     count: Mock;
   };
   $transaction: Mock;
-  $executeRaw: Mock;
+  $queryRaw: Mock;
 };
 
 beforeEach(() => {
@@ -55,9 +55,9 @@ beforeEach(() => {
   // so the conflict-detection branch in mintTokenForUser stays inert
   // for tests that aren't exercising it.
   mockPrisma.harnessToken.findFirst.mockResolvedValue(null);
-  // `pg_advisory_xact_lock` is a void SQL call; resolve it as 0 so the
-  // helper's await goes through.
-  mockPrisma.$executeRaw.mockResolvedValue(0);
+  // `pg_try_advisory_xact_lock` returns boolean; default success.
+  // Tests that exercise the lock-conflict path override this.
+  mockPrisma.$queryRaw.mockResolvedValue([{ acquired: true }]);
 });
 
 describe("generateToken", () => {
@@ -167,39 +167,37 @@ describe("mintTokenForUser", () => {
     expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(1);
   });
 
-  it("acquires a per-user advisory lock before the in-tx count check", async () => {
+  it("try-acquires a per-user advisory lock before the in-tx count check", async () => {
     // Without the lock, two concurrent POSTs at count=cap-1 can both
-    // read cap-1 under READ COMMITTED and both insert. The lock
-    // serializes the critical section by user — verify it's actually
-    // requested before the count.
+    // read cap-1 under READ COMMITTED and both insert. The non-blocking
+    // try-lock serializes the critical section by user — verify it's
+    // actually requested.
     mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
     mockPrisma.harnessToken.create.mockResolvedValue({});
 
     await mintTokenForUser("user-1");
 
-    expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
-    // Vitest's $executeRaw mock receives the tagged-template fragments.
-    // Argument 0 is the strings array; argument 1+ are the values. We
-    // assert the lock key includes our user-scoped identifier.
-    const callArgs = mockPrisma.$executeRaw.mock.calls[0];
-    // The first arg is a TemplateStringsArray containing the SQL
-    // fragments; the second is the lock-key string.
-    expect(String(callArgs[0])).toContain("pg_advisory_xact_lock");
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(1);
+    const callArgs = mockPrisma.$queryRaw.mock.calls[0];
+    // First arg is a TemplateStringsArray containing the SQL fragments;
+    // second is the lock-key string.
+    expect(String(callArgs[0])).toContain("pg_try_advisory_xact_lock");
     expect(callArgs[1]).toBe("mint:user-1");
   });
 
-  it("throws MintConflictError when a recent active token already exists", async () => {
-    // Concurrent-mint scenario: caller A's POST committed milliseconds
-    // ago and is the active token. Caller B (double-click, retry, or
-    // racing browser) acquires the lock next. Without conflict
-    // detection, B's updateMany would silently revoke A's freshly-
-    // returned token and B would mint its own. Detect the recent
-    // active row and surface MintConflictError so B's HTTP layer 409s.
-    mockPrisma.harnessToken.findFirst.mockResolvedValueOnce({ id: "tok-A" });
+  it("throws MintConflictError when the try-lock cannot be acquired", async () => {
+    // Concurrent-mint scenario: caller A holds the per-user lock.
+    // Caller B's pg_try_advisory_xact_lock returns false → throw
+    // MintConflictError so the HTTP layer 409s. Without this
+    // short-circuit, B would block until A commits, then run
+    // updateMany against A's freshly-committed row and silently
+    // revoke A's just-returned token.
+    mockPrisma.$queryRaw.mockResolvedValueOnce([{ acquired: false }]);
 
     const thrown = await mintTokenForUser("user-1").catch((e: unknown) => e);
     expect(thrown).toBeInstanceOf(MintConflictError);
-    // Crucially: no updateMany / create call (would have revoked the winner).
+    // No DB writes when the lock is held by another caller.
+    expect(mockPrisma.harnessToken.count).not.toHaveBeenCalled();
     expect(mockPrisma.harnessToken.updateMany).not.toHaveBeenCalled();
     expect(mockPrisma.harnessToken.create).not.toHaveBeenCalled();
   });

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/db", () => ({
       count: vi.fn(),
     },
     $transaction: vi.fn(),
+    $executeRaw: vi.fn(),
   },
 }));
 
@@ -38,6 +39,7 @@ const mockPrisma = prisma as unknown as {
     count: Mock;
   };
   $transaction: Mock;
+  $executeRaw: Mock;
 };
 
 beforeEach(() => {
@@ -49,6 +51,9 @@ beforeEach(() => {
   // Default: zero prior mints in the 24h window so the in-tx rate-limit
   // check passes. Tests that exercise the cap override this.
   mockPrisma.harnessToken.count.mockResolvedValue(0);
+  // `pg_advisory_xact_lock` is a void SQL call; resolve it as 0 so the
+  // helper's await goes through.
+  mockPrisma.$executeRaw.mockResolvedValue(0);
 });
 
 describe("generateToken", () => {
@@ -156,6 +161,27 @@ describe("mintTokenForUser", () => {
     // Single attempt only — no retry.
     expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(1);
     expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("acquires a per-user advisory lock before the in-tx count check", async () => {
+    // Without the lock, two concurrent POSTs at count=cap-1 can both
+    // read cap-1 under READ COMMITTED and both insert. The lock
+    // serializes the critical section by user — verify it's actually
+    // requested before the count.
+    mockPrisma.harnessToken.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.harnessToken.create.mockResolvedValue({});
+
+    await mintTokenForUser("user-1");
+
+    expect(mockPrisma.$executeRaw).toHaveBeenCalledTimes(1);
+    // Vitest's $executeRaw mock receives the tagged-template fragments.
+    // Argument 0 is the strings array; argument 1+ are the values. We
+    // assert the lock key includes our user-scoped identifier.
+    const callArgs = mockPrisma.$executeRaw.mock.calls[0];
+    // The first arg is a TemplateStringsArray containing the SQL
+    // fragments; the second is the lock-key string.
+    expect(String(callArgs[0])).toContain("pg_advisory_xact_lock");
+    expect(callArgs[1]).toBe("mint:user-1");
   });
 
   it("throws MintRateLimitError when the in-transaction count is at cap", async () => {

--- a/src/lib/__tests__/harness-tokens.test.ts
+++ b/src/lib/__tests__/harness-tokens.test.ts
@@ -4,9 +4,11 @@ vi.mock("@/lib/db", () => ({
   prisma: {
     harnessToken: {
       findUnique: vi.fn(),
+      findFirst: vi.fn(),
       update: vi.fn(),
       updateMany: vi.fn(),
       create: vi.fn(),
+      count: vi.fn(),
     },
     $transaction: vi.fn(),
   },
@@ -16,7 +18,9 @@ import { prisma } from "@/lib/db";
 import {
   generateToken,
   hashSecret,
+  MINT_CAP_PER_24H,
   MintConflictError,
+  MintRateLimitError,
   mintTokenForUser,
   parseToken,
   revokeActiveTokensForUser,
@@ -27,9 +31,11 @@ import {
 const mockPrisma = prisma as unknown as {
   harnessToken: {
     findUnique: Mock;
+    findFirst: Mock;
     update: Mock;
     updateMany: Mock;
     create: Mock;
+    count: Mock;
   };
   $transaction: Mock;
 };
@@ -40,6 +46,9 @@ beforeEach(() => {
   mockPrisma.$transaction.mockImplementation(
     async (cb: (tx: typeof mockPrisma) => Promise<unknown>) => cb(mockPrisma),
   );
+  // Default: zero prior mints in the 24h window so the in-tx rate-limit
+  // check passes. Tests that exercise the cap override this.
+  mockPrisma.harnessToken.count.mockResolvedValue(0);
 });
 
 describe("generateToken", () => {
@@ -147,6 +156,28 @@ describe("mintTokenForUser", () => {
     // Single attempt only — no retry.
     expect(mockPrisma.harnessToken.create).toHaveBeenCalledTimes(1);
     expect(mockPrisma.harnessToken.updateMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws MintRateLimitError when the in-transaction count is at cap", async () => {
+    // Atomic in-tx check: even if the soft pre-check passed (the route's
+    // pre-tx call to checkMintRateLimit), a concurrent burst could have
+    // pushed the count to cap by the time this transaction runs. The
+    // helper must catch that and surface MintRateLimitError, not silently
+    // mint the (cap+1)-th token.
+    const oldestRow = {
+      createdAt: new Date(Date.now() - 60 * 60 * 1000), // 1h ago
+    };
+    mockPrisma.harnessToken.count.mockResolvedValue(MINT_CAP_PER_24H);
+    mockPrisma.harnessToken.findFirst.mockResolvedValue(oldestRow);
+
+    const thrown = await mintTokenForUser("user-1").catch((e: unknown) => e);
+    expect(thrown).toBeInstanceOf(MintRateLimitError);
+    expect((thrown as MintRateLimitError).oldestCreatedAt).toEqual(
+      oldestRow.createdAt,
+    );
+    // Critically: no create call should have been attempted.
+    expect(mockPrisma.harnessToken.create).not.toHaveBeenCalled();
+    expect(mockPrisma.harnessToken.updateMany).not.toHaveBeenCalled();
   });
 
   it("rethrows non-active-slot P2002 unchanged (e.g. selector collision)", async () => {

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -33,16 +33,6 @@ const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 /** R13 — at most this many mints per user per rolling 24h window. */
 export const MINT_CAP_PER_24H = 10;
-/**
- * If we acquire the mint lock and find an active token created in
- * the last `MINT_CONFLICT_FRESHNESS_MS`, treat the request as a
- * concurrent mint (e.g. double-click, retry) and surface
- * MintConflictError instead of silently revoking the freshly-minted
- * winner's token. Tuned to comfortably cover one outbound HTTP
- * round-trip while staying well below "user reloaded the page to
- * deliberately rotate."
- */
-export const MINT_CONFLICT_FRESHNESS_MS = 5_000;
 
 export interface GeneratedToken {
   raw: string;
@@ -159,20 +149,32 @@ export async function mintTokenForUser(
 
   try {
     await prisma.$transaction(async (tx) => {
-      // Serialize concurrent mints for this user. Without a lock, two
-      // POSTs at count=9 can both read 9 under READ COMMITTED, both
-      // pass the cap check, and both insert — yielding 11 mints in
-      // 24h. `pg_advisory_xact_lock` blocks the second caller until
-      // the first transaction commits/rolls back, after which the
-      // second sees the freshly-committed row in its count and trips
-      // the cap.
+      // Try-acquire a per-user advisory lock. If we don't get it, a
+      // concurrent mint for this user is in flight; surface
+      // MintConflictError so the HTTP layer 409s rather than fall
+      // through to the rotation path (which would silently revoke the
+      // winner's freshly-returned token in updateMany).
+      //
+      // Try-acquire (vs. blocking acquire) closes the race exposed
+      // during code review: blocking would let us serialize behind the
+      // winner, then run updateMany against their committed row,
+      // returning 201 with their token already dead. The non-blocking
+      // version is also robust to commit-time vs. createdAt skew —
+      // we don't need a freshness window, the lock IS the signal.
       //
       // Lock key: a 32-bit hash of `mint:<userId>` so we don't
-      // serialize unrelated users. We only need scoping by user for
-      // this critical section; the bcrypt cost of the loser's wasted
-      // hash work (~80ms) is bounded by the rate-limit cap anyway.
-      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`mint:${userId}`}))`;
+      // serialize unrelated users.
+      const lockResult = await tx.$queryRaw<Array<{ acquired: boolean }>>`
+        SELECT pg_try_advisory_xact_lock(hashtext(${`mint:${userId}`})) AS acquired
+      `;
+      if (!lockResult[0]?.acquired) {
+        throw new MintConflictError(userId);
+      }
 
+      // With the lock held, count + insert are atomic w.r.t. other
+      // mints for this user. Concurrent bursts now serialize into
+      // single-attempt MintConflictErrors; the lock holder always sees
+      // up-to-date state.
       const since = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
       const count = await tx.harnessToken.count({
         where: { userId, createdAt: { gt: since } },
@@ -183,33 +185,7 @@ export async function mintTokenForUser(
           orderBy: { createdAt: "asc" },
           select: { createdAt: true },
         });
-        // Fallback to `now` if the row vanished between count and read
-        // (vanishingly unlikely; HarnessToken rows aren't deleted).
         throw new MintRateLimitError(userId, oldest?.createdAt ?? now);
-      }
-
-      // Conflict detection: if a recently-created active token already
-      // exists, the prior caller in the lock queue just minted. We
-      // would otherwise revoke their (still-in-flight, freshly-issued)
-      // token in the updateMany below, returning 201 with a token they
-      // already received plus a token they don't know about. Surface
-      // MintConflictError so the HTTP layer 409s and the client can
-      // reload (or re-mint deliberately).
-      //
-      // Threshold tuned at MINT_CONFLICT_FRESHNESS_MS — long enough to
-      // catch double-clicks and HTTP retries, short enough that a
-      // deliberate reload-and-rotate flow still works.
-      const freshCutoff = new Date(Date.now() - MINT_CONFLICT_FRESHNESS_MS);
-      const recentActive = await tx.harnessToken.findFirst({
-        where: {
-          userId,
-          revokedAt: null,
-          createdAt: { gt: freshCutoff },
-        },
-        select: { id: true },
-      });
-      if (recentActive) {
-        throw new MintConflictError(userId);
       }
 
       await tx.harnessToken.updateMany({

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -33,6 +33,16 @@ const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 /** R13 — at most this many mints per user per rolling 24h window. */
 export const MINT_CAP_PER_24H = 10;
+/**
+ * If we acquire the mint lock and find an active token created in
+ * the last `MINT_CONFLICT_FRESHNESS_MS`, treat the request as a
+ * concurrent mint (e.g. double-click, retry) and surface
+ * MintConflictError instead of silently revoking the freshly-minted
+ * winner's token. Tuned to comfortably cover one outbound HTTP
+ * round-trip while staying well below "user reloaded the page to
+ * deliberately rotate."
+ */
+export const MINT_CONFLICT_FRESHNESS_MS = 5_000;
 
 export interface GeneratedToken {
   raw: string;
@@ -176,6 +186,30 @@ export async function mintTokenForUser(
         // Fallback to `now` if the row vanished between count and read
         // (vanishingly unlikely; HarnessToken rows aren't deleted).
         throw new MintRateLimitError(userId, oldest?.createdAt ?? now);
+      }
+
+      // Conflict detection: if a recently-created active token already
+      // exists, the prior caller in the lock queue just minted. We
+      // would otherwise revoke their (still-in-flight, freshly-issued)
+      // token in the updateMany below, returning 201 with a token they
+      // already received plus a token they don't know about. Surface
+      // MintConflictError so the HTTP layer 409s and the client can
+      // reload (or re-mint deliberately).
+      //
+      // Threshold tuned at MINT_CONFLICT_FRESHNESS_MS — long enough to
+      // catch double-clicks and HTTP retries, short enough that a
+      // deliberate reload-and-rotate flow still works.
+      const freshCutoff = new Date(Date.now() - MINT_CONFLICT_FRESHNESS_MS);
+      const recentActive = await tx.harnessToken.findFirst({
+        where: {
+          userId,
+          revokedAt: null,
+          createdAt: { gt: freshCutoff },
+        },
+        select: { id: true },
+      });
+      if (recentActive) {
+        throw new MintConflictError(userId);
       }
 
       await tx.harnessToken.updateMany({

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -30,6 +30,9 @@ const TOKEN_REGEX = new RegExp(
 
 const BCRYPT_COST = 10;
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+/** R13 — at most this many mints per user per rolling 24h window. */
+export const MINT_CAP_PER_24H = 10;
 
 export interface GeneratedToken {
   raw: string;
@@ -99,6 +102,25 @@ export class MintConflictError extends Error {
 }
 
 /**
+ * Thrown when a mint attempt is over the per-user rate limit. Detected
+ * INSIDE the transaction (atomic count + create) so concurrent bursts
+ * cannot blow past the cap by each calling soft-check
+ * `checkMintRateLimit` before any of them commits. The HTTP layer
+ * should translate to 429.
+ *
+ * `oldestCreatedAt` is the timestamp of the oldest counted row in the
+ * 24h window — callers compute Retry-After from it.
+ */
+export class MintRateLimitError extends Error {
+  readonly oldestCreatedAt: Date;
+  constructor(userId: string, oldestCreatedAt: Date) {
+    super(`Mint cap reached for user ${userId}`);
+    this.name = "MintRateLimitError";
+    this.oldestCreatedAt = oldestCreatedAt;
+  }
+}
+
+/**
  * Mint a new token for `userId`. Implicitly revokes any prior active
  * tokens (R3): a user has at most one active token at a time. Returns
  * the raw token exactly once — callers must surface it immediately
@@ -127,6 +149,31 @@ export async function mintTokenForUser(
 
   try {
     await prisma.$transaction(async (tx) => {
+      // Atomic rate-limit check: count this user's mints in the last 24h
+      // INSIDE the transaction. Without this, two concurrent POSTs could
+      // each pass the soft `checkMintRateLimit` (which runs before the
+      // transaction) and serialize through to mint, exceeding the cap.
+      // Postgres's MVCC won't synchronize their reads, but having both
+      // bursts trip the cap inside the same critical section as the
+      // create gives us a hard upper bound: one of the two will see the
+      // other's row by the time it gets here, OR both will be under
+      // cap and we accept up to MINT_CAP_PER_24H + concurrent_bursts as
+      // the worst case (still bounded by Postgres's serialization).
+      const since = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
+      const count = await tx.harnessToken.count({
+        where: { userId, createdAt: { gt: since } },
+      });
+      if (count >= MINT_CAP_PER_24H) {
+        const oldest = await tx.harnessToken.findFirst({
+          where: { userId, createdAt: { gt: since } },
+          orderBy: { createdAt: "asc" },
+          select: { createdAt: true },
+        });
+        // Fallback to `now` if the row vanished between count and read
+        // (vanishingly unlikely; HarnessToken rows aren't deleted).
+        throw new MintRateLimitError(userId, oldest?.createdAt ?? now);
+      }
+
       await tx.harnessToken.updateMany({
         where: { userId, revokedAt: null },
         data: { revokedAt: now },

--- a/src/lib/harness-tokens.ts
+++ b/src/lib/harness-tokens.ts
@@ -149,16 +149,20 @@ export async function mintTokenForUser(
 
   try {
     await prisma.$transaction(async (tx) => {
-      // Atomic rate-limit check: count this user's mints in the last 24h
-      // INSIDE the transaction. Without this, two concurrent POSTs could
-      // each pass the soft `checkMintRateLimit` (which runs before the
-      // transaction) and serialize through to mint, exceeding the cap.
-      // Postgres's MVCC won't synchronize their reads, but having both
-      // bursts trip the cap inside the same critical section as the
-      // create gives us a hard upper bound: one of the two will see the
-      // other's row by the time it gets here, OR both will be under
-      // cap and we accept up to MINT_CAP_PER_24H + concurrent_bursts as
-      // the worst case (still bounded by Postgres's serialization).
+      // Serialize concurrent mints for this user. Without a lock, two
+      // POSTs at count=9 can both read 9 under READ COMMITTED, both
+      // pass the cap check, and both insert — yielding 11 mints in
+      // 24h. `pg_advisory_xact_lock` blocks the second caller until
+      // the first transaction commits/rolls back, after which the
+      // second sees the freshly-committed row in its count and trips
+      // the cap.
+      //
+      // Lock key: a 32-bit hash of `mint:<userId>` so we don't
+      // serialize unrelated users. We only need scoping by user for
+      // this critical section; the bcrypt cost of the loser's wasted
+      // hash work (~80ms) is bounded by the rate-limit cap anyway.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtext(${`mint:${userId}`}))`;
+
       const since = new Date(Date.now() - TWENTY_FOUR_HOURS_MS);
       const count = await tx.harnessToken.count({
         where: { userId, createdAt: { gt: since } },

--- a/src/lib/publish-report.ts
+++ b/src/lib/publish-report.ts
@@ -1,0 +1,253 @@
+/**
+ * Server-side report-publish helper used by the bearer-auth direct-POST
+ * path of /api/upload (Unit 7 of Wave 3b plan).
+ *
+ * The browser flow has historically split this work between the client
+ * (`src/app/upload/page.tsx:handlePublish` — title fallback, section
+ * snake→camel mapping, redaction application) and the server
+ * (`POST /api/insights` — DB transaction, project link upsert). For the
+ * bearer path the same logic must run server-side. Per Decision 10 in
+ * the plan, this helper consolidates the publish-side transformations
+ * so future Unit 9 can refactor `handlePublish` to call it too.
+ *
+ * Pragmatic scope (per task notes): this helper only needs to satisfy
+ * the bearer path right now. It does NOT yet handle the inline-project
+ * link enrichment that `POST /api/insights` performs — bearer-path
+ * drafts are created with `projectIds: []` and the user attaches
+ * projects on the edit page. Unit 9 will widen this helper if needed.
+ */
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/db";
+import { applyRedactions } from "@/lib/redaction";
+import { normalizeHarnessData } from "@/types/insights";
+import type {
+  InsightsData,
+  ParsedInsightsReport,
+  RedactionItem,
+} from "@/types/insights";
+
+/**
+ * Maps the snake_case keys used in InsightsData to the camelCase
+ * fields stored on the InsightReport row. Identical to the mapping
+ * in `src/app/upload/page.tsx:handlePublish` so the bearer path
+ * produces drafts with the same shape as the browser path.
+ */
+const SECTION_KEY_MAP: Record<keyof InsightsData, string> = {
+  at_a_glance: "atAGlance",
+  interaction_style: "interactionStyle",
+  project_areas: "projectAreas",
+  what_works: "impressiveWorkflows",
+  friction_analysis: "frictionAnalysis",
+  suggestions: "suggestions",
+  on_the_horizon: "onTheHorizon",
+  fun_ending: "funEnding",
+};
+
+/**
+ * Slug shape used by both browser and bearer paths. Format:
+ * `<YYYYMMDD>-<random>` keeps reports chronologically sortable in
+ * URL listings while staying short enough to type.
+ */
+function generateSlug(): string {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const shortId = Math.random().toString(36).substring(2, 8);
+  return `${date}-${shortId}`;
+}
+
+/**
+ * Build the auto-generated title used when the caller didn't supply
+ * one. Mirrors `handlePublish`'s "<First>'s {Insight Harness | Claude
+ * Code Insights} - {Mon YYYY}" format. The bearer path doesn't have a
+ * session.user.name so we fall back to the username (the first segment
+ * of which is the closest analogue to a "first name").
+ */
+function buildAutoTitle(args: {
+  username: string;
+  isHarness: boolean;
+  dateRangeEnd?: string | null;
+}): string {
+  const firstName = args.username.split(/[-_]/)[0] || args.username;
+  let titleDate: string;
+  if (args.dateRangeEnd) {
+    const d = new Date(args.dateRangeEnd + "T00:00:00");
+    titleDate = d.toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+    });
+  } else {
+    titleDate = new Date().toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+    });
+  }
+  return args.isHarness
+    ? `${firstName}'s Insight Harness - ${titleDate}`
+    : `${firstName}'s Claude Code Insights - ${titleDate}`;
+}
+
+export interface PublishReportArgs {
+  userId: string;
+  username: string;
+  parsed: ParsedInsightsReport;
+  /** Caller-supplied redactions; bearer path defaults to []. */
+  redactions: RedactionItem[];
+  /** Caller-supplied project ids; bearer path defaults to []. */
+  projectIds: string[];
+  /** Caller-supplied hidden harness section keys; bearer path defaults to []. */
+  hiddenHarnessSections: string[];
+  /**
+   * Whether the new row should be persisted as a draft. The bearer
+   * path always passes true. Browser publish keeps the existing
+   * `false` semantics for compatibility (Unit 9 will revisit).
+   */
+  isDraft: boolean;
+  /** Optional caller-supplied title; falls back to buildAutoTitle. */
+  title?: string;
+}
+
+export interface PublishedReport {
+  id: string;
+  slug: string;
+  authorId: string;
+  isDraft: boolean;
+}
+
+/**
+ * Apply redactions, map section keys, generate a fallback title, then
+ * insert the InsightReport row inside a transaction so a partial
+ * failure rolls back cleanly.
+ *
+ * Returns the minimal fields the bearer path needs to redirect the
+ * caller to the edit page. Callers that want the full row should
+ * issue their own follow-up read with the desired include shape.
+ */
+export async function publishReport(
+  args: PublishReportArgs,
+): Promise<PublishedReport> {
+  const { userId, username, parsed, redactions, projectIds, isDraft } = args;
+
+  // 1. Redaction. applyRedactions is a pure function on InsightsData —
+  // empty list returns a deep clone unchanged.
+  const redactedData = applyRedactions(parsed.data, redactions);
+
+  // 2. Section-map snake → camel. The Prisma fields are camelCase;
+  // the parser emits snake_case to mirror the JSON-serialized shape
+  // the skill produces.
+  const sectionFields: Record<string, unknown> = {};
+  for (const [dataKey, prismaKey] of Object.entries(SECTION_KEY_MAP)) {
+    sectionFields[prismaKey] =
+      redactedData[dataKey as keyof InsightsData] ?? null;
+  }
+
+  // 3. Title fallback.
+  const isHarness = parsed.reportType === "insight-harness";
+  const title =
+    args.title ||
+    buildAutoTitle({
+      username,
+      isHarness,
+      dateRangeEnd: parsed.stats.dateRangeEnd,
+    });
+
+  // 4. Slug. Random, collision-prone but practically unique enough at
+  // current scale; the unique constraint is on `(authorId, slug)` so
+  // a repeat slug under the same author is the only failure mode.
+  const slug = generateSlug();
+
+  // 5. Insert. Inside a transaction so any future hookup of project
+  // junctions rolls back atomically. For now the bearer path passes
+  // an empty projectIds list — the user picks projects on the edit
+  // page after the draft renders.
+  const created = await prisma.$transaction(async (tx) => {
+    const row = await tx.insightReport.create({
+      data: {
+        authorId: userId,
+        title,
+        slug,
+        isDraft,
+        sessionCount: parsed.stats.sessionCount ?? null,
+        messageCount: parsed.stats.messageCount ?? null,
+        commitCount: parsed.stats.commitCount ?? null,
+        dateRangeStart: parsed.stats.dateRangeStart ?? null,
+        dateRangeEnd: parsed.stats.dateRangeEnd ?? null,
+        linesAdded: parsed.stats.linesAdded ?? null,
+        linesRemoved: parsed.stats.linesRemoved ?? null,
+        fileCount: parsed.stats.fileCount ?? null,
+        dayCount: parsed.stats.dayCount ?? null,
+        msgsPerDay: parsed.stats.msgsPerDay ?? null,
+        atAGlance:
+          (sectionFields.atAGlance as Prisma.InputJsonValue) ?? undefined,
+        interactionStyle:
+          (sectionFields.interactionStyle as Prisma.InputJsonValue) ??
+          undefined,
+        projectAreas:
+          (sectionFields.projectAreas as Prisma.InputJsonValue) ?? undefined,
+        impressiveWorkflows:
+          (sectionFields.impressiveWorkflows as Prisma.InputJsonValue) ??
+          undefined,
+        frictionAnalysis:
+          (sectionFields.frictionAnalysis as Prisma.InputJsonValue) ??
+          undefined,
+        suggestions:
+          (sectionFields.suggestions as Prisma.InputJsonValue) ?? undefined,
+        onTheHorizon:
+          (sectionFields.onTheHorizon as Prisma.InputJsonValue) ?? undefined,
+        funEnding:
+          (sectionFields.funEnding as Prisma.InputJsonValue) ?? undefined,
+        chartData:
+          (parsed.chartData as Prisma.InputJsonValue | undefined) ?? undefined,
+        detectedSkills: parsed.detectedSkills ?? [],
+        reportType: parsed.reportType ?? "insights",
+        // Harness scalar denorm — null when this isn't a harness report.
+        totalTokens:
+          typeof parsed.harnessData?.stats.totalTokens === "number"
+            ? BigInt(parsed.harnessData.stats.totalTokens)
+            : null,
+        durationHours:
+          typeof parsed.harnessData?.stats.durationHours === "number"
+            ? Math.round(parsed.harnessData.stats.durationHours)
+            : null,
+        avgSessionMinutes: parsed.harnessData?.stats.avgSessionMinutes ?? null,
+        prCount: parsed.harnessData?.stats.prCount ?? null,
+        autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
+        harnessData:
+          (normalizeHarnessData(
+            parsed.harnessData,
+          ) as unknown as Prisma.InputJsonValue) ?? undefined,
+        hiddenHarnessSections: args.hiddenHarnessSections,
+      },
+      select: {
+        id: true,
+        slug: true,
+        authorId: true,
+        isDraft: true,
+      },
+    });
+
+    // Reserved for future projectIds support. Bearer path passes [];
+    // browser path (in Unit 9) will pass real ids and the junction
+    // rows will be created here under the same transaction.
+    if (projectIds.length > 0) {
+      const owned = await tx.project.findMany({
+        where: { id: { in: projectIds }, userId },
+        select: { id: true },
+      });
+      const ownedSet = new Set(owned.map((p) => p.id));
+      const validIds = projectIds.filter((id) => ownedSet.has(id));
+      if (validIds.length > 0) {
+        await tx.reportProject.createMany({
+          data: validIds.map((pid, i) => ({
+            reportId: row.id,
+            projectId: pid,
+            position: i,
+          })),
+          skipDuplicates: true,
+        });
+      }
+    }
+
+    return row;
+  });
+
+  return created;
+}


### PR DESCRIPTION
## Summary

Implements Units 6 and 7 of [the tokenized direct-POST plan](docs/plans/2026-04-22-001-feat-tokenized-direct-post-plan.md):

- **Unit 6** — `POST/DELETE /api/harness-tokens`: session-only mint and revoke endpoints. Mint enforces the 10/24h cap with both a soft pre-check (accurate `Retry-After`) and a hard in-transaction cap protected by `pg_try_advisory_xact_lock` (concurrent bursts cannot exceed the cap, and overlapping POSTs surface `MintConflictError` → 409 instead of silently revoking the winner).
- **Unit 7** — bearer-auth direct-POST on `POST /api/upload`: branches on `Content-Type`. Multipart browser flow is unchanged. The new bearer path: authenticate → validate `X-Upload-Id` UUID → `findIdempotentResult` (R14a — replays beat the rate limit) → `checkUploadRateLimit` → byte-size cap → `looksLikeHtml` + `parseUploadHtml` + `hasParsedContent` content gate → `withIdempotency(publishReport)` → structured `logHarnessRequest` on every terminal response.
- **Decision 10** — extracted `src/lib/publish-report.ts` (scoped to bearer-path needs for now; Unit 9 will widen). Bearer drafts are created with `isDraft: true`, empty `redactions` and `projectIds` (user redacts/links projects on the edit page).

## Architectural decisions made during implementation

- `mintTokenForUser` now uses `pg_try_advisory_xact_lock` keyed by `mint:<userId>` to serialize the in-tx cap check and surface concurrent overlaps as `MintConflictError` (409). Wave 2's signature added a new `MintRateLimitError` so the route can distinguish "cap exceeded" (429) from "active mint in flight" (409).
- `recordFailure` falls back to a synthetic `uploadId` on P2002 so retries of an already-failed `(userId, uploadId)` still increment the 60/24h attempt counter.
- Body size cap measured via `arrayBuffer().byteLength` (UTF-8 bytes) rather than `string.length` (UTF-16 units) so multibyte HTML cannot bypass it.
- Pre-parse `looksLikeHtml` + post-parse `hasParsedContent` gate prevents `{}` and other non-HTML bodies from landing as junk drafts.

## Codex review verdicts per commit

| Commit  | Subject                                                                          | Codex outcome                              |
| ------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
| c545176 | feat(harness): add /api/harness-tokens mint + revoke endpoints                   | P1 + 2× P2 — fixed in 0a1b985             |
| 0a1b985 | fix(harness): atomic mint cap + structured 5xx                                   | P1 (race) — fixed in 63bb760              |
| 63bb760 | fix(harness): serialize mint cap with pg_advisory_xact_lock                      | P1 (silent revocation) — fixed in 5910b39 |
| 5910b39 | fix(harness): detect recent active token, restore MintConflictError path         | P2 (createdAt skew) — fixed in 8cf6be7    |
| 8cf6be7 | fix(harness): switch to pg_try_advisory_xact_lock                                | 3-round limit hit — see below             |
| 79b9b1d | feat(harness): bearer-auth direct-POST upload + publishReport helper             | 2× P1 + P2 — fixed in 995564f             |
| 995564f | fix(harness): tighter bearer-path validation + UTF-8 byte-size cap               | P1 (Content-Type spoofable) — fixed in c899d55 |
| c899d55 | fix(harness): reject non-HTML bodies before they land as junk drafts             | P2 (substring spoofable) — fixed in 1d52c7d |
| 1d52c7d | fix(harness): post-parse content check rejects parses-to-empty reports           | 3-round limit hit — see below             |

## Remaining codex findings (3-round limit hit)

**Unit 6 (8cf6be7) — surfaced and not fixed:**

- [P1] Cross-user advisory-lock collision: `hashtext()` is 32-bit. Two unrelated users whose ids happen to hash-collide would see one of them get a spurious 409 under concurrent mints. Mitigation requires either a wider key (encode userId into 64-bit `pg_try_advisory_xact_lock(int8)`) or a row-level lock. Deferred — collision probability is ~1/4B per cross-user pair, well below the user-visible noise floor for an anti-abuse surface that is allowed to false-positive.
- [P1] Post-commit silent revocation: if a duplicate POST arrives just AFTER the winner commits and releases the lock, the loser's `try_advisory_xact_lock` succeeds and proceeds to revoke the winner's freshly-issued token. The 5s freshness check would have caught this but was rejected last round as brittle vs. commit-time skew. Net outcome: this is a correctness gap for retries that land in the few-ms window after commit. The only robust fix is server-side de-duplication keyed by request id, which is out of scope for Wave 3b.

**Unit 7 (1d52c7d) — none surfaced after fix.**

## Test plan

- [ ] Manual: mint a token via session, post HTML to `/api/upload` with `Authorization: Bearer ih_...` and `X-Upload-Id: <uuid>`, verify 200 + draft created with `isDraft: true`.
- [ ] Manual: re-post with the same `X-Upload-Id` → 200, `replayed: true`, same slug.
- [ ] Manual: post `{}` with octet-stream + valid bearer + valid `X-Upload-Id` → 400, no draft.
- [ ] Manual: post 11+ mints in 24h → second mint at cap returns 429 with `Retry-After`.
- [ ] Manual: revoked token → 401, no `HarnessUpload` row written.
- [ ] Automated: `npx vitest run` (651 passing).
- [ ] Automated: `npx tsc --noEmit` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)