### PR TITLE
fix(upload): host-qualified editUrl in bearer-auth response

### DIFF
--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -402,7 +402,12 @@ describe("POST /api/upload — bearer idempotency", () => {
       uploadId: VALID_UUID,
       status: "draft",
     });
-    expect(body.editUrl).toBe("/insights/alice/20260421-prior/edit");
+    // editUrl is host-qualified so the skill can print/clipboard it
+    // directly. AUTH_URL is unset in this test, so the route falls
+    // back to the incoming request's origin (`http://localhost`).
+    expect(body.editUrl).toBe(
+      "http://localhost/insights/alice/20260421-prior/edit",
+    );
     // CRITICAL: no rate-limit check on replays (R14a).
     expect(mockUploadLimit).not.toHaveBeenCalled();
     expect(mockPublish).not.toHaveBeenCalled();
@@ -489,7 +494,9 @@ describe("POST /api/upload — bearer happy path", () => {
       status: "draft",
       replayed: false,
     });
-    expect(body.editUrl).toBe("/insights/alice/20260421-abc123/edit");
+    expect(body.editUrl).toBe(
+      "http://localhost/insights/alice/20260421-abc123/edit",
+    );
     // publishReport called with isDraft:true, redactions/projectIds
     // empty (the user redacts on the edit page).
     expect(mockPublish).toHaveBeenCalledWith(
@@ -515,6 +522,38 @@ describe("POST /api/upload — bearer happy path", () => {
     // Selector is logged in 8-char trimmed form, never the full 12.
     const logArg = mockLog.mock.calls.at(-1)?.[0];
     expect(logArg.tokenSelectorPrefix.length).toBe(8);
+  });
+
+  it("uses AUTH_URL as the editUrl origin when set (production canonical host)", async () => {
+    // In production AUTH_URL is set to the canonical app origin
+    // (e.g. https://insightharness.com). buildAbsoluteEditUrl prefers
+    // it over the incoming request's origin so deployments behind
+    // proxies or with custom domains still return the user-facing URL.
+    vi.stubEnv("AUTH_URL", "https://insightharness.com");
+    try {
+      const response = await uploadPOST(bearerRequest());
+      const body = await response.json();
+      expect(body.editUrl).toBe(
+        "https://insightharness.com/insights/alice/20260421-abc123/edit",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("strips a trailing slash from AUTH_URL before joining", async () => {
+    // AUTH_URL is commonly stored with a trailing slash; the join must
+    // not produce a double-slash in the resulting editUrl.
+    vi.stubEnv("AUTH_URL", "https://insightharness.com/");
+    try {
+      const response = await uploadPOST(bearerRequest());
+      const body = await response.json();
+      expect(body.editUrl).toBe(
+        "https://insightharness.com/insights/alice/20260421-abc123/edit",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 });
 

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -393,21 +393,28 @@ describe("POST /api/upload — bearer idempotency", () => {
   it("short-circuits with replayed:true on a prior successful uploadId", async () => {
     mockFindIdempotent.mockResolvedValue({ slug: "20260421-prior" });
 
-    const response = await uploadPOST(bearerRequest());
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body).toMatchObject({
-      replayed: true,
-      slug: "20260421-prior",
-      uploadId: VALID_UUID,
-      status: "draft",
-    });
-    // editUrl is host-qualified so the skill can print/clipboard it
-    // directly. AUTH_URL is unset in this test, so the route falls
-    // back to the incoming request's origin (`http://localhost`).
-    expect(body.editUrl).toBe(
-      "http://localhost/insights/alice/20260421-prior/edit",
-    );
+    // Explicitly clear AUTH_URL so this assertion is hermetic
+    // regardless of ambient env (CI may set AUTH_URL globally). With
+    // AUTH_URL unset the route falls back to the request's origin.
+    vi.stubEnv("AUTH_URL", "");
+    try {
+      const response = await uploadPOST(bearerRequest());
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toMatchObject({
+        replayed: true,
+        slug: "20260421-prior",
+        uploadId: VALID_UUID,
+        status: "draft",
+      });
+      // editUrl is host-qualified so the skill can print/clipboard it
+      // directly.
+      expect(body.editUrl).toBe(
+        "http://localhost/insights/alice/20260421-prior/edit",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
     // CRITICAL: no rate-limit check on replays (R14a).
     expect(mockUploadLimit).not.toHaveBeenCalled();
     expect(mockPublish).not.toHaveBeenCalled();
@@ -485,18 +492,27 @@ describe("POST /api/upload — bearer rate limit", () => {
 
 describe("POST /api/upload — bearer happy path", () => {
   it("parses, publishes a draft, and returns editUrl + slug + uploadId + status", async () => {
-    const response = await uploadPOST(bearerRequest());
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body).toMatchObject({
-      slug: "20260421-abc123",
-      uploadId: VALID_UUID,
-      status: "draft",
-      replayed: false,
-    });
-    expect(body.editUrl).toBe(
-      "http://localhost/insights/alice/20260421-abc123/edit",
-    );
+    // Clear AUTH_URL so the editUrl assertion exercises the
+    // request-origin fallback path independent of ambient env.
+    vi.stubEnv("AUTH_URL", "");
+    let response;
+    let body;
+    try {
+      response = await uploadPOST(bearerRequest());
+      expect(response.status).toBe(200);
+      body = await response.json();
+      expect(body).toMatchObject({
+        slug: "20260421-abc123",
+        uploadId: VALID_UUID,
+        status: "draft",
+        replayed: false,
+      });
+      expect(body.editUrl).toBe(
+        "http://localhost/insights/alice/20260421-abc123/edit",
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
     // publishReport called with isDraft:true, redactions/projectIds
     // empty (the user redacts on the edit page).
     expect(mockPublish).toHaveBeenCalledWith(

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -63,7 +63,10 @@ function buildAbsoluteEditUrl(
   username: string,
   slug: string,
 ): string {
-  const rawOrigin = process.env.AUTH_URL ?? new URL(request.url).origin;
+  // Use `||` not `??` so empty-string env values (common in CI/test
+  // setups where AUTH_URL is stubbed to "") fall through to the
+  // request origin rather than yielding a malformed URL.
+  const rawOrigin = process.env.AUTH_URL || new URL(request.url).origin;
   const origin = rawOrigin.replace(/\/$/, "");
   return `${origin}${buildReportEditUrl(username, slug)}`;
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -46,6 +46,28 @@ const UUID_REGEX =
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB — matches the multipart cap.
 
+/**
+ * Build a fully-qualified edit URL for serialization to the skill.
+ *
+ * The skill prints this string verbatim to its terminal and copies it to
+ * the user's clipboard, so it must be directly clickable / paste-into-
+ * browser-able. `buildReportEditUrl` returns a path-only URL (correct for
+ * in-app `router.push`), so we host-qualify it here.
+ *
+ * Prefers `AUTH_URL` (NextAuth's canonical origin, set in production).
+ * Falls back to the request's own origin for dev / preview deployments
+ * where `AUTH_URL` may not be set.
+ */
+function buildAbsoluteEditUrl(
+  request: Request,
+  username: string,
+  slug: string,
+): string {
+  const rawOrigin = process.env.AUTH_URL ?? new URL(request.url).origin;
+  const origin = rawOrigin.replace(/\/$/, "");
+  return `${origin}${buildReportEditUrl(username, slug)}`;
+}
+
 /** Synthetic upload id used when the request lacks a valid X-Upload-Id.
  *  Prefixed so it can never collide with a real client UUID, and we
  *  still record a HarnessUpload row for rate-limit accounting. */
@@ -431,7 +453,7 @@ async function handleBearer(request: Request): Promise<NextResponse> {
       durationMs: Date.now() - startedAt,
     });
     return NextResponse.json({
-      editUrl: buildReportEditUrl(username, replay.slug),
+      editUrl: buildAbsoluteEditUrl(request, username, replay.slug),
       slug: replay.slug,
       uploadId,
       status: "draft",
@@ -593,7 +615,7 @@ async function handleBearer(request: Request): Promise<NextResponse> {
     durationMs: Date.now() - startedAt,
   });
   return NextResponse.json({
-    editUrl: buildReportEditUrl(username, result.slug),
+    editUrl: buildAbsoluteEditUrl(request, username, result.slug),
     slug: result.slug,
     uploadId,
     status: "draft",


### PR DESCRIPTION
The skill's first end-to-end smoke test against production revealed that `POST /api/upload` (bearer path) returns a path-only `editUrl` (e.g. `/insights/alice/abc123/edit`). The skill prints this verbatim and copies it to the clipboard, so users get a non-clickable string.

## Fix

New `buildAbsoluteEditUrl(request, username, slug)` helper in `src/app/api/upload/route.ts`. Prefers `AUTH_URL` (production canonical origin) and falls back to the incoming request's origin for dev/preview. Used in both the idempotent-replay response (line ~456) and the fresh-publish response (line ~618). `buildReportEditUrl` is unchanged — it's still path-only and still correct for in-app `router.push`.

## Tests

3 tests covering:
- Request-origin fallback when `AUTH_URL` is unset (hermetic via `vi.stubEnv("AUTH_URL", "")`)
- `AUTH_URL` precedence when set
- Trailing-slash on `AUTH_URL` is stripped

## Codex review

Two rounds. Round 1 caught a real bug: my fallback tests failed under any environment that had `AUTH_URL` set (CI, codex sandbox). Fixed by switching `??` → `||` so empty-string stubs trigger fallback, and wrapping the assertions in `vi.stubEnv("AUTH_URL", "")` / `vi.unstubAllEnvs()`. Round 2 clean.

Paired with a matching defensive fix in the insight-harness skill repo (PR forthcoming) so the skill ALSO host-qualifies any relative URL it receives — belt-and-suspenders for future regressions.