### PR TITLE
fix(domain): correct insightful.com -> insightharness.com

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -896,7 +896,7 @@ function TokenizedFlow({
           Run one command — your profile shows up here
         </h1>
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-          The skill posts your report straight to insightful.com, and we
+          The skill posts your report straight to insightharness.com, and we
           redirect you to the edit page when it lands.
         </p>
       </div>


### PR DESCRIPTION
The production domain is insightharness.com (insightful.com doesn't resolve). One user-facing string in the upload page hero copy still referenced the wrong host — this was the last reference in the insightful repo.

Codex flagged this on the parallel insight-harness PR (#18) and the agent noted it as a follow-up; fixing here in both repos in tandem so the smoke test works end-to-end.

## Verification

- `grep -rn "insightful\.com" src/ docs/` returns no hits after this change.
- The matching fix in the insight-harness repo is on PR https://github.com/kabirdos/insight-harness/pull/18 (commit `1200dc9`), which also corrects the skill's `PUBLISH_DEFAULT_BASE_URL` so the direct-POST flow targets the live host.

## Codex review

Single commit reviewed: clean. "Only updates a user-facing domain string... no correctness, security, performance, or maintainability issues introduced."