### PR TITLE
docs: Codex extractor Phase 1 brainstorm + plan

### DIFF
--- a/docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md
+++ b/docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md
@@ -1,0 +1,176 @@
+---
+date: 2026-05-25
+topic: codex-extractor-multiagent
+---
+
+# Codex Extractor & Multi-Agent Harness Profile
+
+## Problem Frame
+
+Insightful's `insight-harness` skill today profiles exactly one tool: Claude Code. It reads `~/.claude/`, scrubs PII, and publishes a "harness profile" (skills, hooks, plugins, tool usage, tokens, workflow patterns) to insightharness.com. That artifact answers _"what does this person's Claude Code setup look like?"_
+
+The product owner wants to expand the lens from **one tool** to **how a person works across tools** — starting with OpenAI Codex, which the author already uses heavily (267 Codex sessions in the trailing 30 days, 36 active days since 2026-04-01). The strategic bet: **"how this person works across agents" is more differentiating recruiting content than any single-tool profile.** The audience is public AI power-users we want to recruit to publish profiles; a multi-agent profile is a stronger flex and a harder thing to fake.
+
+**This is a positioning shift, not just a parser.** Today the profile's implicit claim is "Claude Code mastery." A multi-agent profile claims "AI-native operator across the ecosystem." That reframes the page, the outreach pitch, and the agent-consumable payload (see `2026-04-28-agent-consumable-harness-report-requirements.md`).
+
+### The honest limit: only LOCAL data is visible
+
+This is the single most important constraint and it must be stated on the artifact itself (the 2026-04-09 prototype already did this for tokens — we extend the principle):
+
+- **Codex CLI / `codex exec` — yes.** Writes to `~/.codex/` exactly like Claude Code writes to `~/.claude/`. Fully local, fully parseable.
+- **Codex desktop app (Electron) — recency/presence only.** Storage lives in `~/Library/Application Support/Codex/` as Chromium SQLite/LevelDB blobs (Cookies, Session Storage, IndexedDB). It is actively used (1,406 files modified in the trailing 5 days; most-recent mtime is today). But the content is opaque Electron storage — we can detect _that_ the desktop app is in use and _how recently_, not _what_ was done. Parsing message content is out of scope and likely a moving target across app versions.
+- **Codex mobile / web / Cowork — invisible.** Server-side; nothing lands locally. We cannot detect it at all.
+
+The profile therefore measures **the locally-visible surface of a person's agent usage**, not their total agent usage. The artifact must say so plainly, or it over-claims. A user who does most Codex work on mobile would show a thin Codex profile that misrepresents them.
+
+## Decisions (resolved in 2026-05-25 brainstorm)
+
+- **D1 — Artifact shape: one profile, tool-partitioned (Option C).** Not separate reports. Both tools' data lives in one report at one URL, viewed through a tool selector/tabs. **Why:** same-tool-to-same-tool agent learning — a consumer's Claude agent learns from the author's Claude slice, a consumer's Codex agent from the Codex slice; the slices must never cross. This makes the agent-consumable payload a tool-keyed map from day one.
+- **D2 — Scope: Claude Code + Codex only (not generic N-tool).** Build a clean two-tool shape; generalize to N tools later only if a third tool actually arrives (YAGNI). The `tools`-keyed structure stays forward-compatible without building generic multi-tool machinery now. (Note: coarse _presence detection_ of other tools — Gemini CLI, Cursor, Copilot, Factory — already ships via Work Surfaces; that is presence-pills only, not a full profile.)
+- **D3 — Thin-tool handling: show + "local CLI only" caveat, with an activity floor.** Always label a tool's data honestly ("local CLI data only — may use Codex more elsewhere"); hide a tab only below a minimal activity floor so a near-empty profile is never presented as someone's whole Codex story. **Why:** credibility for the public-author audience while preserving the cross-tool signal.
+- **D4 — Codex skills: inventory only, no usage count.** Codex loads skills into context (no discrete invocation event), so a per-skill "calls" count has no clean signal. Show which Codex skills the author has (name, description, install pointer); ship no fabricated count.
+- **D5 — Safety: per-tool section.** Each tool renders its native mechanism under a "Safety & Automation" heading inside its own profile: Claude → hooks + fire frequencies; Codex → rules allowlist + `approval_policy` + `sandbox_policy`. No forced cross-tool unification.
+- **D6 — Codex desktop app: presence + recency only.** Detect that the desktop app is in use and how recently; never parse Electron storage content.
+- **D7 — Ship Codex token totals.** Use `payload.token_count.info.total_token_usage` (now reliable); retire the stale April "no tokens" disclaimer. Note in the publish disclosure that reasoning-spend (`reasoning_output_tokens`, `effort`) is now visible.
+
+## Existing-Prototype Findings
+
+**There is no dedicated Codex-extractor script anywhere.** Searched the `insight-harness` repo, `~/Coding/claude-toolkit` (skills source-of-truth), `~/.codex`, and `~/Coding` broadly. What exists:
+
+1. **The 2026-04-09 HTML artifact** (`~/.codex/usage-data/insight-harness-codex-20260409-000327.html`, 33 KB). A complete, polished Codex profile page covering: Tool Usage, CLI Commands, Skills, Plugins, Agent Dispatch, Environment, Session Shape, MCP and Runtime, Project Ecosystem, Workflow Phases, Skill Workflow. Subtitle: _"79 sessions across 11 active days | 2026-03-12 to 2026-04-09."_ It carries a disclaimer: _"Codex session logs currently do not expose reliable token totals, so this report intentionally omits token usage claims."_ This is **a one-off output, not committed code** — the generator that produced it was not saved (or was discarded). So the work is **building on a design spike, not greenfield**: the section taxonomy and the honest-limit framing are already proven; the parser is not.
+
+2. **Coarse tool presence-detection already ships** in the Claude extractor (`skills/insight-harness/scripts/extract.py`). As of the Work Surfaces change (PR #22), this is `detect_agent_tools()` — directory presence + mtime for Codex CLI, Codex desktop, Cursor, Claude desktop, Gemini CLI, Copilot, and Factory (it superseded the older text-scanning `extract_hybrid_tools()`). This is the seam the multi-agent work plugs into — presence-detection already ships; the depth is what's missing.
+
+**Material change since April:** the 2026-04-09 disclaimer is now **stale**. Codex session logs _do_ expose reliable token totals today — `payload.token_count.info.total_token_usage` carries `{input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens}` as a cumulative-per-session counter. A new extractor should ship token stats (and must not blindly copy the old disclaimer). Confirmed on a real session: cumulative `total_tokens` of 433,312 across 14 `token_count` records in one rollout file.
+
+## Codex Data Inventory
+
+Verified against real data in `~/.codex`. Structural mirror of `~/.claude` confirmed.
+
+### Directory layout (mirrors `~/.claude`)
+
+- `sessions/YYYY/MM/DD/rollout-*.jsonl` — per-session event logs (545 total; 267 in trailing 30d). **The richest source.**
+- `skills/` — 21 skill directories, each with `SKILL.md` using **the same `name:`/`description:` frontmatter** as Claude skills. Same `parse_skill_frontmatter()` works unchanged.
+- `plugins/` — plugin cache (config lists `github`, `gmail`, `slack`, `computer-use`, `google-calendar`, `google-drive`, `granola`, `documents`, `spreadsheets`, `presentations`, `browser` from `openai-curated`/`openai-bundled`/`openai-primary-runtime` marketplaces).
+- `rules/default.rules` — Codex's permission-allowlist equivalent: `prefix_rule(pattern=[...], decision="allow")` lines. **Contains absolute OS-username paths and full shell commands — a scrub surface** (e.g. `pattern=["open", "/Users/craigdossantos/..."]`, and one rule embeds a Vercel bearer-token curl).
+- `memories/` — present but empty in this install.
+- `config.toml` — model, reasoning effort, per-project `trust_level` (keyed by **absolute project paths** → scrub surface), enabled plugins, marketplaces, feature flags (`multi_agent`, `js_repl`).
+- `history.jsonl` — keys `{session_id, text, ts}`. `text` is raw prompt content → **do not read `text`** (PII/content).
+- `session_index.jsonl` — keys `{id, thread_name, updated_at}`. `thread_name` may leak project/feature names → treat as content.
+- `version.json` — `{latest_version, last_checked_at, dismissed_version}`.
+- `sqlite/`, `logs_2.sqlite`, `state_5.sqlite`, `goals_*.sqlite` — Codex internal DBs; not yet characterized, likely lower-value and higher-risk than the JSONL. Out of scope for v1.
+
+### Rollout JSONL schema (the core)
+
+Each line: `{timestamp, type, payload}`. `type` ∈ `{session_meta, event_msg, response_item, turn_context}`. `payload.type` breakdown (one session): `function_call`, `function_call_output`, `token_count`, `reasoning`, `message`, `agent_message`, `task_started`, `task_complete`, `user_message`, plus the `session_meta` header.
+
+High-value, **safe-to-read** fields:
+
+- **`session_meta`** → `id`, `timestamp`, `cli_version`, `originator` (`codex_exec`), `model_provider`, `model`, `personality`, `effort`, `approval_policy`, `sandbox_policy`, `collaboration_mode`, `source.subagent` (e.g. `"review"`). **`cwd` and `git.{commit_hash, branch, repository_url}` are present but are scrub surfaces** — `repository_url` populated 5/5 in the sample (carries GitHub owner/repo).
+- **`function_call.name`** → the tool taxonomy. Real distribution (May sessions): `exec_command` (1,727), `write_stdin` (49), `shell_command` (97 in wider sample), `update_plan` (6–27), `spawn_agent`/`wait_agent`/`close_agent` (sub-agent lifecycle), `view_image`, `press_key`/`click`/`set_value`/`get_app_state`/`list_apps` (computer-use), plus MCP-style `_list_meetings`/`_get_meetings` (Granola). **Tool _name_ is safe; `arguments` is not** (carries `cmd`, `workdir` → content + paths).
+- **`token_count.info.total_token_usage`** → `{input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens, total_tokens}`. Cumulative per session. **Strategy: take the last record per rollout file, sum across files for the 30d total.**
+- **`function_call.arguments.cmd`** → for the CLI-command breakdown, the _first token only_ via the existing `extract_safe_command_name()` normalizer (never the full command). This is the Codex analog of the Bash-first-token rule.
+
+### Mapping to the existing Claude `harnessData` shape
+
+| Claude profile field                        | Codex source                                                                                                                                                                                                                                                                                                | Maps cleanly?                                                                                   |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `skillInventory` (name/desc/README/hero)    | `~/.codex/skills/*/SKILL.md` (21) — same frontmatter                                                                                                                                                                                                                                                        | **Yes** — `parse_skill_frontmatter()` + showcase pipeline reusable as-is                        |
+| `skillInvocations` (counts)                 | **Hard.** Codex has no `Skill` tool-call; skills load into context, not via a discrete invocation event. Best proxy: skill-dir references in exec/session content (noisy — a directory-listing inflates every skill to a flat baseline; `code-review` 25 / `codex-primary-runtime` 18 stood out as genuine) | **Partial / divergent**                                                                         |
+| `toolUsage`                                 | `function_call.name` counts                                                                                                                                                                                                                                                                                 | **Yes**, but a _different tool universe_ (exec/shell/plan/agent-lifecycle, not Read/Edit/Write) |
+| `cliTools` (Bash first-token)               | `exec_command`/`shell_command` `arguments.cmd` first-token                                                                                                                                                                                                                                                  | **Yes** — reuse `extract_safe_command_name()`                                                   |
+| token totals (`perModelTokens`, throughput) | `token_count.info` (now available!)                                                                                                                                                                                                                                                                         | **Yes** — richer than April thought; adds `reasoning_output_tokens` (Codex-specific)            |
+| `agentDispatch` (sub-agents)                | `spawn_agent`/`wait_agent`/`close_agent` + `session_meta.source.subagent`                                                                                                                                                                                                                                   | **Yes**, different mechanism (no `subagent_type`/`model` the way Claude's Agent tool carries)   |
+| `hookDefinitions`                           | **No Codex equivalent.** Codex has `rules/default.rules` (prefix allowlist), not lifecycle hooks                                                                                                                                                                                                            | **Diverges** — map to a "permission rules" concept instead                                      |
+| `plugins`, `mcpServers`                     | `config.toml` `[plugins.*]` + MCP-style `_`-prefixed function calls                                                                                                                                                                                                                                         | **Yes**                                                                                         |
+| `permissionModes`                           | `session_meta.approval_policy` + `sandbox_policy` + `rules/default.rules`                                                                                                                                                                                                                                   | **Diverges** — Codex model is approval-policy + sandbox, not Claude's permission modes          |
+| `workflowData` (phases, transitions)        | Derivable from `function_call.name` sequences via the same phase classifier (re-mapped: `exec_command`→needs sub-classification by cmd token)                                                                                                                                                               | **Partial** — phase classifier needs Codex-aware tool→phase mapping                             |
+| `versions`, `models`, `entrypoints`         | `session_meta.cli_version`/`model`/`originator`                                                                                                                                                                                                                                                             | **Yes**                                                                                         |
+| session count / active days / duration      | rollout file timestamps + `session_meta`                                                                                                                                                                                                                                                                    | **Yes**                                                                                         |
+
+**Codex-specific fields with no Claude analog** (net-new, and part of the differentiation): `reasoning_output_tokens`, `effort` (reasoning-effort setting), `personality`, `collaboration_mode`, `sandbox_policy`, the `spawn_agent`/`wait_agent` parallel-agent lifecycle, and computer-use tool calls (`click`/`press_key`/`get_app_state`).
+
+## Product / Architecture Options
+
+Three shapes for how Codex data reaches insightharness.com. They differ in scope, schema risk, and how much they touch the existing upload/publish flow (`src/app/api/upload/route.ts` → `harnessData` JSON → `/insights/[username]/[slug]`).
+
+### Option A — Separate Codex report (parallel artifact)
+
+A standalone `insight-harness-codex` extractor emits its own HTML + JSON island; uploads as a _distinct_ `InsightReport` with a `tool: "codex"` discriminator. Two reports per user, two URLs.
+
+- **Pros:** lowest coupling; ships fast; the 2026-04-09 artifact already proves the standalone page design; no risk to the working Claude pipeline; per-tool schema can diverge freely.
+- **Cons:** doesn't deliver the "how they work across tools" story in one glance — a reviewer must visit two pages; duplicated nav/upload UX; the cross-tool _comparison_ (the actual differentiator) lives in neither report.
+
+### Option B — Combined multi-tool profile (one artifact, both tools)
+
+One extractor run produces a single profile with a `tools: ["claude-code", "codex"]` array; the page renders side-by-side or unified sections. One `InsightReport`, one URL.
+
+- **Pros:** delivers the strategic story directly ("here's me across both tools"); enables cross-tool stats ("60% of shipping happens in Codex, 80% of brainstorming in Claude"); one publish flow.
+- **Cons:** biggest schema change to `harnessData` (must stay backward-compatible — CLAUDE.md invariant: preserve the existing JSON shape); the extractor must run on machines where one tool may be absent; harder to reason about "thin Codex, rich Claude" asymmetry without misleading the reader.
+
+### Option C — Tool-selector on one page (combined storage, tabbed view)
+
+Store both tools' data in one report (as Option B) but render a tool **selector/tab** so each tool's profile is viewed independently, with an optional "Combined" tab for cross-tool stats. One URL, progressive disclosure.
+
+- **Pros:** gets Option B's single-artifact + cross-tool upside while sidestepping the "how do I lay out two tools at once" design problem; degrades gracefully when a tool is thin/absent (hide its tab); matches how the agent-consumable payload would want it (a `tools` map keyed by tool name).
+- **Cons:** still the Option B schema lift; tabbed UI is more front-end work than a second static page.
+
+### Relationship to the agent-consumable payload work
+
+The `2026-04-28` brainstorm freezes a `harness-agent-payload` JSON contract with `schema_version`. **A multi-agent profile must shape that contract from day one**, or we freeze a Claude-only schema and re-break it. The clean shape is a top-level `tools` map: `{ "claude-code": {...}, "codex": {...}, "_cross_tool": {...} }`, each tool's object reusing the per-skill/per-tool sub-schemas. Phase 0 findings (`phase0-results-2026-05-23.md`) apply to Codex too: F1 (drop hero blobs from the agent payload), F2 (guarantee a minimum field set per tool), F4 (structured install pointers) — and Codex's skill-invocation gap is a _new_ instance of F3 (the highest-signal item is the most opaque).
+
+## Privacy / Threat Model (mirror the existing scrub posture)
+
+The existing Claude extractor's posture (`SKILL.md`, `extract.py`): **strict field whitelist; never read tool arguments, message text, tool results, or project file paths; scrub git name/email, OS-username paths, GitHub URLs, and `@you` mentions; exclude `repo: private`/`none` skills entirely.** Codex inherits this verbatim, plus Codex-specific surfaces:
+
+| Codex surface                                                                                                   | Risk                                                        | Posture                                                                                                                                                               |
+| --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `session_meta.git.repository_url` (5/5 populated)                                                               | GitHub owner/repo → identity                                | Scrub via the existing GitHub-URL rule; do not emit raw                                                                                                               |
+| `session_meta.cwd`, `config.toml` per-project paths, `rules/*.rules` paths                                      | OS-username + project names                                 | Reuse OS-username path scrub; never emit raw absolute paths                                                                                                           |
+| `rules/default.rules` command bodies                                                                            | One sampled rule embeds a **Vercel bearer token** in a curl | **Never read rule command bodies.** Extract only the prefix's first token (the binary name), same as Bash. Treat rule files as a secret-bearing surface — over-redact |
+| `function_call.arguments.cmd` / `.workdir`                                                                      | Full shell commands + paths                                 | Never read except first-token via `extract_safe_command_name()`                                                                                                       |
+| `history.jsonl.text`, `session_index.jsonl.thread_name`, `user_message`, `message.content`, `reasoning.content` | Raw prompt/response content                                 | **Never read.** Not whitelisted                                                                                                                                       |
+| Codex `skills/*/README.md` + heroes                                                                             | Same as Claude showcase                                     | Same two-pass owner-aware scrub + PNG/JPEG magic-byte check + per-skill caps; honor `repo: private/none`                                                              |
+| Codex desktop Electron storage                                                                                  | Opaque, version-volatile                                    | Read **presence + mtime only**; never parse blobs                                                                                                                     |
+
+**Threat carryover from `2026-04-28`:** combinatorial fingerprinting gets _stronger_ with a second tool's data union (accept + disclose at publish time); prompt-injection-as-data now has a second author-controlled corpus (Codex READMEs/descriptions) — namespace free-text the same way. **New:** the `reasoning_output_tokens` and `effort` fields reveal model-tier/reasoning-spend patterns; harmless but note in the disclosure that reasoning-spend is now visible.
+
+## Scope Boundaries
+
+**In scope (v1 candidate):**
+
+- A Codex extractor (`extract.py` analog) reading `~/.codex/{sessions,skills,plugins,rules,config.toml,version.json}`, reusing the existing PII-scrub, field-whitelist, skill-frontmatter parser, command-name normalizer, and showcase pipeline.
+- Codex token totals (correcting the stale April disclaimer).
+- Codex-aware tool→phase classification.
+- Presence + recency detection for the Codex desktop app (no content).
+- A clear on-artifact "local-data-only" limit statement.
+
+**Not in scope (v1):**
+
+- Parsing Codex desktop Electron storage content.
+- Parsing `~/.codex/*.sqlite` internal DBs.
+- Mobile/web/Cowork detection (impossible locally).
+- Reading any content field (`text`, `thread_name`, `cmd`, `message.content`, `reasoning`).
+- A full combined-page redesign (depends on the option chosen below).
+
+**Explicitly deferred:** cross-tool comparison stats (the `_cross_tool` payload block) — high value but should follow once single-tool Codex data is validated.
+
+## Recommended Phased Approach
+
+**Phase 1 — Codex extractor, standalone output (Option A as the parser foundation).** Build the Codex extractor mirroring `extract.py`'s structure and privacy posture. Emit a standalone Codex profile (the 2026-04-09 artifact is the design reference) _and_ a `harness-data`-style JSON island shaped as a per-tool object so it's forward-compatible with a `tools` map. Validate the data is accurate and the scrub holds before touching the publish schema. Low risk to the working Claude pipeline.
+
+**Phase 2 — Combined storage + tool selector (Option C).** Extend `harnessData` to a `tools` map (backward-compatible — Claude data stays at its current keys or moves behind `tools["claude-code"]` with a compatibility shim), add a tool selector to `/insights/[username]/[slug]`, and gate each tab on data presence so "thin Codex" hides rather than misleads. This is the artifact that delivers the strategic "across tools" story.
+
+**Phase 3 — Cross-tool stats + agent payload.** Add the `_cross_tool` block (which tool owns which workflow phase, relative token spend, skill overlap) and fold the whole `tools` map into the `harness-agent-payload` contract from the `2026-04-28` brainstorm, applying the Phase 0 F1–F8 fixes per tool.
+
+**Rationale for A→C→cross-tool rather than straight to B:** Option C is the right _end_ shape, but jumping there before the Codex parser is proven means designing a combined UI around data we haven't validated. Phase 1 de-risks the parser and the scrub; Phase 2 commits the schema once; Phase 3 adds the differentiating layer. Each phase ships independently and is revertible — matching the repo's one-atomic-change-per-PR norm.
+
+## Outstanding Questions
+
+The strategic and product questions are resolved in **Decisions (D1–D7)** above. What remains is technical and belongs in planning.
+
+### Deferred to Planning
+
+- **[Affects D4][Needs research]** Is there a reliable Codex skill-usage signal in `~/.codex/sqlite` or the logs? If found, D4's inventory-only view can add counts later; if not, inventory-only stands. Investigate during planning rather than blocking the brainstorm.
+- **[Affects D1/D2][Technical]** Backward-compatibility shim for the existing `harnessData` JSON shape when introducing the `tools` map. CLAUDE.md invariant requires preserving the current column shape — decide whether Claude data stays at its current top-level keys with a `tools["claude-code"]` alias, or moves with a compatibility read-shim. Migration approach → planning.
+- **[Affects schema][Technical]** Where the per-tool sub-schema lives relative to the `2026-04-28` `harness-agent-payload` contract, and how the Claude and Codex per-tool schemas stay aligned (shared `schema_version`, F2 minimum-field-set guarantee per tool). Resolve when the agent-payload contract is implemented.

--- a/docs/plans/2026-05-25-001-feat-codex-extractor-phase1-plan.md
+++ b/docs/plans/2026-05-25-001-feat-codex-extractor-phase1-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Codex extractor (Phase 1 — standalone profile)"
 type: feat
-status: active
+status: completed
 date: 2026-05-25
 deepened: 2026-05-26
 origin: docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md

--- a/docs/plans/2026-05-25-001-feat-codex-extractor-phase1-plan.md
+++ b/docs/plans/2026-05-25-001-feat-codex-extractor-phase1-plan.md
@@ -1,0 +1,306 @@
+---
+title: "feat: Codex extractor (Phase 1 — standalone profile)"
+type: feat
+status: active
+date: 2026-05-25
+deepened: 2026-05-26
+origin: docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md
+---
+
+# feat: Codex Extractor — Phase 1 (Standalone Profile)
+
+**Target repo:** `insight-harness` (`/Users/craigdossantos/Coding/insight-harness`). Code paths are relative to that repo; the mirrored file is `skills/insight-harness/scripts/extract.py`. This plan lives in the `insightful` repo per the planning-doc convention.
+
+> **Revised 2026-05-26 after document-review.** Five reviewers inspected the real `~/.codex` tree and falsified several first-draft assumptions about Codex's data formats. The corrections below are grounded in that inspection, not the Claude analogy. Key reversals: token totals are **cumulative-per-session** (not per-line deltas); the token path is `payload.info.total_token_usage`; rollout logs come in **two Codex formats**; `config.toml` uses different safety keys; commands and rules are **structured lists**, not shell strings; and `pii_scrub.py` is identity-only (not a secret detector).
+
+## Overview
+
+Build a standalone OpenAI Codex harness extractor that reads `~/.codex/` and emits its own HTML profile plus a per-tool JSON island, mirroring the Claude extractor's structure and privacy posture **but grounded in Codex's real data shapes**. Phase 1 stops short of publishing or changing the insightharness.com schema — it de-risks the parser and the scrub against real data before any contract is committed (Phases 2/3 handle storage, the tool selector, and the agent payload).
+
+## Problem Frame
+
+`insight-harness` profiles one tool today. The product is shifting to a multi-agent profile where a consumer's Claude agent learns from an author's Claude slice and a consumer's Codex agent from the Codex slice — same-tool-to-same-tool (origin D1). Codex CLI writes local, parseable data to `~/.codex/`; this phase turns that into a profile. Only locally-visible Codex usage is captured (mobile/web/Cowork are server-side and invisible), which the artifact states plainly.
+
+## Requirements Trace
+
+- R1. Produce a standalone Codex profile (HTML) + a per-tool JSON island shaped `{tool: "codex", ...}`. Ship only `tool` as the committed envelope key; `schema_version`/`generated_at` are **provisional** and owned by Phase 2 (origin D1/D2; review: forward-contract is overstated while the Claude island + DB column are deferred).
+- R2. Reuse the existing PII-scrub, skill-frontmatter parser, command-name normalizer, and showcase pipeline where the data shapes match; reimplement only the path-coupled / Codex-shaped parts. Emit Codex skills as **inventory only** — name, description, install pointer; no usage count (origin D3, D4).
+- R3. **Token totals (corrected):** read `payload.info.total_token_usage.total_tokens` on records where `payload.type == "token_count"`. This value is **cumulative within a session** — take the last (max) value per session and **sum across sessions**; do NOT sum per-record (that inflates ~9×). Skip records where `payload.info` is `null` (rate-limit-only records). (origin D7; review ADV-1/ADV-3, feasibility.)
+- R4. **Per-tool safety (corrected):** derive from the real `config.toml` keys — top-level `approvals_reviewer`, per-app `approval_mode` (nested under `[apps...tools.*]`), and per-project `trust_level`. Emit **enum values only**; never emit the `[projects."<absolute-path>"]` section keys (home-dir/project-name leaks) and **never read or emit the `[apps.connector_*]` section key** (the connector UUID — read only the `approval_mode` value beneath it, not the key). Rules: parse the `prefix_rule(pattern=[...])` DSL and emit `pattern[0]` (the binary) **only**; assert no path-like element (`/`, `~`, `/Users/`) ever reaches output. (origin D5; review ADV-4/ADV-5, SEC-2, SEC-6 re-review.)
+- R5. **Positive read-allowlist (corrected from a deny-list):** the parser reads ONLY: `payload.type`, `timestamp`, `payload.info.total_token_usage`, the extracted inner command binary (R6), and whitelisted skill/plugin metadata. Every other field — including all content carriers — is never read. (review SEC-4/SEC-9.)
+- R6. **Command extraction (corrected):** Codex `shell`/`exec` commands live in `function_call.arguments` as a JSON string whose `command` is a **list** like `["bash","-lc","<full cmd>"]`. Parse the JSON, strip the shell-runner wrapper (`bash`/`sh`/`zsh` + `-lc`/`-c`), then run the inner command string through `extract_safe_command_name` to get the first token. Never emit the full command. (review SEC-1.)
+- R7. **Emit-time secret gate (two-tier, to avoid a footgun):** before writing the island or HTML, scan the serialized output. **(a) Known token prefixes** (`sk-`, `Bearer `, `AKIA`, `ghp_`) → **fail loud** (these are unambiguous). **(b) High-entropy heuristic** → **redact-the-offending-field-and-warn**, not abort, AND scope it to the post-allowlist _text_ fields only — explicitly exclude already-budgeted high-entropy content the plan intends to emit (hero-image data URIs from the showcase pipeline, skill IDs, and any hash/UUID values). This is defense-in-depth because `pii_scrub.py` is identity-only and the read-allowlist is otherwise the sole control. **Why two-tier:** a single fail-loud entropy gate would block a benign harness from ever generating a profile (false-positive on legitimate base64/hashes) or get its threshold loosened until it misses real tokens. (review SEC-3; SEC/ADV re-review both flagged the false-positive risk.)
+- R8. **Identity scrubbing:** never emit `session_meta.git.repository_url`, `commit_hash`, `branch`, or `cwd`; never emit MCP/connector identities — normalize `mcp__<server>__<tool>` tool names to a generic bucket (don't reveal connected Gmail/Slack/etc. or connector UUIDs); derive any work-surface signal from path **shape** only. (review SEC-5/SEC-6/SEC-7.)
+- R9. **Dual rollout format:** detect format per file (presence of the `payload` envelope). Count **every** session toward session/timespan totals; extract token/tool detail only from the current `payload`-envelope format; the honest-limit caveat states that detail is available for recent sessions only. (review ADV-2.)
+- R10. **Plugins (corrected):** source the plugin inventory from `config.toml` `[plugins.*]` (name + enabled), not a `~/.codex/plugins` directory walk. (review ADV-6.)
+- R11. **Island ⊆ rendered:** the JSON island must be a subset of fields the HTML renders (no hidden fields); the privacy test scans the **serialized island string**, not the parsed object. (review SEC-8; Phase-0 F1.)
+- R12. Thin local data is shown with a "local CLI only" caveat + an activity floor (threshold chosen at Unit 5 from real session-count distributions) that hides a near-empty profile; the local-only limit is always stated. (origin D3.)
+- R13. Codex desktop app: presence + recency only via the existing `detect_agent_tools` (already covers it); never parse Electron storage. (origin D6.)
+
+## Scope Boundaries
+
+- **No publish/upload, no `harnessData` schema change, no tool selector, no combined page** → Phase 2.
+- **No cross-tool stats** (`_cross_tool`) → Phase 3.
+- **No Electron storage parsing, no `~/.codex/*.sqlite` parsing, no Codex skill usage counts.**
+- **No refactor of the working Claude `extract.py`** beyond importing already-pure helpers (`extract_skill_inventory` and `generate_html` are _reimplemented_ for Codex, not edited in place — see Key Decisions).
+- **No `schema_version`/`generated_at` envelope commitment** (provisional only; Phase 2 owns the real cross-tool contract once it touches the Claude island + DB column).
+
+## Context & Research
+
+### Relevant Code and Patterns (insight-harness repo)
+
+Reusable **as-is** (verified pure, no module-level side effects — import is safe): `pii_scrub.py` (`detect_pii`, `scrub`, `SanitizeError` — **identity-only, NOT a secret detector**), `parse_skill_frontmatter`, `build_skill_meta`, `derive_description_from_body`/`_skill_md_body`, showcase pipeline (`_read_raw_readme`, `_finalize_showcase`, `_read_hero_image`, `_truncate_to_bytes`, `_enforce_showcase_budget`), `extract_safe_command_name` (operates on a bash **string** — only valid after R6 unwrapping), `detect_agent_tools` (already includes Codex CLI + Codex desktop).
+
+Reimplement (path/shape-coupled): `extract_skill_inventory` (Codex roots), `generate_html`/`generate_writeup` (Codex section set + Codex-appropriate prose — **Phase-0 F6: no hardcoded author-specific claims**).
+
+Section map: **map** — Tool Usage, Tool Transitions, Workflow Phases, File Ops, CLI Commands (after R6 unwrapping), Tokens, Work Surfaces. **Inventory-only** — Skills. **Reshape** — Safety. **Skip** — Hooks, Agent Dispatch/Teams, Memory Architecture, Permission Accumulation, /insights tab.
+
+### Institutional Learnings
+
+`docs/solutions/` exists in neither repo. Load-bearing: origin brainstorm + `insightful/docs/brainstorms/phase0-results-2026-05-23.md` — F1 (island can hide leaks the HTML doesn't show → R11), F6 (no hardcoded author prose).
+
+## Key Technical Decisions
+
+- **Reuse via direct import, no shared-module refactor** (verified: helpers are pure, `extract.py` has no import side effects). Keeps the Claude pipeline untouched (Phase 1 low risk). `harness_common.py` extraction deferred (YAGNI).
+- **Tokens are cumulative-per-session:** last-per-session, summed across sessions; correct path `payload.info.total_token_usage`; guard `null` info (R3).
+- **Commands and rules are structured lists, not strings** — dedicated parsing (R4, R6); `extract_safe_command_name` only runs on the unwrapped inner command string.
+- **`pii_scrub` is identity-only** — the positive read-allowlist (R5) is the primary control; the emit-time secret gate (R7) is the backstop.
+- **Plugins from `config.toml`, safety from real config keys** (R10, R4).
+- **Envelope: `tool` only**, rest provisional (R1).
+- **Dual rollout format handled by detection + count-all / detail-from-current** (R9).
+
+## Open Questions
+
+### Resolved During Planning
+
+- Standalone vs integrated? Standalone `codex_extract.py` (origin phasing; low risk).
+- Refactor `extract.py`? No — import pure helpers; reimplement coupled parts.
+- Publish in Phase 1? No — local generation only.
+- Old-format sessions? Count toward totals; detail from current format only; caveat (R9).
+- Output path? `~/.codex/usage-data/` (the 2026-04-09 prototype precedent; keeps Codex artifacts under the Codex root).
+- Secret gate? Yes (R7). Envelope? `tool` only (R1).
+
+### Deferred to Implementation
+
+- The activity-floor threshold value (R12) — pick from real session-count distributions.
+- Exact high-entropy threshold + prefix list for the secret gate (R7) — tune to minimize false positives without missing known token shapes.
+- Whether any current-format token detail is recoverable from old-format sessions (likely none) — confirm during Unit 2.
+
+## High-Level Technical Design
+
+> _Directional guidance for review, not implementation specification._
+
+```
+~/.codex/                              reused (imported) helpers
+  sessions/**/rollout-*.jsonl ──┐       pii_scrub.scrub (identity-only)
+   (two formats: payload-env /  │       parse_skill_frontmatter / build_skill_meta
+    flat legacy)                │       derive_description_from_body
+  skills/*/SKILL.md ────────────┤       _finalize_showcase / _read_hero_image
+  config.toml ([plugins.*],     │       extract_safe_command_name (on unwrapped cmd only)
+   approvals_reviewer,          │       detect_agent_tools (desktop presence)
+   approval_mode, trust_level) ─┤
+  rules/*.rules                 │
+   (prefix_rule(pattern=[...])) ┘
+            │
+            ▼  codex_extract.py
+            │   - per-file format detect; count all sessions
+            │   - positive read-allowlist; cumulative-per-session tokens
+            │   - command-list unwrap → inner binary; rules pattern[0] only
+            │   - identity/MCP scrubbing
+            │
+            ├── two-tier secret gate (prefix→fail-loud, entropy→redact+warn)  ◀── R7
+            │
+            ├── standalone HTML profile (honest-limit + thin-tool caveat)
+            └── JSON island (⊆ rendered):  <script id="harness-data">
+                  { "tool": "codex", "stats": {tokens...}, "toolUsage": {...},
+                    "cliTools": {...}, "skillInventory": [{name,description,installPointer}],
+                    "safety": { rulesAllowlist:[binaries], approvalsReviewer, approvalMode, trustLevels:[enums] },
+                    "workflowData": {...}, "workSurfaces": {desktopPresence}, "localOnly": true }
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Scaffold — paths, helper imports, fixtures, CLI skeleton**
+
+**Goal:** Stand up `codex_extract.py` with `~/.codex` roots, reused-helper imports, a test fixtures directory, and an argparse skeleton emitting the output contract (final stdout line = report path, written to `~/.codex/usage-data/`).
+
+**Requirements:** R2
+
+**Dependencies:** None
+
+**Files:**
+
+- Create: `skills/insight-harness/scripts/codex_extract.py`
+- Create: `skills/insight-harness/scripts/tests/fixtures/` (template rollout files — payload-format + legacy-format + null-info + secret-bearing — for Units 2/4)
+- Test: `skills/insight-harness/scripts/test_codex_extract.py`
+
+**Approach:** `CODEX_DIR = Path.home()/".codex"` + derived roots as module globals (patchable in tests, mirror `extract.py`). Import pure helpers; confirm no import side effects. argparse: `--include-skills`/`--no-include-skills`; output dir `~/.codex/usage-data/`.
+
+**Patterns to follow:** `extract.py` constants + `main` output contract; `test_skill_description_fallback.py` global-patching.
+
+**Test scenarios:**
+
+- Happy path: CLI on a fixture `CODEX_DIR` writes HTML to `usage-data/` and prints its absolute path as the final line.
+- Edge case: absent `~/.codex` → clean "no Codex data" exit, no crash.
+
+**Verification:** Runs against tmp `CODEX_DIR`, produces a file + parseable final-line path.
+
+- [ ] **Unit 2: Dual-format rollout parser + tokens + command extraction**
+
+**Goal:** Parse rollout files (both formats), reading only the positive allowlist; count all sessions; compute cumulative-per-session token totals; tally CLI commands via the list-unwrap rule.
+
+**Requirements:** R3, R5, R6, R9
+
+**Dependencies:** Unit 1
+
+**Files:** Modify `codex_extract.py`; Test `test_codex_extract.py`
+
+**Approach:**
+
+- Per file, detect format by presence of the `payload` envelope. Count every session toward session count + timespan regardless of format.
+- Positive allowlist: read only `payload.type`, `timestamp`, `payload.info.total_token_usage`, command binary, whitelisted markers. Never read content carriers (`*_output.output`, `apply_patch.*`, `message.content`, `reasoning.*`, `agent_message.message`, `update_plan`, `spawn_agent.message`, `web_search_call.action`, `session_meta` instruction/nickname fields, etc.).
+- Tokens: on `payload.type=="token_count"` with non-null `info`, read `info.total_token_usage.total_tokens`; keep the **max per session**; sum maxes across sessions.
+- Commands: `json.loads(function_call.arguments)`, take `command` list, strip `bash/sh/zsh` + `-lc/-c` wrapper, run the inner string through `extract_safe_command_name`; emit first token only.
+
+**Execution note:** Start with failing tests that (a) plant a cumulative token series and assert the total equals the per-session max summed (NOT the per-record sum), and (b) plant a `["bash","-lc","curl -H 'Authorization: Bearer sk-SECRET' ..."]` command and assert only `curl` is emitted and the token never appears.
+
+**Patterns to follow:** `extract_safe_command_name`; `extract.py` session iteration.
+
+**Test scenarios:**
+
+- Happy path: cumulative series `28887,67874,107911` in one session → total = `107911` (max), not `204672` (sum).
+- Edge case: `payload.info == null` record → skipped, no NoneType crash.
+- Edge case: legacy-format file (no `payload`) → counted as a session/timespan, contributes no token detail.
+- Error path (security): secret in a `["bash","-lc","..."]` command → only inner binary emitted; secret absent from output.
+- Integration (privacy guard): monkeypatch `open`/parse to assert no content-carrier value is ever materialized.
+
+**Verification:** Token total uses max-per-session; legacy sessions counted; privacy + secret guards pass.
+
+- [ ] **Unit 3: Codex skill inventory + plugins from config**
+
+**Goal:** Build inventory-only Codex skills (reuse frontmatter/showcase) and source plugins from `config.toml` `[plugins.*]`.
+
+**Requirements:** R2, R10
+
+**Dependencies:** Unit 1
+
+**Files:** Modify `codex_extract.py`; Test `test_codex_extract.py`
+
+**Approach:** Walk `~/.codex/skills/*/SKILL.md`; reuse `parse_skill_frontmatter`, `derive_description_from_body`, `_finalize_showcase`/`_read_hero_image` (owner-aware scrub). Emit `{name, description, installPointer}` with **no** `calls`. Honor `repo: private/none`. Plugins from `config.toml` `[plugins.*]` (name + enabled), not a dir walk.
+
+**Patterns to follow:** `extract_skill_inventory` (reimplemented), `build_skill_meta`.
+
+**Test scenarios:**
+
+- Happy path: 3 fixture skills → listed with descriptions, no counts; plugins read from a fixture `config.toml` `[plugins.*]`.
+- Edge case: blank frontmatter description → body-derived.
+- Error path: `repo: private` skill excluded entirely.
+- Integration (concrete pass/fail): a **third-party-owned** README whose `github.com/<upstream-owner>/...` URL differs from the local git identity → assert (1) the local user's identity is NOT injected in place of the upstream owner (no mis-attribution rewrite), and (2) the emitted README excerpt contains neither the local OS-username nor any `sk-`/`Bearer ` token. (SEC-10 re-review: criterion made concrete.)
+
+**Verification:** Inventory has no counts; private excluded; plugins from config; third-party README handled.
+
+- [ ] **Unit 4: Codex safety posture (real config keys + rules parser)**
+
+**Goal:** Produce the per-tool "Safety & Automation" data from the real `config.toml` keys and the `prefix_rule(pattern=[...])` DSL, emitting enums + binaries only.
+
+**Requirements:** R4, R8
+
+**Dependencies:** Unit 1
+
+**Files:** Modify `codex_extract.py`; Test `test_codex_extract.py`
+
+**Approach:** Read `approvals_reviewer`, per-app `approval_mode`, per-project `trust_level` **values** (enums); never emit the `[projects."<path>"]` section keys. Parse rules with a dedicated `prefix_rule(pattern=[...])` parser; emit `pattern[0]` only; discard the rest.
+
+**Execution note:** Start with a failing test planting a rule whose `pattern` embeds an absolute path to a credentials file (`/Users/.../com.vercel.cli/auth.json`) and a bearer token in a later element; assert neither the path nor the token appears.
+
+**Test scenarios:**
+
+- Happy path: fixture `config.toml` with `approvals_reviewer`/`approval_mode`/`trust_level` → enums surfaced; rules list shows binaries only.
+- Error path (security/PII): rule `prefix_rule(pattern=["git","add","/Users/.../auth.json"])` → output contains `git` only; the path never appears.
+- Edge case: no `rules/`, empty `config.toml` → "none configured", no crash; project-path section keys never emitted.
+
+**Verification:** Enums-only safety; rules emit binaries only; no path/secret leak.
+
+- [ ] **Unit 5: Profile assembly — HTML + tool-only JSON island**
+
+**Goal:** Assemble the Codex HTML profile + `{tool:"codex", ...}` island from Units 2–4, including tokens, desktop presence, identity/MCP scrubbing, thin-tool caveat, honest-limit. Island ⊆ rendered.
+
+**Requirements:** R1, R8, R11, R12, R13
+
+**Dependencies:** Units 2, 3, 4
+
+**Files:** Modify `codex_extract.py`; Test `test_codex_extract.py`
+
+**Approach:** Render Codex sections (no Claude-only sections); Codex-appropriate prose (no hardcoded author claims, F6). Normalize `mcp__<server>__<tool>` to a generic bucket; never emit `repository_url`/`cwd`/`commit_hash`/`branch`. Reuse `detect_agent_tools` for desktop presence. Activity floor → "local CLI only" caveat; always render the local-only limit. Island carries only fields the HTML renders.
+
+**Test scenarios:**
+
+- Happy path: rich fixture → island parses, `tool=="codex"`, token total present, `skillInventory` has no `calls`.
+- Edge case (thin tool): below-threshold session count → caveat present; not shown as a full profile.
+- Integration: an `mcp__gmail__send` tool name → bucketed, not emitted verbatim; a planted `repository_url`/`cwd` → absent from island + HTML.
+- Integration: island field set ⊆ rendered field set (assert no island-only fields).
+
+**Verification:** Island ⊆ rendered; identity/MCP scrubbed; caveat + honest-limit present; no Claude-only sections; no author-hardcoded prose.
+
+- [ ] **Unit 6: Secret-scan emit gate + real-data scrub validation gate**
+
+**Goal:** Add the emit-time secret-scan backstop and run the load-bearing real-`~/.codex` scrub validation — the security gate before any Phase 2 work.
+
+**Requirements:** R7
+
+**Dependencies:** Unit 5
+
+**Files:** Modify `codex_extract.py`; Test `test_codex_extract.py`
+
+**Approach:** Two-tier gate (R7) over the **serialized** output. Tier (a): known prefixes (`sk-`, `Bearer `, `AKIA`, `ghp_`) → fail loud (raise + non-zero exit, no file written). Tier (b): high-entropy heuristic over post-allowlist text fields only, **excluding** hero-image data URIs, skill IDs, and hash/UUID values → redact the offending field + warn, do not abort. Then run against the real `~/.codex` and verify.
+
+**Execution note:** This is the security gate — adversarial, not confirmatory.
+
+**Test scenarios:**
+
+- Happy path: clean output → gate passes, file written.
+- Error path (tier a): planted `Bearer sk-...` in any assembled field → gate raises, no file written.
+- Edge case (tier b, the footgun guard): a legitimate hero-image data URI + a long base64 skill ID present → run completes, file written, no false-positive abort.
+- Edge case (tier b): a non-prefixed high-entropy secret in a text field → field redacted + warning emitted, run continues.
+- Real-data gate: run on the real `~/.codex`; grep emitted HTML + island for the known bearer-token prefix → zero hits; confirm no `cwd`/`repository_url`/connector-UUID strings; confirm the token total is within a sane ratio of the true per-session-max sum (catches the ADV-1 inflation class); confirm legacy sessions are counted; **confirm the run was not falsely blocked.**
+
+**Verification:** Gate blocks secret-bearing output; real-data run is clean and the headline number is sane.
+
+- [ ] **Unit 7: SKILL.md wiring**
+
+**Goal:** Document how to run `codex_extract.py` (background-Bash pattern, output contract, local-only limit, Phase-1-is-local-only).
+
+**Requirements:** R1
+
+**Dependencies:** Unit 6
+
+**Files:** Modify `skills/insight-harness/SKILL.md`
+
+**Test scenarios:** `Test expectation: none` — docs only. Verification is the full suite passing + the Unit 6 real-data gate.
+
+**Verification:** Suite green; SKILL.md documents the Codex invocation accurately.
+
+## System-Wide Impact
+
+- **Interaction graph:** New standalone script; imports pure helpers; does not call/modify `extract.py`'s flow.
+- **Error propagation:** Missing `~/.codex` subdirs / null token info / legacy-format files degrade gracefully (count-only / "none"), never abort.
+- **API surface parity:** The `tool`-discriminated island is the seam Phase 2's `tools` map + agent payload inherit; `schema_version`/`generated_at` deferred to Phase 2 alongside the Claude-island retrofit.
+- **Unchanged invariants:** Claude `extract.py` behavior, its `harness-data` shape, and the insightharness.com schema are untouched.
+
+## Risks & Dependencies
+
+| Risk                                                     | Mitigation                                                                                                                                                           |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Token inflation from summing a cumulative field (ADV-1)  | Max-per-session, sum across sessions; Unit 2 + Unit 6 ratio assertion.                                                                                               |
+| Live secret leak to a public page (SEC-1/2/3, ADV-5)     | Positive read-allowlist + list/rules structured parsers (binary/`pattern[0]` only) + emit-time secret gate (R7) + serialized-island scan (R11); failing-first tests. |
+| Silently dropping legacy-format Codex history (ADV-2)    | Per-file format detect; count all sessions; caveat detail is recent-only (R9).                                                                                       |
+| Identity leak via repo URL / cwd / MCP names (SEC-5/6/7) | Never emit; MCP bucketed; work-surface from path shape only (R8).                                                                                                    |
+| Wrong config keys → empty safety section (ADV-4)         | Use real keys (`approvals_reviewer`/`approval_mode`/`trust_level`); enums only (R4).                                                                                 |
+| Island leaks fields HTML doesn't show (F1, SEC-8)        | Island ⊆ rendered; scan serialized island (R11).                                                                                                                     |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md](docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md)
+- Review corrections: document-review 2026-05-26 (coherence, feasibility, security-lens, scope-guardian, adversarial) — verified against the real `~/.codex` tree.
+- Related findings: docs/brainstorms/phase0-results-2026-05-23.md (F1, F6)
+- Pattern source (insight-harness repo): `skills/insight-harness/scripts/extract.py`, `pii_scrub.py`, `SKILL.md`; tests `test_skill_description_fallback.py`, `test_work_surfaces.py`


### PR DESCRIPTION
## Summary

Planning artifacts for the multi-agent harness direction — extending `insight-harness` to profile OpenAI Codex alongside Claude Code.

- **Brainstorm** (`docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md`) — decisions D1–D7: one tool-partitioned profile with same-tool-to-same-tool agent learning, Claude+Codex only (not generic N-tool), inventory-only Codex skills, per-tool safety section, ship Codex tokens, presence-only desktop detection.
- **Phase 1 plan** (`docs/plans/2026-05-25-001-feat-codex-extractor-phase1-plan.md`) — a standalone Codex extractor (implemented in the separate `insight-harness` repo) that reuses the existing PII-scrub/frontmatter/showcase helpers and reimplements only the Codex-shaped parts. Grounded in real `~/.codex` data shapes after a 5-persona document-review + a security/adversarial re-review (all 18 findings closed; two-tier secret gate, cumulative-per-session token math, dual rollout-format handling).

Docs only — no code. Implementation lands in `insight-harness`.

## Test plan
- [ ] N/A — planning docs