### PR TITLE
feat: support multi-tool harness profiles

### DIFF
--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -80,6 +80,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 
 ### Unit 2: Parser and upload storage
 
+**Status:** completed 2026-05-28
+
 **Goal:** Parse all three supported `harness-data` shapes and persist the normalized stored shape.
 
 **Files:**
@@ -106,6 +108,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 **Verification:** targeted parser/upload/insights Vitest files.
 
 ### Unit 3: Hidden-section filtering for tools map
+
+**Status:** completed 2026-05-28
 
 **Goal:** Preserve privacy filtering for both legacy and envelope-shaped `harnessData`.
 

--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -135,6 +135,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 
 ### Unit 4: Public report tool selector and Codex dashboard
 
+**Status:** completed 2026-05-28
+
 **Goal:** Render multi-tool reports on `/insights/[username]/[slug]`.
 
 **Files:**

--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -47,6 +47,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 
 ### Unit 1: Multi-tool type and normalization helpers
 
+**Status:** completed 2026-05-28
+
 **Goal:** Add typed helpers that classify legacy Claude data, Codex islands, and tools-map envelopes.
 
 **Files:**
@@ -205,4 +207,3 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 - The current `ProfileTabs` and report page are large and Claude-shaped. The first implementation should avoid broad redesign; isolate Codex UI in a new component.
 - Existing list/OG routes may still use scalar denorms. Phase 2 should not promise cross-tool aggregate cards until Phase 3.
 - Codex standalone HTML currently lacks the `insight-harness-integrity` marker. `isHarnessReport` may need to recognize `script#harness-data` with `tool:"codex"` as a harness report.
-

--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Phase 2 multi-agent tools map + tool selector"
 type: feat
-status: in_progress
+status: completed
 date: 2026-05-28
 origin: docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md
 ---
@@ -196,6 +196,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 **Verification:** `npx vitest run src/app/insights/__tests__/edit-flow.test.ts`
 
 ### Unit 6: Full verification and PR
+
+**Status:** completed 2026-05-28
 
 **Goal:** Prove the feature works without regressing legacy flows.
 

--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -1,0 +1,208 @@
+---
+title: "feat: Phase 2 multi-agent tools map + tool selector"
+type: feat
+status: in_progress
+date: 2026-05-28
+origin: docs/brainstorms/2026-05-25-codex-extractor-multiagent-requirements.md
+---
+
+# feat: Phase 2 Multi-Agent Tools Map + Tool Selector
+
+## Overview
+
+Phase 1 shipped a standalone Codex extractor in `insight-harness`. Phase 2 brings that output into `insightful` without migrating the database: `InsightReport.harnessData` remains a JSON column, but the app learns a backward-compatible envelope shape:
+
+```json
+{
+  "tools": {
+    "claude-code": { "...legacy HarnessData..." },
+    "codex": { "tool": "codex", "...Codex island fields..." }
+  },
+  "primaryTool": "claude-code"
+}
+```
+
+Existing rows remain valid. A current top-level Claude `HarnessData` normalizes as `tools["claude-code"]`. A Phase 1 Codex standalone island normalizes as `tools.codex`. A future combined upload can provide the `tools` map directly.
+
+## Requirements
+
+- R1. Preserve every existing Claude-only report without DB migration or data backfill.
+- R2. Accept three upload shapes at `script#harness-data`: legacy Claude `HarnessData`, Codex Phase 1 `{ tool: "codex", ... }`, and combined `{ tools: { "claude-code"?, codex? } }`.
+- R3. Store normalized multi-tool envelopes in `harnessData`, while exposing a Claude-compatible `harnessData` slice to old render surfaces until they are migrated.
+- R4. Add a public report tool selector only when more than one valid tool profile exists.
+- R5. Render Codex profiles honestly: local CLI caveat, no fake skill usage counts, no Claude-only hooks/agent-dispatch claims.
+- R6. Keep hidden-section privacy filtering for legacy keys and apply equivalent stripping inside each tool in an envelope.
+- R7. Keep `harnessData` excluded from PUT updates. Phase 2 storage changes are upload-only.
+- R8. Keep scalar denorms (`totalTokens`, `durationHours`, `prCount`, etc.) Claude-compatible for legacy behavior; for Codex-only reports, populate scalar fields from Codex stats only where the scalar meaning is clear.
+
+## Key Decisions
+
+- **No Prisma migration.** `harnessData Json?` already supports the envelope. Backfills add risk and do not improve runtime behavior.
+- **Compatibility helpers, not ad hoc checks.** Add one normalization module in `src/types/insights.ts` so upload, filtering, detail UI, edit UI, OG/list routes, and tests share the same shape decisions.
+- **Legacy top-level Claude stays accepted.** Treat it as an implicit `tools["claude-code"]`, but do not rewrite old rows until they are re-uploaded.
+- **Codex renders through a separate dashboard path.** Reusing the Claude dashboard wholesale would over-claim; Codex lacks hooks, agent dispatch, Claude writeups, and skill invocation counts.
+- **Tool selector is separate from section tabs.** `ProfileTabs` remains Dashboard/Skills/Write-up/Claude Insights; a new `ToolSelector` chooses Claude Code vs Codex above those tabs.
+
+## Implementation Units
+
+### Unit 1: Multi-tool type and normalization helpers
+
+**Goal:** Add typed helpers that classify legacy Claude data, Codex islands, and tools-map envelopes.
+
+**Files:**
+- Modify: `src/types/insights.ts`
+- Create/modify tests: `src/lib/__tests__/harness-tools.test.ts`
+
+**Depends on:** none
+
+**Approach:**
+- Add `HarnessToolKey = "claude-code" | "codex"`.
+- Add minimal `CodexHarnessData` type matching Phase 1 island fields.
+- Add `HarnessToolsEnvelope`.
+- Add helpers:
+  - `normalizeHarnessEnvelope(raw)`
+  - `normalizeHarnessData(raw)` remains Claude-slice compatible for existing callers.
+  - `getClaudeHarnessData(raw)`
+  - `getCodexHarnessData(raw)`
+  - `listHarnessTools(raw)`
+  - `toStoredHarnessData(raw)` for upload persistence.
+
+**Test scenarios:**
+- Legacy top-level Claude `HarnessData` normalizes and lists only `claude-code`.
+- Codex `{ tool: "codex" }` island normalizes and lists only `codex`.
+- Combined `{ tools: { "claude-code": legacy, codex } }` normalizes both.
+- Malformed tools are ignored; empty envelope returns null.
+- `normalizeHarnessData` still returns the Claude slice for old and new shapes.
+
+**Verification:** `npx vitest run src/lib/__tests__/harness-tools.test.ts`
+
+### Unit 2: Parser and upload storage
+
+**Goal:** Parse all three supported `harness-data` shapes and persist the normalized stored shape.
+
+**Files:**
+- Modify: `src/lib/harness-parser.ts`
+- Modify: `src/app/api/upload/route.ts`
+- Modify: `src/app/api/insights/route.ts`
+- Modify: `src/lib/publish-report.ts`
+- Tests: `src/lib/__tests__/harness-parser.test.ts`, `src/app/api/upload/__tests__/route.test.ts`, `src/app/api/insights/__tests__/route.test.ts`
+
+**Depends on:** Unit 1
+
+**Approach:**
+- Keep `parseHarnessHtml` as the parser boundary, but have it return normalized stored harness data.
+- Sanitize Claude `writeupSections.contentHtml` wherever the Claude slice appears.
+- Store envelopes via `toStoredHarnessData`.
+- Derive scalar denorms from the Claude slice if present; otherwise from Codex stats for Codex-only reports.
+
+**Test scenarios:**
+- Legacy Claude fixture still parses unchanged.
+- Codex Phase 1 fixture with `tool:"codex"` parses and is accepted by `/api/upload`.
+- Combined envelope parses, sanitizes Claude writeup HTML, and preserves Codex data.
+- `/api/insights` stores normalized envelope, not `null`, for Codex-only input.
+
+**Verification:** targeted parser/upload/insights Vitest files.
+
+### Unit 3: Hidden-section filtering for tools map
+
+**Goal:** Preserve privacy filtering for both legacy and envelope-shaped `harnessData`.
+
+**Files:**
+- Modify: `src/lib/harness-section-visibility.ts`
+- Modify: `src/lib/filter-report-response.ts`
+- Tests: `src/lib/__tests__/filter-report-response.test.ts`
+
+**Depends on:** Unit 1
+
+**Approach:**
+- Legacy hide keys (`skillInventory`, `plugins`, etc.) continue applying to Claude slice.
+- Namespaced keys (`tools.codex.skillInventory`, `tools.claude-code.plugins`) apply to specific tools.
+- List-feed filtering drops showcase bytes from Claude skills and any compatible Codex skill showcase fields.
+
+**Test scenarios:**
+- Non-owner hidden `skillInventory` strips legacy Claude skill inventory.
+- Non-owner hidden `tools.codex.skillInventory` strips only Codex skills.
+- Owner with `includeHidden=true` receives full envelope.
+- List feed strips heavy showcase fields inside envelope.
+
+**Verification:** `npx vitest run src/lib/__tests__/filter-report-response.test.ts`
+
+### Unit 4: Public report tool selector and Codex dashboard
+
+**Goal:** Render multi-tool reports on `/insights/[username]/[slug]`.
+
+**Files:**
+- Create: `src/components/ToolSelector.tsx`
+- Create: `src/components/CodexHarnessDashboard.tsx`
+- Modify: `src/app/insights/[username]/[slug]/page.tsx`
+- Tests: component tests for `ToolSelector` and Codex dashboard where practical.
+
+**Depends on:** Units 1 and 3
+
+**Approach:**
+- Derive available tools with `listHarnessTools`.
+- Show no selector for a single-tool report.
+- For Claude Code, keep the current report tabs and dashboard behavior using the Claude slice.
+- For Codex, render a Codex-specific dashboard:
+  - local CLI caveat
+  - token/session stats
+  - tool usage
+  - CLI commands
+  - inventory-only skills
+  - plugins
+  - safety/rules
+  - work surfaces
+  - workflow empty state when no phase signal exists
+- Do not show Claude-only Write-up or Claude Insights tabs for Codex-only reports.
+
+**Test scenarios:**
+- Legacy Claude report renders without a tool selector.
+- Combined report renders a selector and changing tools swaps displayed data.
+- Codex-only report does not show Claude-only hooks/writeup claims.
+- Codex skills with no `calls` render as inventory items.
+
+**Verification:** targeted component tests plus browser smoke test on a fixture report if local data is available.
+
+### Unit 5: Edit page compatibility
+
+**Goal:** Keep the author edit page functional for legacy and envelope reports.
+
+**Files:**
+- Modify: `src/app/insights/[username]/[slug]/edit/page.tsx`
+- Tests: existing edit-flow tests plus targeted render-safe tests if practical.
+
+**Depends on:** Units 1 and 3
+
+**Approach:**
+- Continue editing visibility only; never submit `harnessData`.
+- Use Claude slice for the existing visibility preview.
+- If a report is Codex-only, show a concise visibility preview for Codex sections and allow section-level hides via namespaced keys.
+
+**Test scenarios:**
+- PUT allowlist still excludes `harnessData`.
+- Legacy edit page still normalizes Claude slice.
+- Codex-only edit page does not crash.
+
+**Verification:** `npx vitest run src/app/insights/__tests__/edit-flow.test.ts`
+
+### Unit 6: Full verification and PR
+
+**Goal:** Prove the feature works without regressing legacy flows.
+
+**Files:** no feature files unless fixes are needed.
+
+**Depends on:** Units 1-5
+
+**Verification:**
+- `npm run lint`
+- `npx tsc --noEmit`
+- `npx vitest run`
+- `npm run build`
+- Manual browser smoke if a dev server is started for UI verification.
+
+## Open Risks
+
+- The current `ProfileTabs` and report page are large and Claude-shaped. The first implementation should avoid broad redesign; isolate Codex UI in a new component.
+- Existing list/OG routes may still use scalar denorms. Phase 2 should not promise cross-tool aggregate cards until Phase 3.
+- Codex standalone HTML currently lacks the `insight-harness-integrity` marker. `isHarnessReport` may need to recognize `script#harness-data` with `tool:"codex"` as a harness report.
+

--- a/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
+++ b/docs/plans/2026-05-28-phase2-multiagent-tools-map-plan.md
@@ -171,6 +171,8 @@ Existing rows remain valid. A current top-level Claude `HarnessData` normalizes 
 
 ### Unit 5: Edit page compatibility
 
+**Status:** completed 2026-05-28
+
 **Goal:** Keep the author edit page functional for legacy and envelope reports.
 
 **Files:**

--- a/src/app/api/insights/__tests__/route.test.ts
+++ b/src/app/api/insights/__tests__/route.test.ts
@@ -328,6 +328,54 @@ describe("POST /api/insights — save-side happy path", () => {
     expect(createArgs.data.reportType).toBe("insight-harness");
     expect(createArgs.data.harnessData).toBeDefined();
   });
+
+  it("stores Codex-only harnessData as an envelope and derives clear scalar stats", async () => {
+    mockSessionAndUser("user-1");
+    wireTransaction();
+    seedReportMock();
+
+    await insightsPOST(
+      postRequest({
+        sessionCount: null,
+        reportType: "insight-harness",
+        harnessData: {
+          tool: "codex",
+          stats: { totalTokens: 2000, sessionCount: 12 },
+          toolUsage: { exec_command: 8 },
+          cliTools: { git: 3 },
+          skillInventory: [
+            { name: "code-review", description: "Review code" },
+          ],
+          plugins: [{ name: "github", enabled: true }],
+          safety: {
+            approvalsReviewer: "model",
+            approvalModes: ["approve"],
+            trustLevels: ["trusted"],
+            rulesAllowlist: ["git"],
+          },
+          workflowData: { phaseTransitions: {} },
+          workSurfaces: {
+            desktopPresence: [{ tool: "Codex CLI", present: true }],
+          },
+          localOnly: true,
+        },
+      }),
+    );
+
+    const createArgs = mockPrisma.insightReport.create.mock.calls[0][0];
+    expect(createArgs.data.reportType).toBe("insight-harness");
+    expect(createArgs.data.totalTokens).toBe(BigInt(2000));
+    expect(createArgs.data.durationHours).toBeNull();
+    expect(createArgs.data.harnessData).toMatchObject({
+      primaryTool: "codex",
+      tools: {
+        codex: {
+          tool: "codex",
+          stats: { totalTokens: 2000, sessionCount: 12 },
+        },
+      },
+    });
+  });
 });
 
 describe("POST /api/insights — field allowlist enforcement", () => {

--- a/src/app/api/insights/__tests__/route.test.ts
+++ b/src/app/api/insights/__tests__/route.test.ts
@@ -340,7 +340,7 @@ describe("POST /api/insights — save-side happy path", () => {
         reportType: "insight-harness",
         harnessData: {
           tool: "codex",
-          stats: { totalTokens: 2000, sessionCount: 12 },
+          stats: { totalTokens: 2000.6, sessionCount: 12 },
           toolUsage: { exec_command: 8 },
           cliTools: { git: 3 },
           skillInventory: [
@@ -353,7 +353,7 @@ describe("POST /api/insights — save-side happy path", () => {
             trustLevels: ["trusted"],
             rulesAllowlist: ["git"],
           },
-          workflowData: { phaseTransitions: {} },
+          workflowData: { phaseTransitions: { planning: 2 } },
           workSurfaces: {
             desktopPresence: [{ tool: "Codex CLI", present: true }],
           },
@@ -364,14 +364,15 @@ describe("POST /api/insights — save-side happy path", () => {
 
     const createArgs = mockPrisma.insightReport.create.mock.calls[0][0];
     expect(createArgs.data.reportType).toBe("insight-harness");
-    expect(createArgs.data.totalTokens).toBe(BigInt(2000));
+    expect(createArgs.data.totalTokens).toBe(BigInt(2001));
     expect(createArgs.data.durationHours).toBeNull();
     expect(createArgs.data.harnessData).toMatchObject({
       primaryTool: "codex",
       tools: {
         codex: {
           tool: "codex",
-          stats: { totalTokens: 2000, sessionCount: 12 },
+          stats: { totalTokens: 2001, sessionCount: 12 },
+          workflowData: { phaseTransitions: { planning: 2 } },
         },
       },
     });

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import type { InsightReportListItemContract } from "@/types/api-contracts";
-import { normalizeHarnessData } from "@/types/insights";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  toStoredHarnessData,
+} from "@/types/insights";
 import type { Prisma } from "@prisma/client";
 import { fetchLinkPreview } from "@/lib/link-preview";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
@@ -338,6 +342,19 @@ export async function POST(request: Request) {
       harnessData,
       hiddenHarnessSections,
     } = parsed.data;
+    const storedHarnessData = toStoredHarnessData(harnessData);
+    const claudeHarnessData = getClaudeHarnessData(storedHarnessData);
+    const codexHarnessData = getCodexHarnessData(storedHarnessData);
+    const derivedTotalTokens =
+      typeof claudeHarnessData?.stats.totalTokens === "number"
+        ? claudeHarnessData.stats.totalTokens
+        : typeof codexHarnessData?.stats.totalTokens === "number"
+          ? codexHarnessData.stats.totalTokens
+          : null;
+    const derivedDurationHours =
+      typeof claudeHarnessData?.stats.durationHours === "number"
+        ? claudeHarnessData.stats.durationHours
+        : null;
 
     // Auto-generate title if not provided
     const title =
@@ -496,18 +513,26 @@ export async function POST(request: Request) {
           detectedSkills: detectedSkills ?? [],
           reportType: reportType ?? "insights",
           totalTokens:
-            typeof totalTokens === "number" ? BigInt(totalTokens) : null,
+            typeof totalTokens === "number"
+              ? BigInt(totalTokens)
+              : typeof derivedTotalTokens === "number"
+                ? BigInt(derivedTotalTokens)
+                : null,
           durationHours:
-            typeof durationHours === "number"
-              ? Math.round(durationHours)
+            typeof durationHours === "number" ||
+            typeof derivedDurationHours === "number"
+              ? Math.round(durationHours ?? derivedDurationHours ?? 0)
               : null,
-          avgSessionMinutes: avgSessionMinutes ?? null,
-          prCount: prCount ?? null,
-          autonomyLabel: autonomyLabel ?? null,
+          avgSessionMinutes:
+            avgSessionMinutes ??
+            claudeHarnessData?.stats.avgSessionMinutes ??
+            null,
+          prCount: prCount ?? claudeHarnessData?.stats.prCount ?? null,
+          autonomyLabel:
+            autonomyLabel ?? claudeHarnessData?.autonomy.label ?? null,
           harnessData:
-            (normalizeHarnessData(
-              harnessData,
-            ) as unknown as Prisma.InputJsonValue) ?? undefined,
+            (storedHarnessData as unknown as Prisma.InputJsonValue) ??
+            undefined,
           hiddenHarnessSections: Array.isArray(hiddenHarnessSections)
             ? hiddenHarnessSections
             : [],

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -81,6 +81,14 @@ const createInsightReportSchema = z.object({
   harnessData: z.unknown().optional(),
   hiddenHarnessSections: z.array(z.string()).optional(),
 });
+
+function toStoredTokenCount(value: unknown): bigint | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return BigInt(Math.round(value));
+}
+
 const SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
@@ -483,6 +491,9 @@ export async function POST(request: Request) {
         uniqueProjectIds.push(id);
       }
 
+      const storedTotalTokens =
+        typeof totalTokens === "number" ? totalTokens : derivedTotalTokens;
+
       const created = await tx.insightReport.create({
         data: {
           authorId: user.id,
@@ -512,12 +523,7 @@ export async function POST(request: Request) {
           chartData: (chartData as Prisma.InputJsonValue) ?? undefined,
           detectedSkills: detectedSkills ?? [],
           reportType: reportType ?? "insights",
-          totalTokens:
-            typeof totalTokens === "number"
-              ? BigInt(totalTokens)
-              : typeof derivedTotalTokens === "number"
-                ? BigInt(derivedTotalTokens)
-                : null,
+          totalTokens: toStoredTokenCount(storedTotalTokens),
           durationHours:
             typeof durationHours === "number" ||
             typeof derivedDurationHours === "number"

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -101,6 +101,34 @@ const FIXTURE_PATH = resolve(
 );
 const FIXTURE_HTML = readFileSync(FIXTURE_PATH, "utf-8");
 const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+const CODEX_HARNESS_HTML = `<!doctype html>
+<html>
+  <body>
+    <script id="harness-data" type="application/json">
+      {
+        "tool": "codex",
+        "stats": { "totalTokens": 2000, "sessionCount": 12 },
+        "toolUsage": { "exec_command": 8 },
+        "cliTools": { "git": 3 },
+        "skillInventory": [
+          { "name": "code-review", "description": "Review code" }
+        ],
+        "plugins": [{ "name": "github", "enabled": true }],
+        "safety": {
+          "approvalsReviewer": "model",
+          "approvalModes": ["approve"],
+          "trustLevels": ["trusted"],
+          "rulesAllowlist": ["git"]
+        },
+        "workflowData": { "phaseTransitions": {} },
+        "workSurfaces": {
+          "desktopPresence": [{ "tool": "Codex CLI", "present": true }]
+        },
+        "localOnly": true
+      }
+    </script>
+  </body>
+</html>`;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -272,6 +300,26 @@ describe("POST /api/upload — multipart v2.7.0 happy path", () => {
     const body = await response.json();
     expect(body.stats.sessionCount).toBe(95);
     expect(body.stats.linesAdded).toBe(12500);
+  });
+});
+
+describe("POST /api/upload — multipart Codex harness happy path", () => {
+  it("accepts Codex Phase 1 output without the legacy integrity marker", async () => {
+    mockSession("user-1");
+    const response = await uploadPOST(multipartRequest(CODEX_HARNESS_HTML));
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.reportType).toBe("insight-harness");
+    expect(body.stats.sessionCount).toBe(12);
+    expect(body.harnessData).toMatchObject({
+      primaryTool: "codex",
+      tools: {
+        codex: {
+          tool: "codex",
+          stats: { totalTokens: 2000, sessionCount: 12 },
+        },
+      },
+    });
   });
 });
 
@@ -538,6 +586,30 @@ describe("POST /api/upload — bearer happy path", () => {
     // Selector is logged in 8-char trimmed form, never the full 12.
     const logArg = mockLog.mock.calls.at(-1)?.[0];
     expect(logArg.tokenSelectorPrefix.length).toBe(8);
+  });
+
+  it("passes Codex-only parsed envelopes through to publishReport", async () => {
+    const response = await uploadPOST(
+      bearerRequest({ contentType: "text/html", body: CODEX_HARNESS_HTML }),
+    );
+    expect(response.status).toBe(200);
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parsed: expect.objectContaining({
+          reportType: "insight-harness",
+          stats: expect.objectContaining({ sessionCount: 12 }),
+          harnessData: expect.objectContaining({
+            primaryTool: "codex",
+            tools: expect.objectContaining({
+              codex: expect.objectContaining({
+                tool: "codex",
+                stats: expect.objectContaining({ totalTokens: 2000 }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("uses AUTH_URL as the editUrl origin when set (production canonical host)", async () => {

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -39,7 +39,11 @@ import {
 import { logHarnessRequest } from "@/lib/harness-logging";
 import { publishReport } from "@/lib/publish-report";
 import { buildReportEditUrl } from "@/lib/urls";
-import type { ParsedInsightsReport } from "@/types/insights";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  type ParsedInsightsReport,
+} from "@/types/insights";
 
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -225,29 +229,44 @@ function parseUploadHtml(html: string): ParsedUpload {
     // translate to 400 so the message reaches the user.
     harnessData = parseHarnessHtml(html);
   }
+  const claudeHarnessData = getClaudeHarnessData(harnessData);
+  const codexHarnessData = getCodexHarnessData(harnessData);
 
-  const enhancedStats = harnessData?.enhancedStats
+  const enhancedStats = claudeHarnessData?.enhancedStats
     ? {
-        linesAdded: harnessData.enhancedStats.linesAdded,
-        linesRemoved: harnessData.enhancedStats.linesRemoved,
-        fileCount: harnessData.enhancedStats.fileCount,
-        dayCount: harnessData.enhancedStats.dayCount,
-        msgsPerDay: harnessData.enhancedStats.msgsPerDay,
+        linesAdded: claudeHarnessData.enhancedStats.linesAdded,
+        linesRemoved: claudeHarnessData.enhancedStats.linesRemoved,
+        fileCount: claudeHarnessData.enhancedStats.fileCount,
+        dayCount: claudeHarnessData.enhancedStats.dayCount,
+        msgsPerDay: claudeHarnessData.enhancedStats.msgsPerDay,
       }
     : extractEnhancedStats(insightsHtml);
 
   const stats = {
     ...parsed.stats,
     ...enhancedStats,
-    ...(harnessData
+    ...(claudeHarnessData
       ? {
           sessionCount:
-            harnessData.stats.sessionCount ?? parsed.stats.sessionCount ?? 0,
+            claudeHarnessData.stats.sessionCount ??
+            parsed.stats.sessionCount ??
+            0,
           commitCount:
-            harnessData.stats.commitCount ?? parsed.stats.commitCount ?? 0,
+            claudeHarnessData.stats.commitCount ??
+            parsed.stats.commitCount ??
+            0,
           dayCount: enhancedStats.dayCount ?? 30,
         }
-      : {}),
+      : codexHarnessData
+        ? {
+            sessionCount:
+              codexHarnessData.stats.sessionCount ??
+              parsed.stats.sessionCount ??
+              0,
+            commitCount: parsed.stats.commitCount ?? 0,
+            dayCount: enhancedStats.dayCount ?? 30,
+          }
+        : {}),
   };
 
   // Compose the ParsedInsightsReport that publishReport expects. Layer

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -96,7 +96,9 @@ type CodexVisibilitySectionKey =
   | "skillInventory"
   | "plugins"
   | "cliTools"
-  | "workflowData";
+  | "workflowData"
+  | "safety"
+  | "workSurfaces";
 
 const CODEX_VISIBILITY_PREFIX = "tools.codex";
 
@@ -227,6 +229,8 @@ function CodexVisibilityPreview({
   const skillSectionKey = buildCodexVisibilityKey("skillInventory");
   const pluginSectionKey = buildCodexVisibilityKey("plugins");
   const workflowSectionKey = buildCodexVisibilityKey("workflowData");
+  const safetySectionKey = buildCodexVisibilityKey("safety");
+  const workSurfacesSectionKey = buildCodexVisibilityKey("workSurfaces");
   const toolEntries = Object.entries(codexData.toolUsage ?? {});
   const cliEntries = Object.entries(codexData.cliTools ?? {});
   const workflowKeys = codexData.workflowData
@@ -406,11 +410,71 @@ function CodexVisibilityPreview({
           </HideableCard>
         )}
 
+        <HideableCard
+          title="Codex Safety And Rules"
+          hidden={!!hiddenSections[safetySectionKey]}
+          onToggle={() => onToggle(safetySectionKey)}
+        >
+          <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-900">
+            <div className="grid gap-3 sm:grid-cols-2">
+              {codexData.safety.approvalsReviewer && (
+                <div>
+                  <div className="text-xs font-semibold uppercase text-slate-400">
+                    Approvals reviewer
+                  </div>
+                  <div className="mt-1 text-slate-700 dark:text-slate-300">
+                    {codexData.safety.approvalsReviewer}
+                  </div>
+                </div>
+              )}
+              <div>
+                <div className="text-xs font-semibold uppercase text-slate-400">
+                  Safety fields
+                </div>
+                <div className="mt-1 text-slate-700 dark:text-slate-300">
+                  {[
+                    ...codexData.safety.approvalModes,
+                    ...codexData.safety.trustLevels,
+                    ...codexData.safety.rulesAllowlist,
+                  ].length.toLocaleString()} values
+                </div>
+              </div>
+            </div>
+          </div>
+        </HideableCard>
+
+        {codexData.workSurfaces.desktopPresence.length > 0 && (
+          <HideableCard
+            title="Codex Work Surfaces"
+            hidden={!!hiddenSections[workSurfacesSectionKey]}
+            onToggle={() => onToggle(workSurfacesSectionKey)}
+          >
+            <div className="grid gap-2 sm:grid-cols-2">
+              {codexData.workSurfaces.desktopPresence.map((surface, i) => (
+                <div
+                  key={`${surface.tool ?? "surface"}-${i}`}
+                  className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                >
+                  <div className="font-medium text-slate-800 dark:text-slate-100">
+                    {surface.tool ?? `Surface ${i + 1}`}
+                  </div>
+                  {typeof surface.present === "boolean" && (
+                    <div className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                      {surface.present ? "Detected" : "Not detected"}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </HideableCard>
+        )}
+
         {toolEntries.length === 0 &&
           cliEntries.length === 0 &&
           codexData.skillInventory.length === 0 &&
           codexData.plugins.length === 0 &&
-          workflowKeys.length === 0 && (
+          workflowKeys.length === 0 &&
+          codexData.workSurfaces.desktopPresence.length === 0 && (
             <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
               This Codex report does not include hideable Codex sections.
             </p>

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -11,8 +11,18 @@ import { useSession } from "next-auth/react";
 import { ArrowLeft, AlertTriangle } from "lucide-react";
 import EyeToggle from "@/components/EyeToggle";
 import HideableItem from "@/components/HideableItem";
-import type { HarnessData } from "@/types/insights";
-import { normalizeHarnessData } from "@/types/insights";
+import type {
+  CodexHarnessData,
+  HarnessData,
+  HarnessToolsEnvelope,
+  HarnessToolKey,
+} from "@/types/insights";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  listHarnessTools,
+  normalizeHarnessEnvelope,
+} from "@/types/insights";
 import { buildItemKey } from "@/lib/item-visibility";
 import HeroStats from "@/components/HeroStats";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
@@ -68,7 +78,7 @@ interface ReportData {
   durationHours: number | null;
   linesAdded: number | null;
   linesRemoved: number | null;
-  harnessData: HarnessData | null;
+  harnessData: HarnessToolsEnvelope | null;
   hiddenHarnessSections: string[];
   atAGlance: unknown;
   interactionStyle: unknown;
@@ -79,6 +89,36 @@ interface ReportData {
   onTheHorizon: unknown;
   reportProjects: EditReportProject[];
   author: { id: string; username: string; displayName: string | null };
+}
+
+type CodexVisibilitySectionKey =
+  | "toolUsage"
+  | "skillInventory"
+  | "plugins"
+  | "cliTools"
+  | "workflowData";
+
+const CODEX_VISIBILITY_PREFIX = "tools.codex";
+
+export function buildCodexVisibilityKey(
+  sectionKey: CodexVisibilitySectionKey,
+  itemKey?: string,
+): string {
+  return itemKey
+    ? `${CODEX_VISIBILITY_PREFIX}.${sectionKey}.${itemKey}`
+    : `${CODEX_VISIBILITY_PREFIX}.${sectionKey}`;
+}
+
+export function getEditHarnessPreviewData(raw: unknown): {
+  availableTools: HarnessToolKey[];
+  claudeHarnessData: HarnessData | null;
+  codexHarnessData: CodexHarnessData | null;
+} {
+  return {
+    availableTools: listHarnessTools(raw),
+    claudeHarnessData: getClaudeHarnessData(raw),
+    codexHarnessData: getCodexHarnessData(raw),
+  };
 }
 
 // Section config for narrative sections
@@ -133,6 +173,249 @@ function HideableCard({
         )}
       </div>
       {!hidden && children}
+    </div>
+  );
+}
+
+function CodexRecordSection({
+  title,
+  sectionKey,
+  entries,
+  color,
+  hiddenSections,
+  onToggle,
+}: {
+  title: string;
+  sectionKey: "toolUsage" | "cliTools";
+  entries: Array<[string, number]>;
+  color: string;
+  hiddenSections: Record<string, boolean>;
+  onToggle: (key: string) => void;
+}) {
+  if (entries.length === 0) return null;
+
+  const visibilityKey = buildCodexVisibilityKey(sectionKey);
+
+  return (
+    <HideableCard
+      title={title}
+      hidden={!!hiddenSections[visibilityKey]}
+      onToggle={() => onToggle(visibilityKey)}
+    >
+      <CollapsibleSection icon="" title={title} defaultOpen={false}>
+        <MiniBarChart
+          data={entries
+            .sort((a, b) => b[1] - a[1])
+            .map(([label, value]) => ({ label, value }))}
+          title=""
+          color={color}
+        />
+      </CollapsibleSection>
+    </HideableCard>
+  );
+}
+
+function CodexVisibilityPreview({
+  codexData,
+  hiddenSections,
+  onToggle,
+}: {
+  codexData: CodexHarnessData;
+  hiddenSections: Record<string, boolean>;
+  onToggle: (key: string) => void;
+}) {
+  const skillSectionKey = buildCodexVisibilityKey("skillInventory");
+  const pluginSectionKey = buildCodexVisibilityKey("plugins");
+  const workflowSectionKey = buildCodexVisibilityKey("workflowData");
+  const toolEntries = Object.entries(codexData.toolUsage ?? {});
+  const cliEntries = Object.entries(codexData.cliTools ?? {});
+  const workflowKeys = codexData.workflowData
+    ? Object.keys(codexData.workflowData)
+    : [];
+
+  return (
+    <div className="mt-6 border-t border-slate-200 pt-6 dark:border-slate-800">
+      <div className="mb-4">
+        <h2 className="text-base font-semibold text-slate-900 dark:text-white">
+          Codex Visibility
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Hide Codex-specific sections without changing the uploaded harness
+          data.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+          {typeof codexData.stats.totalTokens === "number" && (
+            <span className="rounded-full bg-slate-100 px-2 py-1 dark:bg-slate-800">
+              {codexData.stats.totalTokens.toLocaleString()} tokens
+            </span>
+          )}
+          {typeof codexData.stats.sessionCount === "number" && (
+            <span className="rounded-full bg-slate-100 px-2 py-1 dark:bg-slate-800">
+              {codexData.stats.sessionCount.toLocaleString()} sessions
+            </span>
+          )}
+          {codexData.localOnly && (
+            <span className="rounded-full bg-amber-100 px-2 py-1 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+              local CLI report
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <CodexRecordSection
+          title="Codex Tool Usage"
+          sectionKey="toolUsage"
+          entries={toolEntries}
+          color="bg-cyan-500"
+          hiddenSections={hiddenSections}
+          onToggle={onToggle}
+        />
+
+        <CodexRecordSection
+          title="Codex CLI Tools"
+          sectionKey="cliTools"
+          entries={cliEntries}
+          color="bg-emerald-500"
+          hiddenSections={hiddenSections}
+          onToggle={onToggle}
+        />
+
+        {codexData.skillInventory.length > 0 && (
+          <HideableCard
+            title="Codex Skills"
+            hidden={!!hiddenSections[skillSectionKey]}
+            onToggle={() => onToggle(skillSectionKey)}
+          >
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {codexData.skillInventory.map((skill, i) => {
+                const itemKey = buildItemKey(
+                  codexData.skillInventory,
+                  i,
+                  (s) => s.name,
+                );
+                const keypath = buildCodexVisibilityKey(
+                  "skillInventory",
+                  itemKey,
+                );
+                return (
+                  <HideableItem
+                    key={itemKey}
+                    hidden={!!hiddenSections[keypath]}
+                    onToggle={() => onToggle(keypath)}
+                  >
+                    <div className="h-full rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-900">
+                      <div className="font-mono text-xs font-semibold text-slate-800 dark:text-slate-100">
+                        {skill.name}
+                      </div>
+                      {skill.description && (
+                        <p className="mt-1 line-clamp-2 text-xs text-slate-500 dark:text-slate-400">
+                          {skill.description}
+                        </p>
+                      )}
+                      <div className="mt-2 flex flex-wrap gap-1 text-[11px] text-slate-400">
+                        {skill.source && <span>{skill.source}</span>}
+                        {skill.category && <span>{skill.category}</span>}
+                        {typeof skill.calls === "number" && (
+                          <span>{skill.calls.toLocaleString()} calls</span>
+                        )}
+                      </div>
+                    </div>
+                  </HideableItem>
+                );
+              })}
+            </div>
+          </HideableCard>
+        )}
+
+        {codexData.plugins.length > 0 && (
+          <HideableCard
+            title="Codex Plugins"
+            hidden={!!hiddenSections[pluginSectionKey]}
+            onToggle={() => onToggle(pluginSectionKey)}
+          >
+            <div className="grid gap-2 sm:grid-cols-2">
+              {codexData.plugins.map((plugin, i) => {
+                const itemKey = buildItemKey(
+                  codexData.plugins,
+                  i,
+                  (p) => p.name,
+                );
+                const keypath = buildCodexVisibilityKey("plugins", itemKey);
+                return (
+                  <HideableItem
+                    key={itemKey}
+                    hidden={!!hiddenSections[keypath]}
+                    onToggle={() => onToggle(keypath)}
+                  >
+                    <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="min-w-0 truncate font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+                          {plugin.name}
+                        </span>
+                        {typeof plugin.enabled === "boolean" && (
+                          <span
+                            className={clsx(
+                              "shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase",
+                              plugin.enabled
+                                ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                                : "bg-slate-100 text-slate-400 dark:bg-slate-800",
+                            )}
+                          >
+                            {plugin.enabled ? "on" : "off"}
+                          </span>
+                        )}
+                      </div>
+                      {(plugin.version || plugin.marketplace) && (
+                        <div className="mt-0.5 text-[11px] text-slate-400">
+                          {plugin.version && `v${plugin.version}`}
+                          {plugin.version && plugin.marketplace && " · "}
+                          {plugin.marketplace}
+                        </div>
+                      )}
+                    </div>
+                  </HideableItem>
+                );
+              })}
+            </div>
+          </HideableCard>
+        )}
+
+        {workflowKeys.length > 0 && (
+          <HideableCard
+            title="Codex Workflow Data"
+            hidden={!!hiddenSections[workflowSectionKey]}
+            onToggle={() => onToggle(workflowSectionKey)}
+          >
+            <CollapsibleSection
+              icon=""
+              title="Codex Workflow Data"
+              defaultOpen={false}
+            >
+              <div className="flex flex-wrap gap-2">
+                {workflowKeys.map((key) => (
+                  <span
+                    key={key}
+                    className="rounded border border-slate-200 bg-slate-50 px-2 py-1 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                  >
+                    {key}
+                  </span>
+                ))}
+              </div>
+            </CollapsibleSection>
+          </HideableCard>
+        )}
+
+        {toolEntries.length === 0 &&
+          cliEntries.length === 0 &&
+          codexData.skillInventory.length === 0 &&
+          codexData.plugins.length === 0 &&
+          workflowKeys.length === 0 && (
+            <p className="rounded-lg border border-slate-200 bg-slate-50 p-4 text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+              This Codex report does not include hideable Codex sections.
+            </p>
+          )}
+      </div>
     </div>
   );
 }
@@ -193,7 +476,7 @@ export default function EditReportPage() {
         } else {
           const r = data.data ?? data;
           r.harnessData = r.harnessData
-            ? normalizeHarnessData(r.harnessData)
+            ? normalizeHarnessEnvelope(r.harnessData)
             : null;
           if (!Array.isArray(r.reportProjects)) {
             r.reportProjects = [];
@@ -563,7 +846,11 @@ export default function EditReportPage() {
   }
 
   const isHarness = report.reportType === "insight-harness";
-  const harnessData = report.harnessData;
+  const {
+    availableTools: availableHarnessTools,
+    claudeHarnessData: harnessData,
+    codexHarnessData,
+  } = getEditHarnessPreviewData(report.harnessData);
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
@@ -618,6 +905,13 @@ export default function EditReportPage() {
       )}
 
       {/* Report preview with harness sections */}
+      {isHarness && availableHarnessTools.length > 1 && (
+        <div className="mb-5 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-400">
+          This report includes {availableHarnessTools.length} harness tools.
+          Claude Code and Codex visibility are edited separately below.
+        </div>
+      )}
+
       {isHarness && harnessData && (
         <>
           <HideableCard
@@ -1108,6 +1402,14 @@ export default function EditReportPage() {
             </HideableCard>
           )}
         </>
+      )}
+
+      {isHarness && codexHarnessData && (
+        <CodexVisibilityPreview
+          codexData={codexHarnessData}
+          hiddenSections={hiddenSections}
+          onToggle={toggleSection}
+        />
       )}
 
       {/* Projects attached to this report */}

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -39,7 +39,10 @@ import CollapsibleSection from "@/components/CollapsibleSection";
 import SectionRenderer from "@/components/SectionRenderer";
 import Link from "next/link";
 import clsx from "clsx";
-import { getHiddenKeypaths } from "@/lib/harness-section-visibility";
+import {
+  buildCodexVisibilityKey,
+  getHiddenKeypaths,
+} from "@/lib/harness-section-visibility";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 
 interface EditProject {
@@ -89,26 +92,6 @@ interface ReportData {
   onTheHorizon: unknown;
   reportProjects: EditReportProject[];
   author: { id: string; username: string; displayName: string | null };
-}
-
-type CodexVisibilitySectionKey =
-  | "toolUsage"
-  | "skillInventory"
-  | "plugins"
-  | "cliTools"
-  | "workflowData"
-  | "safety"
-  | "workSurfaces";
-
-const CODEX_VISIBILITY_PREFIX = "tools.codex";
-
-export function buildCodexVisibilityKey(
-  sectionKey: CodexVisibilitySectionKey,
-  itemKey?: string,
-): string {
-  return itemKey
-    ? `${CODEX_VISIBILITY_PREFIX}.${sectionKey}.${itemKey}`
-    : `${CODEX_VISIBILITY_PREFIX}.${sectionKey}`;
 }
 
 export function getEditHarnessPreviewData(raw: unknown): {

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -24,11 +24,13 @@ import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
 import {
   normalizeSkills,
-  normalizeHarnessData,
+  normalizeHarnessEnvelope,
+  listHarnessTools,
   type InsightsData,
   type ChartData,
   type SkillKey,
-  type HarnessData,
+  type HarnessToolKey,
+  type StoredHarnessData,
 } from "@/types/insights";
 import { normalizeChartData } from "@/lib/chart-parser";
 import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
@@ -47,6 +49,8 @@ import HooksSafetyTable from "@/components/HooksSafetyTable";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
 import MiniBarChart from "@/components/MiniBarChart";
+import ToolSelector from "@/components/ToolSelector";
+import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
 import {
   hideSetFromArray,
   isSectionHidden,
@@ -86,7 +90,7 @@ interface ReportData {
   avgSessionMinutes: number | null;
   prCount: number | null;
   autonomyLabel: string | null;
-  harnessData: HarnessData | null;
+  harnessData: StoredHarnessData | null;
   hiddenHarnessSections: string[];
   author: {
     username: string;
@@ -223,6 +227,8 @@ export default function InsightDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<ProfileTab>("dashboard");
+  const [activeTool, setActiveTool] =
+    useState<HarnessToolKey>("claude-code");
   // Set when the Dashboard's teaser card is clicked: we switch to the Skills
   // tab AND tell SkillsShowcaseSection which accordion item to auto-open.
   // Cleared on any manual tab change so a later direct tab-click doesn't
@@ -263,7 +269,9 @@ export default function InsightDetailPage() {
         if (raw) {
           raw.detectedSkills = normalizeSkills(raw.detectedSkills);
           raw.chartData = normalizeChartData(raw.chartData);
-          raw.harnessData = normalizeHarnessData(raw.harnessData);
+          const harnessEnvelope = normalizeHarnessEnvelope(raw.harnessData);
+          raw.harnessData = harnessEnvelope;
+          if (harnessEnvelope) setActiveTool(harnessEnvelope.primaryTool);
         }
         setReport(raw);
       })
@@ -311,6 +319,13 @@ export default function InsightDetailPage() {
   const isHarness = report.reportType === "insight-harness";
   const hiddenHarnessSections = report.hiddenHarnessSections ?? [];
   const hiddenSet = hideSetFromArray(hiddenHarnessSections);
+  const harnessEnvelope = normalizeHarnessEnvelope(report.harnessData);
+  const availableTools = listHarnessTools(harnessEnvelope);
+  const selectedTool = availableTools.includes(activeTool)
+    ? activeTool
+    : (harnessEnvelope?.primaryTool ?? "claude-code");
+  const claudeHarnessData = harnessEnvelope?.tools["claude-code"] ?? null;
+  const codexHarnessData = harnessEnvelope?.tools.codex ?? null;
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-8">
@@ -379,8 +394,20 @@ export default function InsightDetailPage() {
       </div>
 
       {/* ── Harness Report Layout ── */}
-      {isHarness && report.harnessData ? (
+      {isHarness && harnessEnvelope ? (
         <>
+          <ToolSelector
+            tools={availableTools}
+            active={selectedTool}
+            onChange={setActiveTool}
+          />
+
+          {selectedTool === "codex" && codexHarnessData && (
+            <CodexHarnessDashboard codexData={codexHarnessData} />
+          )}
+
+          {selectedTool === "claude-code" && claudeHarnessData && (
+            <>
           {/* Three-tab navigation — Dashboard (default) / Write-up / Claude Insights.
               Mirrors the insight-harness HTML report structure. A Skill
               Showcase tab will slot in as tab #4 when that feature ships. */}
@@ -391,22 +418,22 @@ export default function InsightDetailPage() {
               {/* Hero Stats */}
               {!isSectionHidden(hiddenSet, "heroStats") && (
                 <HeroStats
-                  stats={report.harnessData.stats}
+                  stats={claudeHarnessData.stats}
                   dayCount={report.dayCount}
                   sessionCount={
                     report.sessionCount ||
-                    report.harnessData?.stats?.sessionCount ||
+                    claudeHarnessData?.stats?.sessionCount ||
                     0
                   }
                   linesAdded={resolveLinesAdded({
                     linesAdded: report.linesAdded,
                     linesRemoved: report.linesRemoved,
-                    harnessData: report.harnessData,
+                    harnessData: claudeHarnessData,
                   })}
                   linesRemoved={resolveLinesRemoved({
                     linesAdded: report.linesAdded,
                     linesRemoved: report.linesRemoved,
-                    harnessData: report.harnessData,
+                    harnessData: claudeHarnessData,
                   })}
                 />
               )}
@@ -416,16 +443,16 @@ export default function InsightDetailPage() {
                 <ActivityHeatmap
                   totalSessions={
                     report.sessionCount ??
-                    report.harnessData?.stats?.sessionCount ??
+                    claudeHarnessData?.stats?.sessionCount ??
                     undefined
                   }
                   totalTokens={report.totalTokens ?? undefined}
                   dayCount={report.dayCount ?? undefined}
                   dateRangeStart={report.dateRangeStart ?? undefined}
                   slug={slug}
-                  models={report.harnessData?.models ?? undefined}
+                  models={claudeHarnessData?.models ?? undefined}
                   perModelTokens={
-                    report.harnessData?.perModelTokens ?? undefined
+                    claudeHarnessData?.perModelTokens ?? undefined
                   }
                 />
               )}
@@ -442,7 +469,7 @@ export default function InsightDetailPage() {
 
               {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
               {!isSectionHidden(hiddenSet, "howIWork") && (
-                <HowIWorkCluster harnessData={report.harnessData} />
+                <HowIWorkCluster harnessData={claudeHarnessData} />
               )}
 
               {/* Skills Teaser — hero-thumbnail cards for the top shareable
@@ -453,10 +480,10 @@ export default function InsightDetailPage() {
                   workflow diagram so the deep-dives sit next to the
                   behavioral context that motivates them. */}
               {!isSectionHidden(hiddenSet, "skillInventory") &&
-                report.harnessData.skillInventory.length > 0 && (
+                claudeHarnessData.skillInventory.length > 0 && (
                   <SkillsTeaserCard
                     skillInventory={filterList(
-                      report.harnessData.skillInventory,
+                      claudeHarnessData.skillInventory,
                       hiddenSet,
                       "skillInventory",
                       (s) => s.name,
@@ -466,18 +493,18 @@ export default function InsightDetailPage() {
                 )}
 
               {/* Workflow Diagrams */}
-              {report.harnessData.workflowData &&
+              {claudeHarnessData.workflowData &&
                 !isSectionHidden(hiddenSet, "workflowData") && (
                   <WorkflowDiagram
-                    workflowData={report.harnessData.workflowData}
-                    agentDispatch={report.harnessData.agentDispatch}
+                    workflowData={claudeHarnessData.workflowData}
+                    agentDispatch={claudeHarnessData.agentDispatch}
                     authorHandle={report.author.username}
                   />
                 )}
 
               {/* Plugins */}
               {!isSectionHidden(hiddenSet, "plugins") &&
-                report.harnessData.plugins.length > 0 && (
+                claudeHarnessData.plugins.length > 0 && (
                   <CollapsibleSection
                     icon="🔌"
                     iconBgClass="bg-teal-100 dark:bg-teal-900/30"
@@ -486,7 +513,7 @@ export default function InsightDetailPage() {
                   >
                     <div className="grid gap-2 sm:grid-cols-2">
                       {filterList(
-                        report.harnessData.plugins,
+                        claudeHarnessData.plugins,
                         hiddenSet,
                         "plugins",
                         (p) => p.name,
@@ -524,50 +551,50 @@ export default function InsightDetailPage() {
 
               {/* Tool Usage Treemap */}
               {!isSectionHidden(hiddenSet, "toolUsage") &&
-                Object.keys(report.harnessData.toolUsage).length > 0 && (
-                  <ToolUsageTreemap toolUsage={report.harnessData.toolUsage} />
+                Object.keys(claudeHarnessData.toolUsage).length > 0 && (
+                  <ToolUsageTreemap toolUsage={claudeHarnessData.toolUsage} />
                 )}
 
               {/* CLI Tools Donut */}
               {!isSectionHidden(hiddenSet, "cliTools") &&
-                Object.keys(report.harnessData.cliTools).length > 0 && (
-                  <CliToolsDonut cliTools={report.harnessData.cliTools} />
+                Object.keys(claudeHarnessData.cliTools).length > 0 && (
+                  <CliToolsDonut cliTools={claudeHarnessData.cliTools} />
                 )}
 
               {/* Git Patterns */}
               {!isSectionHidden(hiddenSet, "gitPatterns") && (
                 <GitPatternsDisplay
-                  gitPatterns={report.harnessData.gitPatterns}
+                  gitPatterns={claudeHarnessData.gitPatterns}
                 />
               )}
 
               {/* Permission Mode & Safety */}
               {!isSectionHidden(hiddenSet, "permissionModes") && (
                 <PermissionModeDisplay
-                  permissionModes={report.harnessData.permissionModes}
-                  featurePills={report.harnessData.featurePills}
+                  permissionModes={claudeHarnessData.permissionModes}
+                  featurePills={claudeHarnessData.featurePills}
                 />
               )}
 
               {/* Hooks & Safety */}
               {!isSectionHidden(hiddenSet, "hookDefinitions") && (
                 <HooksSafetyTable
-                  hookDefinitions={report.harnessData.hookDefinitions}
+                  hookDefinitions={claudeHarnessData.hookDefinitions}
                 />
               )}
 
               {/* Agent Dispatch */}
               {!isSectionHidden(hiddenSet, "agentDispatch") &&
-                report.harnessData.agentDispatch &&
-                report.harnessData.agentDispatch.totalAgents > 0 && (
+                claudeHarnessData.agentDispatch &&
+                claudeHarnessData.agentDispatch.totalAgents > 0 && (
                   <CollapsibleSection
                     icon="🤖"
                     iconBgClass="bg-indigo-100 dark:bg-indigo-900/30"
-                    title={`Agent Dispatch (${report.harnessData.agentDispatch.totalAgents} agents)`}
+                    title={`Agent Dispatch (${claudeHarnessData.agentDispatch.totalAgents} agents)`}
                     defaultOpen={false}
                   >
                     <div className="grid gap-4 sm:grid-cols-2">
-                      {Object.keys(report.harnessData.agentDispatch.types)
+                      {Object.keys(claudeHarnessData.agentDispatch.types)
                         .length > 0 && (
                         <div>
                           <h4 className="mb-2 text-xs font-semibold text-slate-500">
@@ -575,14 +602,14 @@ export default function InsightDetailPage() {
                           </h4>
                           <MiniBarChart
                             data={Object.entries(
-                              report.harnessData.agentDispatch.types,
+                              claudeHarnessData.agentDispatch.types,
                             ).map(([label, value]) => ({ label, value }))}
                             title=""
                             color="bg-indigo-500"
                           />
                         </div>
                       )}
-                      {Object.keys(report.harnessData.agentDispatch.models)
+                      {Object.keys(claudeHarnessData.agentDispatch.models)
                         .length > 0 && (
                         <div>
                           <h4 className="mb-2 text-xs font-semibold text-slate-500">
@@ -590,29 +617,29 @@ export default function InsightDetailPage() {
                           </h4>
                           <MiniBarChart
                             data={Object.entries(
-                              report.harnessData.agentDispatch.models,
+                              claudeHarnessData.agentDispatch.models,
                             ).map(([label, value]) => ({ label, value }))}
                             title=""
                             color="bg-purple-500"
                           />
-                          {report.harnessData.agentDispatch.backgroundPct >
+                          {claudeHarnessData.agentDispatch.backgroundPct >
                             0 && (
                             <p className="mt-1 text-xs text-slate-400">
-                              {report.harnessData.agentDispatch.backgroundPct}%
+                              {claudeHarnessData.agentDispatch.backgroundPct}%
                               run in background
                             </p>
                           )}
                         </div>
                       )}
                     </div>
-                    {report.harnessData.agentDispatch.customAgents.length >
+                    {claudeHarnessData.agentDispatch.customAgents.length >
                       0 && (
                       <div className="mt-3">
                         <h4 className="mb-1 text-xs font-semibold text-slate-500">
                           Custom Agents
                         </h4>
                         <div className="flex flex-wrap gap-1.5">
-                          {report.harnessData.agentDispatch.customAgents.map(
+                          {claudeHarnessData.agentDispatch.customAgents.map(
                             (a) => (
                               <span
                                 key={a}
@@ -630,7 +657,7 @@ export default function InsightDetailPage() {
 
               {/* Languages */}
               {!isSectionHidden(hiddenSet, "languages") &&
-                Object.keys(report.harnessData.languages).length > 0 && (
+                Object.keys(claudeHarnessData.languages).length > 0 && (
                   <CollapsibleSection
                     icon="💻"
                     iconBgClass="bg-green-100 dark:bg-green-900/30"
@@ -640,7 +667,7 @@ export default function InsightDetailPage() {
                     <MiniBarChart
                       data={Object.entries(
                         filterRecord(
-                          report.harnessData.languages,
+                          claudeHarnessData.languages,
                           hiddenSet,
                           "languages",
                         ),
@@ -656,7 +683,7 @@ export default function InsightDetailPage() {
 
               {/* MCP Servers */}
               {!isSectionHidden(hiddenSet, "mcpServers") &&
-                Object.keys(report.harnessData.mcpServers).length > 0 && (
+                Object.keys(claudeHarnessData.mcpServers).length > 0 && (
                   <CollapsibleSection
                     icon="🔗"
                     iconBgClass="bg-cyan-100 dark:bg-cyan-900/30"
@@ -666,7 +693,7 @@ export default function InsightDetailPage() {
                     <div className="space-y-1">
                       {Object.entries(
                         filterRecord(
-                          report.harnessData.mcpServers,
+                          claudeHarnessData.mcpServers,
                           hiddenSet,
                           "mcpServers",
                         ),
@@ -691,7 +718,7 @@ export default function InsightDetailPage() {
 
               {/* Versions */}
               {!isSectionHidden(hiddenSet, "versions") &&
-                report.harnessData.versions.length > 0 && (
+                claudeHarnessData.versions.length > 0 && (
                   <CollapsibleSection
                     icon="📦"
                     iconBgClass="bg-slate-100 dark:bg-slate-900/30"
@@ -700,7 +727,7 @@ export default function InsightDetailPage() {
                   >
                     <div className="flex flex-wrap gap-1.5">
                       {filterList(
-                        report.harnessData.versions,
+                        claudeHarnessData.versions,
                         hiddenSet,
                         "versions",
                         (v) => v,
@@ -718,7 +745,7 @@ export default function InsightDetailPage() {
 
               {/* Harness Files */}
               {!isSectionHidden(hiddenSet, "harnessFiles") &&
-                report.harnessData.harnessFiles.length > 0 && (
+                claudeHarnessData.harnessFiles.length > 0 && (
                   <CollapsibleSection
                     icon="📁"
                     iconBgClass="bg-orange-100 dark:bg-orange-900/30"
@@ -727,7 +754,7 @@ export default function InsightDetailPage() {
                   >
                     <div className="space-y-1">
                       {filterList(
-                        report.harnessData.harnessFiles,
+                        claudeHarnessData.harnessFiles,
                         hiddenSet,
                         "harnessFiles",
                         (f) => f,
@@ -748,11 +775,11 @@ export default function InsightDetailPage() {
           {activeTab === "skills" && (
             <>
               {!isSectionHidden(hiddenSet, "skillInventory") &&
-                report.harnessData.skillInventory.length > 0 && (
+                claudeHarnessData.skillInventory.length > 0 && (
                   <div className="space-y-6">
                     <SkillsShowcaseSection
                       skillInventory={filterList(
-                        report.harnessData.skillInventory,
+                        claudeHarnessData.skillInventory,
                         hiddenSet,
                         "skillInventory",
                         (s) => s.name,
@@ -761,7 +788,7 @@ export default function InsightDetailPage() {
                     />
                     <SkillCardGrid
                       skillInventory={filterList(
-                        report.harnessData.skillInventory,
+                        claudeHarnessData.skillInventory,
                         hiddenSet,
                         "skillInventory",
                         (s) => s.name,
@@ -779,10 +806,10 @@ export default function InsightDetailPage() {
                   want the narrative don't scroll past all the dashboard
                   charts to find it. */}
               {!isSectionHidden(hiddenSet, "writeupSections") &&
-              report.harnessData.writeupSections.length > 0 ? (
+              claudeHarnessData.writeupSections.length > 0 ? (
                 <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
                   {filterList(
-                    report.harnessData.writeupSections,
+                    claudeHarnessData.writeupSections,
                     hiddenSet,
                     "writeupSections",
                     (w) => w.title,
@@ -859,6 +886,8 @@ export default function InsightDetailPage() {
           )}
 
           <NextTabNav active={activeTab} onChange={handleTabChange} />
+            </>
+          )}
         </>
       ) : (
         /* ── Standard /insights Report Layout ── */

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -403,7 +403,16 @@ export default function InsightDetailPage() {
           />
 
           {selectedTool === "codex" && codexHarnessData && (
-            <CodexHarnessDashboard codexData={codexHarnessData} />
+            <>
+              {report.reportProjects.length > 0 && (
+                <div className="mb-6">
+                  <ProjectLinks
+                    links={report.reportProjects.map((rp) => rp.project)}
+                  />
+                </div>
+              )}
+              <CodexHarnessDashboard codexData={codexHarnessData} />
+            </>
           )}
 
           {selectedTool === "claude-code" && claudeHarnessData && (

--- a/src/app/insights/__tests__/edit-flow.test.ts
+++ b/src/app/insights/__tests__/edit-flow.test.ts
@@ -1,5 +1,89 @@
 import { describe, it, expect } from "vitest";
 import { ALLOWED_PUT_FIELDS } from "@/app/api/insights/allowed-fields";
+import {
+  buildCodexVisibilityKey,
+  getEditHarnessPreviewData,
+} from "@/app/insights/[username]/[slug]/edit/page";
+import type { CodexHarnessData, HarnessData } from "@/types/insights";
+
+function legacyClaude(overrides: Partial<HarnessData> = {}): HarnessData {
+  return {
+    stats: {
+      totalTokens: 1000,
+      durationHours: 4,
+      avgSessionMinutes: 24,
+      skillsUsedCount: 1,
+      hooksCount: 0,
+      prCount: 1,
+      sessionCount: 3,
+      commitCount: 2,
+    },
+    autonomy: {
+      label: "Guided",
+      description: "Mostly supervised",
+      userMessages: 5,
+      assistantMessages: 10,
+      turnCount: 15,
+      errorRate: "0%",
+    },
+    featurePills: [],
+    toolUsage: { Read: 2 },
+    skillInventory: [
+      { name: "review", calls: 1, source: "custom", description: "Review" },
+    ],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      readPct: 70,
+      editPct: 20,
+      writePct: 10,
+      grepCount: 1,
+      globCount: 0,
+      style: "read-heavy",
+    },
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 1,
+      commitCount: 2,
+      linesAdded: "100",
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "hash",
+    skillVersion: "2.8.0",
+    ...overrides,
+  };
+}
+
+function codex(overrides: Partial<CodexHarnessData> = {}): CodexHarnessData {
+  return {
+    tool: "codex",
+    stats: { totalTokens: 2000, sessionCount: 7 },
+    toolUsage: { exec_command: 5 },
+    cliTools: { git: 3 },
+    skillInventory: [{ name: "code-review", description: "Review code" }],
+    plugins: [{ name: "github", enabled: true }],
+    safety: {
+      approvalsReviewer: "model",
+      approvalModes: ["approve"],
+      trustLevels: ["trusted"],
+      rulesAllowlist: ["git"],
+    },
+    workflowData: { phaseTransitions: {} },
+    workSurfaces: { desktopPresence: [{ tool: "Codex CLI" }] },
+    localOnly: true,
+    ...overrides,
+  };
+}
 
 describe("Edit report visibility flow", () => {
   it("should allow nulling out a section via PUT", () => {
@@ -19,6 +103,45 @@ describe("Edit report visibility flow", () => {
   it("should reject harnessData in PUT body", () => {
     // harnessData must not be in the allowlist (XSS vector via dangerouslySetInnerHTML)
     expect(ALLOWED_PUT_FIELDS).not.toContain("harnessData");
+  });
+
+  it("derives the Claude slice for legacy and envelope edit previews", () => {
+    const legacyPreview = getEditHarnessPreviewData(legacyClaude());
+    expect(legacyPreview.availableTools).toEqual(["claude-code"]);
+    expect(legacyPreview.claudeHarnessData?.stats.totalTokens).toBe(1000);
+    expect(legacyPreview.codexHarnessData).toBeNull();
+
+    const envelopePreview = getEditHarnessPreviewData({
+      primaryTool: "claude-code",
+      tools: {
+        "claude-code": legacyClaude(),
+        codex: codex(),
+      },
+    });
+    expect(envelopePreview.availableTools).toEqual(["claude-code", "codex"]);
+    expect(envelopePreview.claudeHarnessData?.skillInventory[0].name).toBe(
+      "review",
+    );
+    expect(envelopePreview.codexHarnessData?.skillInventory[0].name).toBe(
+      "code-review",
+    );
+  });
+
+  it("derives a Codex-only edit preview without requiring a Claude slice", () => {
+    const preview = getEditHarnessPreviewData(codex());
+
+    expect(preview.availableTools).toEqual(["codex"]);
+    expect(preview.claudeHarnessData).toBeNull();
+    expect(preview.codexHarnessData?.stats.totalTokens).toBe(2000);
+  });
+
+  it("builds namespaced Codex visibility keys", () => {
+    expect(buildCodexVisibilityKey("skillInventory")).toBe(
+      "tools.codex.skillInventory",
+    );
+    expect(buildCodexVisibilityKey("skillInventory", "code-review")).toBe(
+      "tools.codex.skillInventory.code-review",
+    );
   });
 
   it("should allow nulling stat fields", () => {

--- a/src/app/insights/__tests__/edit-flow.test.ts
+++ b/src/app/insights/__tests__/edit-flow.test.ts
@@ -142,6 +142,10 @@ describe("Edit report visibility flow", () => {
     expect(buildCodexVisibilityKey("skillInventory", "code-review")).toBe(
       "tools.codex.skillInventory.code-review",
     );
+    expect(buildCodexVisibilityKey("safety")).toBe("tools.codex.safety");
+    expect(buildCodexVisibilityKey("workSurfaces")).toBe(
+      "tools.codex.workSurfaces",
+    );
   });
 
   it("should allow nulling stat fields", () => {

--- a/src/app/insights/__tests__/edit-flow.test.ts
+++ b/src/app/insights/__tests__/edit-flow.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { ALLOWED_PUT_FIELDS } from "@/app/api/insights/allowed-fields";
-import {
-  buildCodexVisibilityKey,
-  getEditHarnessPreviewData,
-} from "@/app/insights/[username]/[slug]/edit/page";
+import { getEditHarnessPreviewData } from "@/app/insights/[username]/[slug]/edit/page";
+import { buildCodexVisibilityKey } from "@/lib/harness-section-visibility";
 import type { CodexHarnessData, HarnessData } from "@/types/insights";
 
 function legacyClaude(overrides: Partial<HarnessData> = {}): HarnessData {

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -35,7 +35,11 @@ import type {
 } from "@/types/insights";
 import { applyRedactions } from "@/lib/redaction";
 import { normalizeChartData } from "@/lib/chart-parser";
-import { normalizeHarnessData, normalizeSkills } from "@/types/insights";
+import {
+  normalizeHarnessData,
+  normalizeHarnessEnvelope,
+  normalizeSkills,
+} from "@/types/insights";
 import SectionRenderer from "@/components/SectionRenderer";
 import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
@@ -51,6 +55,7 @@ import WorkflowDiagram from "@/components/WorkflowDiagram";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import ProjectLinks from "@/components/ProjectLinks";
 import MiniBarChart from "@/components/MiniBarChart";
+import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
 import { getHiddenKeypaths } from "@/lib/harness-section-visibility";
 import { buildItemKey } from "@/lib/item-visibility";
 import HideableItem from "@/components/HideableItem";
@@ -59,6 +64,10 @@ import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { buildOgImageUrl, buildReportUrl } from "@/lib/urls";
 
 type Step = "upload" | "projects" | "review";
+
+function buildCodexVisibilityKey(sectionKey: string): string {
+  return `tools.codex.${sectionKey}`;
+}
 
 /** Library Project as returned by GET /api/projects. */
 interface LibraryProject {
@@ -1652,6 +1661,10 @@ export default function UploadPage() {
   const previewHarnessData = parsed?.harnessData
     ? normalizeHarnessData(parsed.harnessData)
     : null;
+  const previewHarnessEnvelope = parsed?.harnessData
+    ? normalizeHarnessEnvelope(parsed.harnessData)
+    : null;
+  const previewCodexData = previewHarnessEnvelope?.tools.codex ?? null;
   const legacyContent = (
     <>
       <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
@@ -2328,6 +2341,74 @@ export default function UploadPage() {
             )}
           </div>
 
+          {parsed.reportType === "insight-harness" &&
+            previewCodexData &&
+            !previewHarnessData && (
+              <div className="space-y-4">
+                <RedactableSection
+                  title="Codex Tool Usage"
+                  enabled={!disabledSections[buildCodexVisibilityKey("toolUsage")]}
+                  onToggle={() =>
+                    toggleSection(buildCodexVisibilityKey("toolUsage"))
+                  }
+                >
+                  <CodexHarnessDashboard codexData={previewCodexData} />
+                </RedactableSection>
+                <RedactableSection
+                  title="Codex Skills"
+                  enabled={
+                    !disabledSections[
+                      buildCodexVisibilityKey("skillInventory")
+                    ]
+                  }
+                  onToggle={() =>
+                    toggleSection(buildCodexVisibilityKey("skillInventory"))
+                  }
+                >
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                    {previewCodexData.skillInventory.length.toLocaleString()}{" "}
+                    inventory items
+                  </div>
+                </RedactableSection>
+                <RedactableSection
+                  title="Codex Plugins"
+                  enabled={!disabledSections[buildCodexVisibilityKey("plugins")]}
+                  onToggle={() =>
+                    toggleSection(buildCodexVisibilityKey("plugins"))
+                  }
+                >
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                    {previewCodexData.plugins.length.toLocaleString()} plugins
+                  </div>
+                </RedactableSection>
+                <RedactableSection
+                  title="Codex Safety And Rules"
+                  enabled={!disabledSections[buildCodexVisibilityKey("safety")]}
+                  onToggle={() =>
+                    toggleSection(buildCodexVisibilityKey("safety"))
+                  }
+                >
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                    Safety metadata will be shown unless hidden.
+                  </div>
+                </RedactableSection>
+                <RedactableSection
+                  title="Codex Work Surfaces"
+                  enabled={
+                    !disabledSections[buildCodexVisibilityKey("workSurfaces")]
+                  }
+                  onToggle={() =>
+                    toggleSection(buildCodexVisibilityKey("workSurfaces"))
+                  }
+                >
+                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                    {previewCodexData.workSurfaces.desktopPresence.length.toLocaleString()}{" "}
+                    desktop signals
+                  </div>
+                </RedactableSection>
+              </div>
+            )}
+
           {/* ── Harness Report Preview — mirrors profile page layout ── */}
           {parsed.reportType === "insight-harness" && previewHarnessData ? (
             <>
@@ -2826,7 +2907,7 @@ export default function UploadPage() {
                 })}
               </div>
             </>
-          ) : (
+          ) : previewCodexData ? null : (
             /* ── Standard Insights Report Preview ── */
             <>
               <SnapshotCard

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -35,7 +35,7 @@ import type {
 } from "@/types/insights";
 import { applyRedactions } from "@/lib/redaction";
 import { normalizeChartData } from "@/lib/chart-parser";
-import { normalizeSkills } from "@/types/insights";
+import { normalizeHarnessData, normalizeSkills } from "@/types/insights";
 import SectionRenderer from "@/components/SectionRenderer";
 import SnapshotCard from "@/components/SnapshotCard";
 import CollapsibleSection from "@/components/CollapsibleSection";
@@ -1498,6 +1498,7 @@ export default function UploadPage() {
         });
       }
       const isHarness = parsed.reportType === "insight-harness";
+      const claudeHarnessData = normalizeHarnessData(parsed.harnessData);
       const title = isHarness
         ? `${firstName}'s Insight Harness - ${titleDate}`
         : `${firstName}'s Claude Code Insights - ${titleDate}`;
@@ -1544,12 +1545,12 @@ export default function UploadPage() {
           detectedSkills: parsed.detectedSkills,
           // v3: Harness fields
           reportType: parsed.reportType ?? "insights",
-          totalTokens: parsed.harnessData?.stats.totalTokens ?? null,
-          durationHours: parsed.harnessData?.stats.durationHours ?? null,
+          totalTokens: claudeHarnessData?.stats.totalTokens ?? null,
+          durationHours: claudeHarnessData?.stats.durationHours ?? null,
           avgSessionMinutes:
-            parsed.harnessData?.stats.avgSessionMinutes ?? null,
-          prCount: parsed.harnessData?.stats.prCount ?? null,
-          autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
+            claudeHarnessData?.stats.avgSessionMinutes ?? null,
+          prCount: claudeHarnessData?.stats.prCount ?? null,
+          autonomyLabel: claudeHarnessData?.autonomy.label ?? null,
           // Persist the FULL harnessData (including hidden showcase content).
           // Filtering is applied server-side in filterReportForResponse on
           // every GET, so third parties never see hidden data, while the
@@ -1648,6 +1649,9 @@ export default function UploadPage() {
   //     DIRECT_POST_ENABLED is true.
   // The render-time hierarchy and all wizard internals (drop zone,
   // project picker, review step) are preserved verbatim.
+  const previewHarnessData = parsed?.harnessData
+    ? normalizeHarnessData(parsed.harnessData)
+    : null;
   const legacyContent = (
     <>
       <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
@@ -2325,7 +2329,7 @@ export default function UploadPage() {
           </div>
 
           {/* ── Harness Report Preview — mirrors profile page layout ── */}
-          {parsed.reportType === "insight-harness" && parsed.harnessData ? (
+          {parsed.reportType === "insight-harness" && previewHarnessData ? (
             <>
               {/* Hero Stats */}
               <RedactableSection
@@ -2334,22 +2338,22 @@ export default function UploadPage() {
                 onToggle={() => toggleSection("heroStats")}
               >
                 <HeroStats
-                  stats={parsed.harnessData.stats}
+                  stats={previewHarnessData.stats}
                   dayCount={parsed.stats.dayCount ?? null}
                   sessionCount={
                     parsed.stats.sessionCount ??
-                    parsed.harnessData.stats.sessionCount ??
+                    previewHarnessData.stats.sessionCount ??
                     0
                   }
                   linesAdded={resolveLinesAdded({
                     linesAdded: parsed.stats.linesAdded ?? null,
                     linesRemoved: parsed.stats.linesRemoved ?? null,
-                    harnessData: parsed.harnessData,
+                    harnessData: previewHarnessData,
                   })}
                   linesRemoved={resolveLinesRemoved({
                     linesAdded: parsed.stats.linesAdded ?? null,
                     linesRemoved: parsed.stats.linesRemoved ?? null,
-                    harnessData: parsed.harnessData,
+                    harnessData: previewHarnessData,
                   })}
                 />
               </RedactableSection>
@@ -2363,17 +2367,17 @@ export default function UploadPage() {
                 <ActivityHeatmap
                   totalSessions={
                     parsed.stats.sessionCount ??
-                    parsed.harnessData.stats.sessionCount ??
+                    previewHarnessData.stats.sessionCount ??
                     undefined
                   }
                   totalTokens={
-                    parsed.harnessData.stats.totalTokens ?? undefined
+                    previewHarnessData.stats.totalTokens ?? undefined
                   }
                   dayCount={parsed.stats.dayCount ?? undefined}
                   dateRangeStart={parsed.stats.dateRangeStart ?? undefined}
                   slug="preview"
-                  models={parsed.harnessData.models}
-                  perModelTokens={parsed.harnessData.perModelTokens}
+                  models={previewHarnessData.models}
+                  perModelTokens={previewHarnessData.perModelTokens}
                 />
               </RedactableSection>
 
@@ -2383,38 +2387,38 @@ export default function UploadPage() {
                 enabled={!disabledSections["howIWork"]}
                 onToggle={() => toggleSection("howIWork")}
               >
-                <HowIWorkCluster harnessData={parsed.harnessData} />
+                <HowIWorkCluster harnessData={previewHarnessData} />
               </RedactableSection>
 
               {/* Workflow Diagrams */}
-              {parsed.harnessData.workflowData && (
+              {previewHarnessData.workflowData && (
                 <RedactableSection
                   title="Workflow Diagrams"
                   enabled={!disabledSections["workflowData"]}
                   onToggle={() => toggleSection("workflowData")}
                 >
                   <WorkflowDiagram
-                    workflowData={parsed.harnessData.workflowData}
-                    agentDispatch={parsed.harnessData.agentDispatch}
+                    workflowData={previewHarnessData.workflowData}
+                    agentDispatch={previewHarnessData.agentDispatch}
                   />
                 </RedactableSection>
               )}
 
               {/* Skills Card Grid */}
-              {parsed.harnessData.skillInventory.length > 0 && (
+              {previewHarnessData.skillInventory.length > 0 && (
                 <RedactableSection
                   title="Skills"
                   enabled={!disabledSections["skillInventory"]}
                   onToggle={() => toggleSection("skillInventory")}
                 >
                   <SkillCardGrid
-                    skillInventory={parsed.harnessData.skillInventory}
+                    skillInventory={previewHarnessData.skillInventory}
                   />
                   {/* Per-skill showcase visibility — only shown when at least
                       one skill carries renderable showcase content, since
                       that's the only case where item-level hides matter for
                       privacy on the public report. */}
-                  {parsed.harnessData.skillInventory.some(
+                  {previewHarnessData.skillInventory.some(
                     hasShowcaseContent,
                   ) && (
                     <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-800">
@@ -2422,10 +2426,10 @@ export default function UploadPage() {
                         Skill Showcase — toggle individual skills
                       </div>
                       <div className="space-y-2">
-                        {parsed.harnessData.skillInventory.map((skill, i) => {
+                        {previewHarnessData.skillInventory.map((skill, i) => {
                           if (!hasShowcaseContent(skill)) return null;
                           const itemKey = buildItemKey(
-                            parsed.harnessData!.skillInventory,
+                            previewHarnessData.skillInventory,
                             i,
                             (s) => s.name,
                           );
@@ -2452,7 +2456,7 @@ export default function UploadPage() {
               )}
 
               {/* Plugins */}
-              {parsed.harnessData.plugins.length > 0 && (
+              {previewHarnessData.plugins.length > 0 && (
                 <RedactableSection
                   title="Plugins"
                   enabled={!disabledSections["plugins"]}
@@ -2465,7 +2469,7 @@ export default function UploadPage() {
                     defaultOpen={true}
                   >
                     <div className="grid gap-2 sm:grid-cols-2">
-                      {parsed.harnessData.plugins.map((plugin) => (
+                      {previewHarnessData.plugins.map((plugin) => (
                         <div
                           key={plugin.name}
                           className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
@@ -2499,24 +2503,24 @@ export default function UploadPage() {
               )}
 
               {/* Tool Usage Treemap */}
-              {Object.keys(parsed.harnessData.toolUsage).length > 0 && (
+              {Object.keys(previewHarnessData.toolUsage).length > 0 && (
                 <RedactableSection
                   title="Tool Usage"
                   enabled={!disabledSections["toolUsage"]}
                   onToggle={() => toggleSection("toolUsage")}
                 >
-                  <ToolUsageTreemap toolUsage={parsed.harnessData.toolUsage} />
+                  <ToolUsageTreemap toolUsage={previewHarnessData.toolUsage} />
                 </RedactableSection>
               )}
 
               {/* CLI Tools Donut */}
-              {Object.keys(parsed.harnessData.cliTools).length > 0 && (
+              {Object.keys(previewHarnessData.cliTools).length > 0 && (
                 <RedactableSection
                   title="CLI Tools"
                   enabled={!disabledSections["cliTools"]}
                   onToggle={() => toggleSection("cliTools")}
                 >
-                  <CliToolsDonut cliTools={parsed.harnessData.cliTools} />
+                  <CliToolsDonut cliTools={previewHarnessData.cliTools} />
                 </RedactableSection>
               )}
 
@@ -2527,7 +2531,7 @@ export default function UploadPage() {
                 onToggle={() => toggleSection("gitPatterns")}
               >
                 <GitPatternsDisplay
-                  gitPatterns={parsed.harnessData.gitPatterns}
+                  gitPatterns={previewHarnessData.gitPatterns}
                 />
               </RedactableSection>
 
@@ -2538,27 +2542,27 @@ export default function UploadPage() {
                 onToggle={() => toggleSection("permissionModes")}
               >
                 <PermissionModeDisplay
-                  permissionModes={parsed.harnessData.permissionModes}
-                  featurePills={parsed.harnessData.featurePills}
+                  permissionModes={previewHarnessData.permissionModes}
+                  featurePills={previewHarnessData.featurePills}
                 />
               </RedactableSection>
 
               {/* Hooks & Safety */}
-              {parsed.harnessData.hookDefinitions.length > 0 && (
+              {previewHarnessData.hookDefinitions.length > 0 && (
                 <RedactableSection
                   title="Hooks & Safety"
                   enabled={!disabledSections["hookDefinitions"]}
                   onToggle={() => toggleSection("hookDefinitions")}
                 >
                   <HooksSafetyTable
-                    hookDefinitions={parsed.harnessData.hookDefinitions}
+                    hookDefinitions={previewHarnessData.hookDefinitions}
                   />
                 </RedactableSection>
               )}
 
               {/* Agent Dispatch */}
-              {parsed.harnessData.agentDispatch &&
-                parsed.harnessData.agentDispatch.totalAgents > 0 && (
+              {previewHarnessData.agentDispatch &&
+                previewHarnessData.agentDispatch.totalAgents > 0 && (
                   <RedactableSection
                     title="Agent Dispatch"
                     enabled={!disabledSections["agentDispatch"]}
@@ -2567,11 +2571,11 @@ export default function UploadPage() {
                     <CollapsibleSection
                       icon="🤖"
                       iconBgClass="bg-indigo-100 dark:bg-indigo-900/30"
-                      title={`Agent Dispatch (${parsed.harnessData.agentDispatch.totalAgents} agents)`}
+                      title={`Agent Dispatch (${previewHarnessData.agentDispatch.totalAgents} agents)`}
                       defaultOpen={false}
                     >
                       <div className="grid gap-4 sm:grid-cols-2">
-                        {Object.keys(parsed.harnessData.agentDispatch.types)
+                        {Object.keys(previewHarnessData.agentDispatch.types)
                           .length > 0 && (
                           <div>
                             <h4 className="mb-2 text-xs font-semibold text-slate-500 dark:text-slate-400">
@@ -2579,14 +2583,14 @@ export default function UploadPage() {
                             </h4>
                             <MiniBarChart
                               data={Object.entries(
-                                parsed.harnessData.agentDispatch.types,
+                                previewHarnessData.agentDispatch.types,
                               ).map(([label, value]) => ({ label, value }))}
                               title=""
                               color="bg-indigo-500"
                             />
                           </div>
                         )}
-                        {Object.keys(parsed.harnessData.agentDispatch.models)
+                        {Object.keys(previewHarnessData.agentDispatch.models)
                           .length > 0 && (
                           <div>
                             <h4 className="mb-2 text-xs font-semibold text-slate-500 dark:text-slate-400">
@@ -2594,29 +2598,29 @@ export default function UploadPage() {
                             </h4>
                             <MiniBarChart
                               data={Object.entries(
-                                parsed.harnessData.agentDispatch.models,
+                                previewHarnessData.agentDispatch.models,
                               ).map(([label, value]) => ({ label, value }))}
                               title=""
                               color="bg-purple-500"
                             />
-                            {parsed.harnessData.agentDispatch.backgroundPct >
+                            {previewHarnessData.agentDispatch.backgroundPct >
                               0 && (
                               <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
-                                {parsed.harnessData.agentDispatch.backgroundPct}
+                                {previewHarnessData.agentDispatch.backgroundPct}
                                 % run in background
                               </p>
                             )}
                           </div>
                         )}
                       </div>
-                      {parsed.harnessData.agentDispatch.customAgents.length >
+                      {previewHarnessData.agentDispatch.customAgents.length >
                         0 && (
                         <div className="mt-3">
                           <h4 className="mb-1 text-xs font-semibold text-slate-500 dark:text-slate-400">
                             Custom Agents
                           </h4>
                           <div className="flex flex-wrap gap-1.5">
-                            {parsed.harnessData.agentDispatch.customAgents.map(
+                            {previewHarnessData.agentDispatch.customAgents.map(
                               (agent) => (
                                 <span
                                   key={agent}
@@ -2634,7 +2638,7 @@ export default function UploadPage() {
                 )}
 
               {/* Languages */}
-              {Object.keys(parsed.harnessData.languages).length > 0 && (
+              {Object.keys(previewHarnessData.languages).length > 0 && (
                 <RedactableSection
                   title="Languages"
                   enabled={!disabledSections["languages"]}
@@ -2647,7 +2651,7 @@ export default function UploadPage() {
                     defaultOpen={false}
                   >
                     <MiniBarChart
-                      data={Object.entries(parsed.harnessData.languages)
+                      data={Object.entries(previewHarnessData.languages)
                         .sort((a, b) => b[1] - a[1])
                         .slice(0, 12)
                         .map(([label, value]) => ({ label, value }))}
@@ -2659,7 +2663,7 @@ export default function UploadPage() {
               )}
 
               {/* MCP Servers */}
-              {Object.keys(parsed.harnessData.mcpServers).length > 0 && (
+              {Object.keys(previewHarnessData.mcpServers).length > 0 && (
                 <RedactableSection
                   title="MCP Servers"
                   enabled={!disabledSections["mcpServers"]}
@@ -2672,7 +2676,7 @@ export default function UploadPage() {
                     defaultOpen={false}
                   >
                     <div className="space-y-1">
-                      {Object.entries(parsed.harnessData.mcpServers)
+                      {Object.entries(previewHarnessData.mcpServers)
                         .sort((a, b) => b[1] - a[1])
                         .map(([server, calls]) => (
                           <div
@@ -2693,7 +2697,7 @@ export default function UploadPage() {
               )}
 
               {/* Versions */}
-              {parsed.harnessData.versions.length > 0 && (
+              {previewHarnessData.versions.length > 0 && (
                 <RedactableSection
                   title="Claude Code Versions"
                   enabled={!disabledSections["versions"]}
@@ -2706,7 +2710,7 @@ export default function UploadPage() {
                     defaultOpen={false}
                   >
                     <div className="flex flex-wrap gap-1.5">
-                      {parsed.harnessData.versions.map((version) => (
+                      {previewHarnessData.versions.map((version) => (
                         <span
                           key={version}
                           className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
@@ -2720,7 +2724,7 @@ export default function UploadPage() {
               )}
 
               {/* Writeup Sections */}
-              {parsed.harnessData.writeupSections.length > 0 && (
+              {previewHarnessData.writeupSections.length > 0 && (
                 <RedactableSection
                   title="Writeup Analysis"
                   enabled={!disabledSections["writeupSections"]}
@@ -2733,7 +2737,7 @@ export default function UploadPage() {
                     defaultOpen={false}
                   >
                     <div className="space-y-6">
-                      {parsed.harnessData.writeupSections.map((section) => (
+                      {previewHarnessData.writeupSections.map((section) => (
                         <div key={section.title}>
                           <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
                             {section.title}
@@ -2752,7 +2756,7 @@ export default function UploadPage() {
               )}
 
               {/* Harness Files */}
-              {parsed.harnessData.harnessFiles.length > 0 && (
+              {previewHarnessData.harnessFiles.length > 0 && (
                 <RedactableSection
                   title="Harness File Ecosystem"
                   enabled={!disabledSections["harnessFiles"]}
@@ -2765,7 +2769,7 @@ export default function UploadPage() {
                     defaultOpen={false}
                   >
                     <div className="space-y-1">
-                      {parsed.harnessData.harnessFiles.map((file) => (
+                      {previewHarnessData.harnessFiles.map((file) => (
                         <div
                           key={file}
                           className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -56,7 +56,10 @@ import HowIWorkCluster from "@/components/HowIWorkCluster";
 import ProjectLinks from "@/components/ProjectLinks";
 import MiniBarChart from "@/components/MiniBarChart";
 import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
-import { getHiddenKeypaths } from "@/lib/harness-section-visibility";
+import {
+  buildCodexVisibilityKey,
+  getHiddenKeypaths,
+} from "@/lib/harness-section-visibility";
 import { buildItemKey } from "@/lib/item-visibility";
 import HideableItem from "@/components/HideableItem";
 import { hasShowcaseContent } from "@/types/insights";
@@ -64,10 +67,6 @@ import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import { buildOgImageUrl, buildReportUrl } from "@/lib/urls";
 
 type Step = "upload" | "projects" | "review";
-
-function buildCodexVisibilityKey(sectionKey: string): string {
-  return `tools.codex.${sectionKey}`;
-}
 
 /** Library Project as returned by GET /api/projects. */
 interface LibraryProject {
@@ -2342,8 +2341,7 @@ export default function UploadPage() {
           </div>
 
           {parsed.reportType === "insight-harness" &&
-            previewCodexData &&
-            !previewHarnessData && (
+            previewCodexData && (
               <div className="space-y-4">
                 <RedactableSection
                   title="Codex Tool Usage"

--- a/src/components/CodexHarnessDashboard.tsx
+++ b/src/components/CodexHarnessDashboard.tsx
@@ -283,9 +283,16 @@ export default function CodexHarnessDashboard({
 
         <Section title="Workflow Signal" icon={Wrench}>
           {hasWorkflowSignal ? (
-            <pre className="max-h-72 overflow-auto rounded-md bg-slate-950 p-3 text-xs text-slate-100">
-              {JSON.stringify(codexData.workflowData, null, 2)}
-            </pre>
+            <div className="flex flex-wrap gap-1.5">
+              {Object.keys(codexData.workflowData ?? {}).map((key) => (
+                <span
+                  key={key}
+                  className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                >
+                  {key}
+                </span>
+              ))}
+            </div>
           ) : (
             <p className="text-sm text-slate-500 dark:text-slate-400">
               No workflow phase signal was detected in this Codex profile.

--- a/src/components/CodexHarnessDashboard.tsx
+++ b/src/components/CodexHarnessDashboard.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import {
+  Code2,
+  Info,
+  Monitor,
+  Package,
+  ShieldCheck,
+  Terminal,
+  Wrench,
+} from "lucide-react";
+import type { ComponentType, ReactNode } from "react";
+import MiniBarChart from "@/components/MiniBarChart";
+import { formatCompactNumber } from "@/lib/number-format";
+import type { CodexHarnessData } from "@/types/insights";
+
+interface CodexHarnessDashboardProps {
+  codexData: CodexHarnessData;
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  icon: ComponentType<{ className?: string }>;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900/50">
+      <div className="mb-3 flex h-9 w-9 items-center justify-center rounded-md bg-blue-50 text-blue-600 dark:bg-blue-950/40 dark:text-blue-300">
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="text-2xl font-bold tracking-tight text-slate-950 dark:text-white">
+        {value}
+      </div>
+      <div className="mt-1 text-xs font-medium uppercase text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  icon: Icon,
+  children,
+}: {
+  title: string;
+  icon: ComponentType<{ className?: string }>;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+      <div className="mb-4 flex items-center gap-2">
+        <span className="flex h-8 w-8 items-center justify-center rounded-md bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+          <Icon className="h-4 w-4" />
+        </span>
+        <h3 className="text-sm font-bold text-slate-950 dark:text-white">
+          {title}
+        </h3>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function KeyValueList({
+  entries,
+  emptyLabel,
+}: {
+  entries: Array<[string, number]>;
+  emptyLabel: string;
+}) {
+  if (entries.length === 0) {
+    return <p className="text-sm text-slate-500 dark:text-slate-400">{emptyLabel}</p>;
+  }
+
+  return (
+    <MiniBarChart
+      data={entries.map(([label, value]) => ({ label, value }))}
+      title=""
+      color="bg-blue-500"
+    />
+  );
+}
+
+export default function CodexHarnessDashboard({
+  codexData,
+}: CodexHarnessDashboardProps) {
+  const stats = codexData.stats;
+  const toolEntries = Object.entries(codexData.toolUsage).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const cliEntries = Object.entries(codexData.cliTools).sort(
+    (a, b) => b[1] - a[1],
+  );
+  const skills = codexData.skillInventory;
+  const plugins = codexData.plugins;
+  const desktopPresence = codexData.workSurfaces.desktopPresence;
+  const hasWorkflowSignal =
+    !!codexData.workflowData &&
+    Object.keys(codexData.workflowData).some((key) => {
+      const value = codexData.workflowData?.[key];
+      if (Array.isArray(value)) return value.length > 0;
+      return !!value && typeof value === "object"
+        ? Object.keys(value).length > 0
+        : value != null;
+    });
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-950 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-100">
+        <div className="flex gap-3">
+          <Info className="mt-0.5 h-5 w-5 shrink-0" />
+          <p>
+            Codex profiles are generated from local CLI and desktop harness
+            signals. Inventory items are shown as discovered capabilities, not
+            as usage counts unless the extractor provided counts.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Tokens"
+          value={
+            typeof stats.totalTokens === "number"
+              ? formatCompactNumber(stats.totalTokens)
+              : "n/a"
+          }
+          icon={Code2}
+        />
+        <StatCard
+          label="Sessions"
+          value={
+            typeof stats.sessionCount === "number"
+              ? formatCompactNumber(stats.sessionCount)
+              : "n/a"
+          }
+          icon={Terminal}
+        />
+        <StatCard
+          label="Payload sessions"
+          value={
+            typeof stats.payloadFormatSessions === "number"
+              ? formatCompactNumber(stats.payloadFormatSessions)
+              : "n/a"
+          }
+          icon={Package}
+        />
+        <StatCard
+          label="Legacy sessions"
+          value={
+            typeof stats.legacyFormatSessions === "number"
+              ? formatCompactNumber(stats.legacyFormatSessions)
+              : "n/a"
+          }
+          icon={Monitor}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Section title="Tool Usage" icon={Wrench}>
+          <KeyValueList entries={toolEntries} emptyLabel="No tool usage data." />
+        </Section>
+
+        <Section title="CLI Commands" icon={Terminal}>
+          <KeyValueList entries={cliEntries} emptyLabel="No CLI command data." />
+        </Section>
+      </div>
+
+      <Section title="Skills Inventory" icon={Code2}>
+        {skills.length > 0 ? (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {skills.map((skill) => (
+              <div
+                key={skill.name}
+                className="rounded-md border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800/50"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="break-words text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      {skill.name}
+                    </div>
+                    {skill.description && (
+                      <p className="mt-1 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                        {skill.description}
+                      </p>
+                    )}
+                  </div>
+                  {typeof skill.calls === "number" && (
+                    <span className="rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+                      {formatCompactNumber(skill.calls)}
+                    </span>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            No skill inventory data.
+          </p>
+        )}
+      </Section>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Section title="Plugins" icon={Package}>
+          {plugins.length > 0 ? (
+            <div className="space-y-2">
+              {plugins.map((plugin) => (
+                <div
+                  key={plugin.name}
+                  className="flex items-center justify-between gap-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 dark:border-slate-700 dark:bg-slate-800/50"
+                >
+                  <span className="min-w-0 break-words font-mono text-xs font-semibold text-slate-700 dark:text-slate-300">
+                    {plugin.name}
+                  </span>
+                  {typeof plugin.enabled === "boolean" && (
+                    <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+                      {plugin.enabled ? "enabled" : "disabled"}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No plugin data.
+            </p>
+          )}
+        </Section>
+
+        <Section title="Safety And Rules" icon={ShieldCheck}>
+          <div className="space-y-4 text-sm">
+            {codexData.safety.approvalsReviewer && (
+              <div>
+                <div className="text-xs font-semibold uppercase text-slate-400">
+                  Approvals reviewer
+                </div>
+                <div className="mt-1 text-slate-700 dark:text-slate-300">
+                  {codexData.safety.approvalsReviewer}
+                </div>
+              </div>
+            )}
+            <TokenList label="Approval modes" items={codexData.safety.approvalModes} />
+            <TokenList label="Trust levels" items={codexData.safety.trustLevels} />
+            <TokenList label="Rules allowlist" items={codexData.safety.rulesAllowlist} />
+          </div>
+        </Section>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Section title="Work Surfaces" icon={Monitor}>
+          {desktopPresence.length > 0 ? (
+            <div className="space-y-2">
+              {desktopPresence.map((surface, index) => (
+                <div
+                  key={`${String(surface.tool ?? "surface")}-${index}`}
+                  className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-800/50"
+                >
+                  <div className="font-medium text-slate-800 dark:text-slate-200">
+                    {typeof surface.tool === "string"
+                      ? surface.tool
+                      : `Surface ${index + 1}`}
+                  </div>
+                  {typeof surface.present === "boolean" && (
+                    <div className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                      {surface.present ? "Detected" : "Not detected"}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No work surface data.
+            </p>
+          )}
+        </Section>
+
+        <Section title="Workflow Signal" icon={Wrench}>
+          {hasWorkflowSignal ? (
+            <pre className="max-h-72 overflow-auto rounded-md bg-slate-950 p-3 text-xs text-slate-100">
+              {JSON.stringify(codexData.workflowData, null, 2)}
+            </pre>
+          ) : (
+            <p className="text-sm text-slate-500 dark:text-slate-400">
+              No workflow phase signal was detected in this Codex profile.
+            </p>
+          )}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function TokenList({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div>
+      <div className="text-xs font-semibold uppercase text-slate-400">
+        {label}
+      </div>
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {items.map((item) => (
+          <span
+            key={item}
+            className="rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CodexHarnessDashboard.tsx
+++ b/src/components/CodexHarnessDashboard.tsx
@@ -101,8 +101,7 @@ export default function CodexHarnessDashboard({
   const desktopPresence = codexData.workSurfaces.desktopPresence;
   const hasWorkflowSignal =
     !!codexData.workflowData &&
-    Object.keys(codexData.workflowData).some((key) => {
-      const value = codexData.workflowData?.[key];
+    Object.values(codexData.workflowData).some((value) => {
       if (Array.isArray(value)) return value.length > 0;
       return !!value && typeof value === "object"
         ? Object.keys(value).length > 0

--- a/src/components/ToolSelector.tsx
+++ b/src/components/ToolSelector.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { Bot, Code2 } from "lucide-react";
+import clsx from "clsx";
+import type { ComponentType } from "react";
+import type { HarnessToolKey } from "@/types/insights";
+
+interface ToolSelectorProps {
+  tools: HarnessToolKey[];
+  active: HarnessToolKey;
+  onChange: (tool: HarnessToolKey) => void;
+}
+
+const TOOL_LABELS: Record<HarnessToolKey, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+};
+
+const TOOL_META: Record<HarnessToolKey, string> = {
+  "claude-code": "Harness report",
+  codex: "Local CLI profile",
+};
+
+const TOOL_ICONS: Record<
+  HarnessToolKey,
+  ComponentType<{ className?: string }>
+> = {
+  "claude-code": Bot,
+  codex: Code2,
+};
+
+export default function ToolSelector({
+  tools,
+  active,
+  onChange,
+}: ToolSelectorProps) {
+  if (tools.length <= 1) return null;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Tool profile"
+      className="mb-6 grid gap-2 rounded-lg border border-slate-200 bg-white p-2 dark:border-slate-700 dark:bg-slate-900/50 sm:grid-cols-2"
+    >
+      {tools.map((tool) => {
+        const Icon = TOOL_ICONS[tool];
+        const selected = active === tool;
+        return (
+          <button
+            key={tool}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onChange(tool)}
+            className={clsx(
+              "flex min-h-16 items-center gap-3 rounded-md px-3 py-2 text-left transition-colors",
+              selected
+                ? "bg-slate-900 text-white shadow-sm dark:bg-slate-100 dark:text-slate-950"
+                : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800",
+            )}
+          >
+            <span
+              className={clsx(
+                "flex h-9 w-9 shrink-0 items-center justify-center rounded-md",
+                selected
+                  ? "bg-white/15 dark:bg-slate-950/10"
+                  : "bg-slate-100 dark:bg-slate-800",
+              )}
+            >
+              <Icon className="h-5 w-5" />
+            </span>
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold leading-tight">
+                {TOOL_LABELS[tool]}
+              </span>
+              <span
+                className={clsx(
+                  "mt-0.5 block text-xs",
+                  selected
+                    ? "text-white/70 dark:text-slate-700"
+                    : "text-slate-400 dark:text-slate-500",
+                )}
+              >
+                {TOOL_META[tool]}
+              </span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/__tests__/CodexHarnessDashboard.test.tsx
+++ b/src/components/__tests__/CodexHarnessDashboard.test.tsx
@@ -1,0 +1,59 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
+import type { CodexHarnessData } from "@/types/insights";
+
+function codexData(
+  overrides: Partial<CodexHarnessData> = {},
+): CodexHarnessData {
+  return {
+    tool: "codex",
+    stats: {
+      totalTokens: 2000,
+      sessionCount: 12,
+      payloadFormatSessions: 10,
+      legacyFormatSessions: 2,
+    },
+    toolUsage: { exec_command: 8 },
+    cliTools: { git: 3 },
+    skillInventory: [{ name: "code-review", description: "Review code" }],
+    plugins: [{ name: "github", enabled: true }],
+    safety: {
+      approvalsReviewer: "model",
+      approvalModes: ["approve"],
+      trustLevels: ["trusted"],
+      rulesAllowlist: ["git"],
+    },
+    workflowData: null,
+    workSurfaces: {
+      desktopPresence: [{ tool: "Codex CLI", present: true }],
+    },
+    localOnly: true,
+    ...overrides,
+  };
+}
+
+describe("CodexHarnessDashboard", () => {
+  it("renders Codex inventory without fabricating skill counts", () => {
+    const html = renderToStaticMarkup(
+      <CodexHarnessDashboard codexData={codexData()} />,
+    );
+
+    expect(html).toContain("Codex profiles are generated from local CLI");
+    expect(html).toContain("code-review");
+    expect(html).toContain("Review code");
+    expect(html).not.toContain("Hooks &amp; Safety");
+    expect(html).not.toContain("Agent Dispatch");
+  });
+
+  it("shows an empty workflow state when no phase signal exists", () => {
+    const html = renderToStaticMarkup(
+      <CodexHarnessDashboard
+        codexData={codexData({ workflowData: { phaseTransitions: {} } })}
+      />,
+    );
+
+    expect(html).toContain("No workflow phase signal was detected");
+  });
+});

--- a/src/components/__tests__/CodexHarnessDashboard.test.tsx
+++ b/src/components/__tests__/CodexHarnessDashboard.test.tsx
@@ -56,4 +56,18 @@ describe("CodexHarnessDashboard", () => {
 
     expect(html).toContain("No workflow phase signal was detected");
   });
+
+  it("shows safe workflow keys when phase signal exists", () => {
+    const html = renderToStaticMarkup(
+      <CodexHarnessDashboard
+        codexData={codexData({
+          workflowData: { phaseTransitions: { planning: 2 } },
+        })}
+      />,
+    );
+
+    expect(html).toContain("Workflow Signal");
+    expect(html).toContain("phaseTransitions");
+    expect(html).not.toContain("planning");
+  });
 });

--- a/src/components/__tests__/ToolSelector.test.tsx
+++ b/src/components/__tests__/ToolSelector.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import ToolSelector from "@/components/ToolSelector";
+
+describe("ToolSelector", () => {
+  it("renders nothing for single-tool reports", () => {
+    const html = renderToStaticMarkup(
+      <ToolSelector
+        tools={["claude-code"]}
+        active="claude-code"
+        onChange={() => undefined}
+      />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders separate Claude Code and Codex choices", () => {
+    const html = renderToStaticMarkup(
+      <ToolSelector
+        tools={["claude-code", "codex"]}
+        active="codex"
+        onChange={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Claude Code");
+    expect(html).toContain("Codex");
+    expect(html).toContain('aria-selected="true"');
+    expect(html).toContain("Local CLI profile");
+  });
+});

--- a/src/lib/__tests__/filter-report-response.test.ts
+++ b/src/lib/__tests__/filter-report-response.test.ts
@@ -144,6 +144,61 @@ function makeReport(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeEnvelopeReport(hiddenHarnessSections: string[] = []) {
+  const claudeHarnessData = makeReportWithShowcase([]).harnessData;
+  return {
+    id: "report-envelope",
+    authorId: "user-1",
+    harnessData: {
+      primaryTool: "claude-code",
+      tools: {
+        "claude-code": claudeHarnessData,
+        codex: {
+          tool: "codex",
+          stats: {
+            totalTokens: 200,
+            sessionCount: 4,
+            payloadFormatSessions: 3,
+            legacyFormatSessions: 1,
+          },
+          toolUsage: { exec_command: 8, apply_patch: 2 },
+          cliTools: { git: 5, npm: 1 },
+          skillInventory: [
+            {
+              name: "Codex Public Skill",
+              description: "visible",
+              readme_markdown: "# Codex public",
+              hero_base64: "CODEXPUBLICBASE64",
+              hero_mime_type: "image/png",
+            },
+            {
+              name: "Codex Secret Skill",
+              description: "hidden",
+              readme_markdown: "# Codex secret",
+              hero_base64: "CODEXSECRETBASE64",
+              hero_mime_type: "image/jpeg",
+            },
+          ],
+          plugins: [
+            { name: "codex-github", enabled: true },
+            { name: "codex-private", enabled: true },
+          ],
+          safety: {
+            approvalsReviewer: "model",
+            approvalModes: ["approve"],
+            trustLevels: ["trusted"],
+            rulesAllowlist: ["git"],
+          },
+          workflowData: { phaseTransitions: { plan: 1 } },
+          workSurfaces: { desktopPresence: [{ tool: "Codex CLI" }] },
+          localOnly: true,
+        },
+      },
+    },
+    hiddenHarnessSections,
+  };
+}
+
 describe("filterReportForResponse", () => {
   it("returns full payload when no hides", () => {
     const report = makeReport();
@@ -313,6 +368,85 @@ describe("filterReportForResponse", () => {
     };
     expect(hd.plugins).toHaveLength(0);
     expect(Object.keys(hd.languages)).toHaveLength(0);
+  });
+
+  it("applies legacy harness hide keys only to the Claude slice in an envelope", () => {
+    const report = makeEnvelopeReport(["skillInventory"]);
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    const tools = (
+      result.harnessData as {
+        tools: {
+          "claude-code": { skillInventory: unknown[] };
+          codex: { skillInventory: unknown[] };
+        };
+      }
+    ).tools;
+
+    expect(tools["claude-code"].skillInventory).toHaveLength(0);
+    expect(tools.codex.skillInventory).toHaveLength(2);
+  });
+
+  it("applies namespaced harness hide keys only to the targeted tool slice", () => {
+    const report = makeEnvelopeReport(["tools.codex.skillInventory"]);
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    const tools = (
+      result.harnessData as {
+        tools: {
+          "claude-code": { skillInventory: unknown[] };
+          codex: { skillInventory: unknown[] };
+        };
+      }
+    ).tools;
+
+    expect(tools["claude-code"].skillInventory).toHaveLength(2);
+    expect(tools.codex.skillInventory).toHaveLength(0);
+  });
+
+  it("applies namespaced item hides inside Codex envelope slices", () => {
+    const report = makeEnvelopeReport([
+      "tools.codex.skillInventory.codex-secret-skill",
+    ]);
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    const codexSkills = (
+      result.harnessData as {
+        tools: { codex: { skillInventory: Array<{ name: string }> } };
+      }
+    ).tools.codex.skillInventory;
+
+    expect(codexSkills).toHaveLength(1);
+    expect(codexSkills[0].name).toBe("Codex Public Skill");
+    expect(JSON.stringify(result)).not.toContain("CODEXSECRETBASE64");
+  });
+
+  it("owner with includeHidden=true receives the full envelope", () => {
+    const report = makeEnvelopeReport([
+      "skillInventory",
+      "tools.codex.skillInventory",
+    ]);
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: true,
+      includeHidden: true,
+    });
+    const tools = (
+      result.harnessData as {
+        tools: {
+          "claude-code": { skillInventory: unknown[] };
+          codex: { skillInventory: unknown[] };
+        };
+      }
+    ).tools;
+
+    expect(tools["claude-code"].skillInventory).toHaveLength(2);
+    expect(tools.codex.skillInventory).toHaveLength(2);
   });
 });
 
@@ -566,5 +700,29 @@ describe("filterReportForListFeed", () => {
     // Shape unchanged for old reports — no new null keys injected where
     // the source skill didn't have them
     expect(skills[0]).not.toHaveProperty("readme_markdown");
+  });
+
+  it("drops showcase bytes from compatible skill inventories inside envelopes", () => {
+    const report = makeEnvelopeReport([]);
+    const result = filterReportForListFeed(report);
+    const tools = (
+      result.harnessData as {
+        tools: {
+          "claude-code": { skillInventory: Array<Record<string, unknown>> };
+          codex: { skillInventory: Array<Record<string, unknown>> };
+        };
+      }
+    ).tools;
+
+    for (const skill of [
+      ...tools["claude-code"].skillInventory,
+      ...tools.codex.skillInventory,
+    ]) {
+      expect(skill.readme_markdown).toBeNull();
+      expect(skill.hero_base64).toBeNull();
+      expect(skill.hero_mime_type).toBeNull();
+    }
+    expect(JSON.stringify(result)).not.toContain("PUBLICBASE64DATA");
+    expect(JSON.stringify(result)).not.toContain("CODEXPUBLICBASE64");
   });
 });

--- a/src/lib/__tests__/filter-report-response.test.ts
+++ b/src/lib/__tests__/filter-report-response.test.ts
@@ -427,6 +427,49 @@ describe("filterReportForResponse", () => {
     expect(JSON.stringify(result)).not.toContain("CODEXSECRETBASE64");
   });
 
+  it("strips namespaced Codex safety and work-surface sections", () => {
+    const report = makeEnvelopeReport([
+      "tools.codex.safety",
+      "tools.codex.workSurfaces",
+    ]);
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    const codex = (
+      result.harnessData as {
+        tools: {
+          codex: {
+            safety: {
+              approvalModes: string[];
+              trustLevels: string[];
+              rulesAllowlist: string[];
+            };
+            workSurfaces: { desktopPresence: unknown[] };
+          };
+        };
+      }
+    ).tools.codex;
+
+    expect(codex.safety.approvalModes).toEqual([]);
+    expect(codex.safety.trustLevels).toEqual([]);
+    expect(codex.safety.rulesAllowlist).toEqual([]);
+    expect(codex.workSurfaces.desktopPresence).toEqual([]);
+  });
+
+  it("keeps list-feed harnessData Claude-compatible when a Claude slice exists", () => {
+    const report = makeEnvelopeReport([]);
+    const result = filterReportForListFeed(report);
+
+    expect(result.harnessData).toMatchObject({
+      stats: { totalTokens: 100 },
+      skillInventory: expect.any(Array),
+    });
+    expect(result.harnessData).not.toMatchObject({
+      tools: expect.any(Object),
+    });
+  });
+
   it("owner with includeHidden=true receives the full envelope", () => {
     const report = makeEnvelopeReport([
       "skillInventory",
@@ -705,24 +748,16 @@ describe("filterReportForListFeed", () => {
   it("drops showcase bytes from compatible skill inventories inside envelopes", () => {
     const report = makeEnvelopeReport([]);
     const result = filterReportForListFeed(report);
-    const tools = (
-      result.harnessData as {
-        tools: {
-          "claude-code": { skillInventory: Array<Record<string, unknown>> };
-          codex: { skillInventory: Array<Record<string, unknown>> };
-        };
-      }
-    ).tools;
+    const skills = (result.harnessData as unknown as {
+      skillInventory: Array<Record<string, unknown>>;
+    }).skillInventory;
 
-    for (const skill of [
-      ...tools["claude-code"].skillInventory,
-      ...tools.codex.skillInventory,
-    ]) {
+    for (const skill of skills) {
       expect(skill.readme_markdown).toBeNull();
       expect(skill.hero_base64).toBeNull();
       expect(skill.hero_mime_type).toBeNull();
     }
     expect(JSON.stringify(result)).not.toContain("PUBLICBASE64DATA");
-    expect(JSON.stringify(result)).not.toContain("CODEXPUBLICBASE64");
+    expect(JSON.stringify(result)).not.toContain("tools");
   });
 });

--- a/src/lib/__tests__/harness-parser-workflow.test.ts
+++ b/src/lib/__tests__/harness-parser-workflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseHarnessHtml } from "@/lib/harness-parser";
+import { getClaudeHarnessData, type HarnessData } from "@/types/insights";
 
 // ---------------------------------------------------------------------------
 // Base HarnessData with workflow data embedded as JSON
@@ -103,10 +104,16 @@ function buildHtml(data: unknown): string {
 </body></html>`;
 }
 
+function parseClaudeHarnessHtml(html: string): HarnessData {
+  const result = getClaudeHarnessData(parseHarnessHtml(html));
+  if (!result) throw new Error("Expected Claude Code harness data");
+  return result;
+}
+
 describe("harness-parser workflow data", () => {
   it("parses workflow phases from JSON", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData).not.toBeNull();
     expect(result.workflowData!.phaseDistribution).toEqual({
       exploration: 40,
@@ -118,7 +125,7 @@ describe("harness-parser workflow data", () => {
 
   it("parses phase transitions", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData!.phaseTransitions).toEqual({
       "exploration->implementation": 23,
       "implementation->testing": 15,
@@ -128,7 +135,7 @@ describe("harness-parser workflow data", () => {
 
   it("parses skill invocations", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData!.skillInvocations).toEqual({
       "ce-brainstorm": 8,
       "ce-work": 12,
@@ -138,7 +145,7 @@ describe("harness-parser workflow data", () => {
 
   it("parses agent dispatches", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData!.agentDispatches).toEqual({
       "Run tests for auth module": 3,
       "Lint and format changed files": 2,
@@ -147,7 +154,7 @@ describe("harness-parser workflow data", () => {
 
   it("parses workflow patterns", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData!.workflowPatterns).toEqual([
       {
         sequence: ["ce-brainstorm", "ce-work", "git-commit-push-pr"],
@@ -159,7 +166,7 @@ describe("harness-parser workflow data", () => {
 
   it("parses phase stats", () => {
     const data = { ...BASE_DATA, workflowData: WORKFLOW_DATA };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData!.phaseStats.exploreBeforeImplPct).toBe(75);
     expect(result.workflowData!.phaseStats.testBeforeShipPct).toBe(60);
     expect(result.workflowData!.phaseStats.totalSessionsWithPhases).toBe(8);
@@ -167,14 +174,14 @@ describe("harness-parser workflow data", () => {
 
   it("returns null workflowData when not present in JSON", () => {
     const data = { ...BASE_DATA, workflowData: null };
-    const result = parseHarnessHtml(buildHtml(data));
+    const result = parseClaudeHarnessHtml(buildHtml(data));
     expect(result.workflowData).toBeNull();
   });
 
   it("returns null workflowData when field is omitted", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { workflowData, ...rest } = BASE_DATA;
-    const result = parseHarnessHtml(buildHtml(rest));
+    const result = parseClaudeHarnessHtml(buildHtml(rest));
     expect(result.workflowData).toBeNull();
   });
 });

--- a/src/lib/__tests__/harness-parser.test.ts
+++ b/src/lib/__tests__/harness-parser.test.ts
@@ -150,6 +150,12 @@ describe("isHarnessReport", () => {
     expect(isHarnessReport(insightsHtml)).toBe(false);
   });
 
+  it("does not classify escaped harness-data text as a harness script", () => {
+    const html =
+      '<html><body><pre>&lt;script id="harness-data"&gt;&lt;/script&gt;</pre></body></html>';
+    expect(isHarnessReport(html)).toBe(false);
+  });
+
   it("returns false for empty/minimal HTML", () => {
     expect(isHarnessReport("")).toBe(false);
     expect(isHarnessReport("<html><body></body></html>")).toBe(false);

--- a/src/lib/__tests__/harness-parser.test.ts
+++ b/src/lib/__tests__/harness-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { isHarnessReport, parseHarnessHtml } from "../harness-parser";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  type HarnessData,
+} from "@/types/insights";
 
 // ---------------------------------------------------------------------------
 // Minimal HarnessData JSON matching the HarnessData interface
@@ -119,6 +124,12 @@ function buildHarnessHtml(
 
 const MINIMAL_HARNESS_HTML = buildHarnessHtml(MINIMAL_HARNESS_DATA);
 
+function parseClaudeHarnessHtml(html: string): HarnessData {
+  const data = getClaudeHarnessData(parseHarnessHtml(html));
+  if (!data) throw new Error("Expected Claude Code harness data");
+  return data;
+}
+
 // ---------------------------------------------------------------------------
 // isHarnessReport
 // ---------------------------------------------------------------------------
@@ -126,6 +137,11 @@ const MINIMAL_HARNESS_HTML = buildHarnessHtml(MINIMAL_HARNESS_DATA);
 describe("isHarnessReport", () => {
   it("detects harness report by integrity script tag", () => {
     expect(isHarnessReport(MINIMAL_HARNESS_HTML)).toBe(true);
+  });
+
+  it("detects Codex harness reports by harness-data script without integrity tag", () => {
+    const html = `<html><body><script id="harness-data" type="application/json">{"tool":"codex","stats":{}}</script></body></html>`;
+    expect(isHarnessReport(html)).toBe(true);
   });
 
   it("returns false for plain insights HTML", () => {
@@ -149,9 +165,78 @@ describe("parseHarnessHtml", () => {
     expect(() => parseHarnessHtml(MINIMAL_HARNESS_HTML)).not.toThrow();
   });
 
+  it("stores legacy Claude data as a tools envelope", () => {
+    const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+    expect(result.primaryTool).toBe("claude-code");
+    expect(result.tools["claude-code"]?.stats.totalTokens).toBe(1200000);
+  });
+
+  it("accepts Codex Phase 1 harness data", () => {
+    const html = buildHarnessHtml({
+      tool: "codex",
+      stats: { totalTokens: 2000, sessionCount: 12 },
+      toolUsage: { exec_command: 8 },
+      cliTools: { git: 3 },
+      skillInventory: [{ name: "code-review", description: "Review code" }],
+      plugins: [{ name: "github", enabled: true }],
+      safety: {
+        approvalsReviewer: "model",
+        approvalModes: ["approve"],
+        trustLevels: ["trusted"],
+        rulesAllowlist: ["git"],
+      },
+      workflowData: { phaseTransitions: {} },
+      workSurfaces: {
+        desktopPresence: [{ tool: "Codex CLI", present: true }],
+      },
+      localOnly: true,
+    });
+
+    const result = parseHarnessHtml(html);
+    expect(result.primaryTool).toBe("codex");
+    expect(getCodexHarnessData(result)?.stats.totalTokens).toBe(2000);
+    expect(getClaudeHarnessData(result)).toBeNull();
+  });
+
+  it("sanitizes Claude writeup HTML inside combined envelopes", () => {
+    const html = buildHarnessHtml({
+      primaryTool: "claude-code",
+      tools: {
+        "claude-code": {
+          ...MINIMAL_HARNESS_DATA,
+          writeupSections: [
+            {
+              title: "Unsafe",
+              contentHtml: '<p onclick="alert(1)">safe text</p>',
+            },
+          ],
+        },
+        codex: {
+          tool: "codex",
+          stats: { totalTokens: 2000 },
+          toolUsage: {},
+          cliTools: {},
+          skillInventory: [],
+          plugins: [],
+          safety: {},
+          workflowData: null,
+          workSurfaces: {},
+          localOnly: true,
+        },
+      },
+    });
+
+    const result = parseHarnessHtml(html);
+    expect(result.primaryTool).toBe("claude-code");
+    expect(getClaudeHarnessData(result)?.writeupSections[0].contentHtml).toBe(
+      "<p>safe text</p>",
+    );
+    expect(getCodexHarnessData(result)?.tool).toBe("codex");
+  });
+
   describe("stats", () => {
     it("extracts all stat fields with correct types", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.stats.totalTokens).toBe(1200000);
       expect(result.stats.lifetimeTokens).toBe(9500000);
       expect(result.stats.durationHours).toBe(18);
@@ -166,7 +251,7 @@ describe("parseHarnessHtml", () => {
 
   describe("autonomy", () => {
     it("extracts autonomy fields", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.autonomy.label).toBe("Fire-and-Forget");
       expect(result.autonomy.description).toBe(
         "You launch tasks and let Claude run",
@@ -180,7 +265,7 @@ describe("parseHarnessHtml", () => {
 
   describe("feature pills", () => {
     it("extracts pill names, active state, and values", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.featurePills).toHaveLength(3);
       expect(result.featurePills[0]).toEqual({
         name: "Task Agents",
@@ -202,14 +287,14 @@ describe("parseHarnessHtml", () => {
 
   describe("tool usage", () => {
     it("extracts tool usage as record", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.toolUsage).toEqual({ Read: 1500, Edit: 800, Bash: 2200 });
     });
   });
 
   describe("skill inventory", () => {
     it("extracts skill entries", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.skillInventory).toHaveLength(2);
       expect(result.skillInventory[0]).toEqual({
         name: "commit",
@@ -228,7 +313,7 @@ describe("parseHarnessHtml", () => {
 
   describe("hook definitions", () => {
     it("extracts hook definitions", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.hookDefinitions).toHaveLength(2);
       expect(result.hookDefinitions[0]).toEqual({
         event: "PreToolUse",
@@ -240,7 +325,7 @@ describe("parseHarnessHtml", () => {
 
   describe("plugins", () => {
     it("extracts plugin info", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.plugins).toHaveLength(1);
       expect(result.plugins[0]).toEqual({
         name: "superpowers",
@@ -253,7 +338,7 @@ describe("parseHarnessHtml", () => {
 
   describe("file operation style", () => {
     it("extracts file op style", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.fileOpStyle.readPct).toBe(45);
       expect(result.fileOpStyle.editPct).toBe(40);
       expect(result.fileOpStyle.writePct).toBe(15);
@@ -265,7 +350,7 @@ describe("parseHarnessHtml", () => {
 
   describe("git patterns", () => {
     it("extracts git patterns", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.gitPatterns.prCount).toBe(7);
       expect(result.gitPatterns.commitCount).toBe(23);
       expect(result.gitPatterns.branchPrefixes).toEqual({
@@ -277,7 +362,7 @@ describe("parseHarnessHtml", () => {
 
   describe("writeup sections", () => {
     it("extracts writeup sections", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.writeupSections).toHaveLength(2);
       expect(result.writeupSections[0].title).toBe("Workflow Analysis");
       expect(result.writeupSections[0].contentHtml).toContain(
@@ -289,24 +374,24 @@ describe("parseHarnessHtml", () => {
 
   describe("integrity hash and versions", () => {
     it("extracts integrity hash", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.integrityHash).toBe("abc123def456");
     });
 
     it("extracts version tags", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.versions).toEqual(["1.0.33", "1.0.34"]);
     });
 
     it("extracts skill version", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.skillVersion).toBe("2.3.0");
     });
   });
 
   describe("enhanced stats", () => {
     it("extracts enhancedStats when present", () => {
-      const result = parseHarnessHtml(MINIMAL_HARNESS_HTML);
+      const result = parseClaudeHarnessHtml(MINIMAL_HARNESS_HTML);
       expect(result.enhancedStats).toEqual({
         linesAdded: 1200,
         linesRemoved: 300,
@@ -321,7 +406,7 @@ describe("parseHarnessHtml", () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { enhancedStats, ...rest } = dataWithout;
       const html = buildHarnessHtml(rest);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.enhancedStats).toBeNull();
     });
   });
@@ -360,7 +445,7 @@ describe("parseHarnessHtml", () => {
       const html = buildHarnessHtml(MINIMAL_HARNESS_DATA, {
         reverseAttrs: true,
       });
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.stats.totalTokens).toBe(1200000);
       expect(result.stats.sessionCount).toBe(42);
     });
@@ -382,7 +467,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("<script>");
       expect(result.writeupSections[0].contentHtml).toContain("<p>Safe</p>");
       expect(result.writeupSections[0].contentHtml).toContain(
@@ -402,7 +487,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("onerror");
       expect(result.writeupSections[0].contentHtml).not.toContain("onclick");
       // img is not in the allowlist, so it gets stripped entirely
@@ -422,7 +507,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("<iframe");
       expect(result.writeupSections[0].contentHtml).not.toContain("<object");
       expect(result.writeupSections[0].contentHtml).not.toContain("<embed");
@@ -441,7 +526,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain(
         "javascript:",
       );
@@ -462,7 +547,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("<svg");
       expect(result.writeupSections[0].contentHtml).not.toContain("<math");
       expect(result.writeupSections[0].contentHtml).toContain("<p>safe</p>");
@@ -480,7 +565,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("onfocus");
       expect(result.writeupSections[0].contentHtml).not.toContain(
         "onanimationstart",
@@ -503,7 +588,7 @@ describe("parseHarnessHtml", () => {
         ],
       };
       const html = buildHarnessHtml(data);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.writeupSections[0].contentHtml).not.toContain("<form");
       expect(result.writeupSections[0].contentHtml).not.toContain("<input");
       expect(result.writeupSections[0].contentHtml).toContain("<p>safe</p>");
@@ -522,7 +607,7 @@ describe("parseHarnessHtml", () => {
         featurePills: MINIMAL_HARNESS_DATA.featurePills,
       };
       const html = buildHarnessHtml(minimal);
-      const result = parseHarnessHtml(html);
+      const result = parseClaudeHarnessHtml(html);
       expect(result.toolUsage).toEqual({});
       expect(result.skillInventory).toEqual([]);
       expect(result.hookDefinitions).toEqual([]);

--- a/src/lib/__tests__/harness-tools.test.ts
+++ b/src/lib/__tests__/harness-tools.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  listHarnessTools,
+  normalizeHarnessData,
+  normalizeHarnessEnvelope,
+  toStoredHarnessData,
+  type CodexHarnessData,
+  type HarnessData,
+} from "@/types/insights";
+
+function legacyClaude(overrides: Partial<HarnessData> = {}): HarnessData {
+  return {
+    stats: {
+      totalTokens: 1000,
+      durationHours: 4,
+      avgSessionMinutes: 24,
+      skillsUsedCount: 2,
+      hooksCount: 1,
+      prCount: 3,
+      sessionCount: 8,
+      commitCount: 5,
+    },
+    autonomy: {
+      label: "Guided",
+      description: "Mostly supervised",
+      userMessages: 10,
+      assistantMessages: 20,
+      turnCount: 30,
+      errorRate: "1%",
+    },
+    featurePills: [],
+    toolUsage: { Read: 4 },
+    skillInventory: [
+      { name: "review", calls: 2, source: "custom", description: "Review" },
+    ],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      readPct: 60,
+      editPct: 30,
+      writePct: 10,
+      grepCount: 1,
+      globCount: 1,
+      style: "read-heavy",
+    },
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 3,
+      commitCount: 5,
+      linesAdded: "100",
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "hash",
+    skillVersion: "2.8.0",
+    ...overrides,
+  };
+}
+
+function codex(overrides: Partial<CodexHarnessData> = {}): CodexHarnessData {
+  return {
+    tool: "codex",
+    stats: {
+      totalTokens: 2000,
+      sessionCount: 12,
+      payloadFormatSessions: 10,
+      legacyFormatSessions: 2,
+    },
+    toolUsage: { exec_command: 8 },
+    cliTools: { git: 3 },
+    skillInventory: [{ name: "code-review", description: "Review code" }],
+    plugins: [{ name: "github", enabled: true }],
+    safety: {
+      approvalsReviewer: "model",
+      approvalModes: ["approve"],
+      trustLevels: ["trusted"],
+      rulesAllowlist: ["git"],
+    },
+    workflowData: {
+      phaseTransitions: {},
+    },
+    workSurfaces: {
+      desktopPresence: [{ tool: "Codex CLI", present: true }],
+    },
+    localOnly: true,
+    ...overrides,
+  };
+}
+
+describe("harness tools normalization", () => {
+  it("treats legacy top-level HarnessData as the Claude Code tool", () => {
+    const raw = legacyClaude();
+
+    expect(listHarnessTools(raw)).toEqual(["claude-code"]);
+    expect(normalizeHarnessData(raw)?.stats.totalTokens).toBe(1000);
+    expect(getClaudeHarnessData(raw)?.skillInventory[0].name).toBe("review");
+    expect(getCodexHarnessData(raw)).toBeNull();
+  });
+
+  it("accepts a Codex Phase 1 tool island", () => {
+    const raw = codex();
+
+    expect(listHarnessTools(raw)).toEqual(["codex"]);
+    expect(getClaudeHarnessData(raw)).toBeNull();
+    expect(getCodexHarnessData(raw)?.stats.totalTokens).toBe(2000);
+    expect(getCodexHarnessData(raw)?.skillInventory[0].calls).toBeUndefined();
+  });
+
+  it("accepts a combined tools envelope", () => {
+    const raw = {
+      primaryTool: "claude-code",
+      tools: {
+        "claude-code": legacyClaude(),
+        codex: codex(),
+      },
+    };
+
+    expect(listHarnessTools(raw)).toEqual(["claude-code", "codex"]);
+    expect(normalizeHarnessEnvelope(raw)?.primaryTool).toBe("claude-code");
+    expect(getClaudeHarnessData(raw)?.stats.totalTokens).toBe(1000);
+    expect(getCodexHarnessData(raw)?.stats.totalTokens).toBe(2000);
+  });
+
+  it("ignores malformed tool entries without rejecting the valid ones", () => {
+    const raw = {
+      primaryTool: "codex",
+      tools: {
+        "claude-code": { stats: {} },
+        codex: codex(),
+        unknown: { anything: true },
+      },
+    };
+
+    expect(listHarnessTools(raw)).toEqual(["codex"]);
+    expect(normalizeHarnessEnvelope(raw)?.primaryTool).toBe("codex");
+  });
+
+  it("returns null for empty or malformed envelopes", () => {
+    expect(normalizeHarnessEnvelope(null)).toBeNull();
+    expect(normalizeHarnessEnvelope({ tools: {} })).toBeNull();
+    expect(normalizeHarnessEnvelope({ tool: "codex", stats: null })).toBeNull();
+  });
+
+  it("stores every accepted shape as a tools envelope", () => {
+    expect(toStoredHarnessData(legacyClaude())).toMatchObject({
+      primaryTool: "claude-code",
+      tools: { "claude-code": { stats: { totalTokens: 1000 } } },
+    });
+    expect(toStoredHarnessData(codex())).toMatchObject({
+      primaryTool: "codex",
+      tools: { codex: { tool: "codex", stats: { totalTokens: 2000 } } },
+    });
+  });
+});

--- a/src/lib/__tests__/harness-tools.test.ts
+++ b/src/lib/__tests__/harness-tools.test.ts
@@ -162,4 +162,41 @@ describe("harness tools normalization", () => {
       tools: { codex: { tool: "codex", stats: { totalTokens: 2000 } } },
     });
   });
+
+  it("drops unrecognized Codex fields before storage", () => {
+    const stored = toStoredHarnessData(
+      codex({
+        stats: {
+          totalTokens: 2000,
+          sessionCount: 12,
+          payloadFormatSessions: 10,
+          legacyFormatSessions: 2,
+          localPath: "/Users/example/secret",
+        },
+        safety: {
+          approvalsReviewer: "model",
+          approvalModes: ["approve"],
+          trustLevels: ["trusted"],
+          rulesAllowlist: ["git"],
+          rawRules: "do not publish",
+        },
+        workSurfaces: {
+          desktopPresence: [
+            {
+              tool: "Codex CLI",
+              present: true,
+              path: "/Users/example/.codex",
+            },
+          ],
+          rawSurface: "private",
+        },
+        workflowData: { rawPrompt: "private" },
+      } as unknown as Partial<CodexHarnessData>),
+    );
+
+    expect(JSON.stringify(stored)).not.toContain("/Users/example");
+    expect(JSON.stringify(stored)).not.toContain("do not publish");
+    expect(JSON.stringify(stored)).not.toContain("rawPrompt");
+    expect(stored?.tools.codex?.workflowData).toBeNull();
+  });
 });

--- a/src/lib/__tests__/harness-tools.test.ts
+++ b/src/lib/__tests__/harness-tools.test.ts
@@ -190,13 +190,38 @@ describe("harness tools normalization", () => {
           ],
           rawSurface: "private",
         },
-        workflowData: { rawPrompt: "private" },
+        workflowData: {
+          rawPrompt: "private",
+          phaseTransitions: { planning: 2 },
+        },
       } as unknown as Partial<CodexHarnessData>),
     );
 
     expect(JSON.stringify(stored)).not.toContain("/Users/example");
     expect(JSON.stringify(stored)).not.toContain("do not publish");
     expect(JSON.stringify(stored)).not.toContain("rawPrompt");
-    expect(stored?.tools.codex?.workflowData).toBeNull();
+    expect(stored?.tools.codex?.workflowData).toEqual({
+      phaseTransitions: { planning: 2 },
+    });
+  });
+
+  it("normalizes Codex stats to non-negative integers", () => {
+    const stored = toStoredHarnessData(
+      codex({
+        stats: {
+          totalTokens: 2000.6,
+          sessionCount: 12.2,
+          payloadFormatSessions: -1,
+          legacyFormatSessions: Number.NaN,
+        },
+      }),
+    );
+
+    expect(stored?.tools.codex?.stats).toMatchObject({
+      totalTokens: 2001,
+      sessionCount: 12,
+    });
+    expect(stored?.tools.codex?.stats.payloadFormatSessions).toBeUndefined();
+    expect(stored?.tools.codex?.stats.legacyFormatSessions).toBeUndefined();
   });
 });

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -226,6 +226,8 @@ function stripShowcaseFieldsFromHarnessData(data: unknown): unknown {
 }
 
 function toListFeedHarnessData(data: unknown): unknown {
+  if (!isRecord(data) || !isRecord(data.tools)) return data;
+
   const envelope = normalizeHarnessEnvelope(data);
   return envelope?.tools["claude-code"] ?? data;
 }

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -6,7 +6,6 @@
  * returned harnessData unfiltered for section-level hides added via edit.
  */
 
-import type { HarnessData } from "@/types/insights";
 import { stripHiddenHarnessData } from "./harness-section-visibility";
 import { hideSetFromArray, filterList } from "./item-visibility";
 
@@ -50,7 +49,7 @@ export function filterReportForResponse<
   // Filter harnessData (the main privacy fix)
   if (result.harnessData && typeof result.harnessData === "object") {
     result.harnessData = stripHiddenHarnessData(
-      result.harnessData as HarnessData,
+      result.harnessData,
       hiddenSections,
     ) as unknown as T["harnessData"];
   }
@@ -191,28 +190,47 @@ export function filterReportForListFeed<
     includeHidden: false,
   });
 
-  if (
-    !filtered.harnessData ||
-    typeof filtered.harnessData !== "object" ||
-    !Array.isArray(
-      (filtered.harnessData as { skillInventory?: unknown }).skillInventory,
-    )
-  ) {
+  const harnessData = stripShowcaseFieldsFromHarnessData(filtered.harnessData);
+  if (harnessData === filtered.harnessData) {
     return filtered;
   }
 
-  const hd = filtered.harnessData as {
-    skillInventory: Array<{
-      readme_markdown?: string | null;
-      hero_base64?: string | null;
-      hero_mime_type?: string | null;
-      [key: string]: unknown;
-    }>;
-  };
+  return {
+    ...filtered,
+    harnessData,
+  } as T;
+}
 
-  const skillInventory = hd.skillInventory.map((skill) => {
+function stripShowcaseFieldsFromHarnessData(data: unknown): unknown {
+  if (!isRecord(data)) return data;
+
+  if (isRecord(data.tools)) {
+    const tools: Record<string, unknown> = { ...data.tools };
+    let changed = false;
+
+    for (const toolKey of ["claude-code", "codex"]) {
+      const stripped = stripShowcaseFieldsFromHarnessSlice(tools[toolKey]);
+      if (stripped !== tools[toolKey]) {
+        tools[toolKey] = stripped;
+        changed = true;
+      }
+    }
+
+    return changed ? { ...data, tools } : data;
+  }
+
+  return stripShowcaseFieldsFromHarnessSlice(data);
+}
+
+function stripShowcaseFieldsFromHarnessSlice(data: unknown): unknown {
+  if (!isRecord(data) || !Array.isArray(data.skillInventory)) return data;
+
+  let changed = false;
+  const skillInventory = data.skillInventory.map((skill) => {
+    if (!isRecord(skill)) return skill;
+
     // Only strip if showcase fields are actually present — avoids unnecessary
-    // object allocation for reports without --include-skills data
+    // object allocation for reports without --include-skills data.
     if (
       skill.readme_markdown == null &&
       skill.hero_base64 == null &&
@@ -220,6 +238,8 @@ export function filterReportForListFeed<
     ) {
       return skill;
     }
+
+    changed = true;
     return {
       ...skill,
       readme_markdown: null,
@@ -228,8 +248,9 @@ export function filterReportForListFeed<
     };
   });
 
-  return {
-    ...filtered,
-    harnessData: { ...hd, skillInventory },
-  } as T;
+  return changed ? { ...data, skillInventory } : data;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -8,6 +8,7 @@
 
 import { stripHiddenHarnessData } from "./harness-section-visibility";
 import { hideSetFromArray, filterList } from "./item-visibility";
+import { normalizeHarnessEnvelope } from "@/types/insights";
 
 /**
  * The shape of a narrative section that contains filterable sub-lists.
@@ -190,7 +191,9 @@ export function filterReportForListFeed<
     includeHidden: false,
   });
 
-  const harnessData = stripShowcaseFieldsFromHarnessData(filtered.harnessData);
+  const harnessData = toListFeedHarnessData(
+    stripShowcaseFieldsFromHarnessData(filtered.harnessData),
+  );
   if (harnessData === filtered.harnessData) {
     return filtered;
   }
@@ -220,6 +223,11 @@ function stripShowcaseFieldsFromHarnessData(data: unknown): unknown {
   }
 
   return stripShowcaseFieldsFromHarnessSlice(data);
+}
+
+function toListFeedHarnessData(data: unknown): unknown {
+  const envelope = normalizeHarnessEnvelope(data);
+  return envelope?.tools["claude-code"] ?? data;
 }
 
 function stripShowcaseFieldsFromHarnessSlice(data: unknown): unknown {

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -8,10 +8,10 @@ import { toStoredHarnessData } from "@/types/insights";
  * Checks for the integrity manifest script tag unique to harness reports.
  */
 export function isHarnessReport(html: string): boolean {
+  const $ = cheerio.load(html);
   return (
-    html.includes('id="insight-harness-integrity"') ||
-    html.includes('id="harness-data"') ||
-    html.includes("id='harness-data'")
+    $("script#insight-harness-integrity").length > 0 ||
+    $("script#harness-data").length > 0
   );
 }
 

--- a/src/lib/harness-parser.ts
+++ b/src/lib/harness-parser.ts
@@ -1,14 +1,18 @@
 import * as cheerio from "cheerio";
 import sanitize from "sanitize-html";
-import type { HarnessData } from "@/types/insights";
-import { normalizeHarnessData } from "@/types/insights";
+import type { HarnessToolsEnvelope } from "@/types/insights";
+import { toStoredHarnessData } from "@/types/insights";
 
 /**
  * Detect whether an HTML string is an insight-harness report (vs plain /insights).
  * Checks for the integrity manifest script tag unique to harness reports.
  */
 export function isHarnessReport(html: string): boolean {
-  return html.includes('id="insight-harness-integrity"');
+  return (
+    html.includes('id="insight-harness-integrity"') ||
+    html.includes('id="harness-data"') ||
+    html.includes("id='harness-data'")
+  );
 }
 
 /**
@@ -17,7 +21,7 @@ export function isHarnessReport(html: string): boolean {
  * sanitizes writeup HTML, and validates the shape.
  * Throws a descriptive error if the tag is missing or JSON is malformed.
  */
-export function parseHarnessHtml(html: string): HarnessData {
+export function parseHarnessHtml(html: string): HarnessToolsEnvelope {
   const $ = cheerio.load(html);
   const script = $("script#harness-data").first();
   const jsonString = script.html();
@@ -37,29 +41,47 @@ export function parseHarnessHtml(html: string): HarnessData {
     );
   }
 
-  // Sanitize writeup contentHtml before validation
-  if (
-    parsed &&
-    typeof parsed === "object" &&
-    Array.isArray((parsed as Record<string, unknown>).writeupSections)
-  ) {
-    const sections = (parsed as Record<string, unknown>)
-      .writeupSections as Array<{ title: string; contentHtml: string }>;
-    for (const section of sections) {
-      if (section.contentHtml) {
-        section.contentHtml = sanitizeWriteupHtml(section.contentHtml);
-      }
-    }
-  }
+  sanitizeClaudeWriteupSections(parsed);
 
-  const data = normalizeHarnessData(parsed);
+  const data = toStoredHarnessData(parsed);
   if (!data) {
     throw new Error(
-      "Harness report JSON is missing required fields (stats, autonomy, featurePills). The embedded data does not match the expected HarnessData shape.",
+      "Harness report JSON is missing required fields. The embedded data does not match a supported Claude Code, Codex, or multi-tool harness shape.",
     );
   }
 
   return data;
+}
+
+function sanitizeClaudeWriteupSections(parsed: unknown) {
+  if (!parsed || typeof parsed !== "object") return;
+  const obj = parsed as Record<string, unknown>;
+  const candidates: unknown[] = [obj];
+
+  if (
+    obj.tools &&
+    typeof obj.tools === "object" &&
+    !Array.isArray(obj.tools)
+  ) {
+    candidates.push((obj.tools as Record<string, unknown>)["claude-code"]);
+  }
+
+  for (const candidate of candidates) {
+    if (!candidate || typeof candidate !== "object") continue;
+    const sections = (candidate as Record<string, unknown>).writeupSections;
+    if (!Array.isArray(sections)) continue;
+    for (const section of sections) {
+      if (
+        section &&
+        typeof section === "object" &&
+        typeof (section as { contentHtml?: unknown }).contentHtml === "string"
+      ) {
+        (section as { contentHtml: string }).contentHtml = sanitizeWriteupHtml(
+          (section as { contentHtml: string }).contentHtml,
+        );
+      }
+    }
+  }
 }
 
 /**

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -1,4 +1,10 @@
-import type { HarnessData } from "@/types/insights";
+import {
+  normalizeHarnessEnvelope,
+  type CodexHarnessData,
+  type HarnessData,
+  type HarnessToolKey,
+  type HarnessToolsEnvelope,
+} from "@/types/insights";
 import {
   hideSetFromArray,
   isSectionHidden,
@@ -47,6 +53,53 @@ const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
   "harnessFiles",
 ]);
 
+const TOOL_KEY_ORDER: HarnessToolKey[] = ["claude-code", "codex"];
+
+function parseToolKeypath(keypath: string): {
+  toolKey: HarnessToolKey;
+  innerKeypath: string;
+} | null {
+  for (const toolKey of TOOL_KEY_ORDER) {
+    const prefix = `tools.${toolKey}.`;
+    if (!keypath.startsWith(prefix)) continue;
+
+    const innerKeypath = keypath.slice(prefix.length);
+    const parsed = parseKeypath(innerKeypath);
+    if (!parsed) return null;
+    if (
+      !(HIDEABLE_HARNESS_SECTION_KEYS as readonly string[]).includes(
+        parsed.topKey,
+      )
+    ) {
+      return null;
+    }
+
+    return { toolKey, innerKeypath };
+  }
+
+  return null;
+}
+
+function hiddenSectionsForTool(
+  hiddenSections: readonly string[],
+  toolKey: HarnessToolKey,
+  includeLegacyKeys: boolean,
+): string[] {
+  const keys: string[] = [];
+
+  for (const key of hiddenSections) {
+    const toolKeypath = parseToolKeypath(key);
+    if (toolKeypath) {
+      if (toolKeypath.toolKey === toolKey) keys.push(toolKeypath.innerKeypath);
+      continue;
+    }
+
+    if (includeLegacyKeys) keys.push(key);
+  }
+
+  return keys;
+}
+
 /**
  * Extract hidden section keys from a disabled-sections record.
  * Returns top-level keys for backward compat.
@@ -68,6 +121,7 @@ export function getHiddenKeypaths(
   const allowedTopKeys = new Set<string>(HIDEABLE_HARNESS_SECTION_KEYS);
   return Object.keys(disabledSections).filter((key) => {
     if (!disabledSections[key]) return false;
+    if (parseToolKeypath(key)) return true;
     const parsed = parseKeypath(key);
     if (!parsed) return false;
     return allowedTopKeys.has(parsed.topKey);
@@ -86,7 +140,7 @@ export function isHarnessSectionHidden(
  * Handles both section-level keys (e.g. "skillInventory") and item-level
  * keypaths (e.g. "skillInventory.superpowers-brainstorming").
  */
-export function stripHiddenHarnessData(
+function stripHiddenLegacyHarnessData(
   data: HarnessData,
   hiddenSections: readonly string[],
 ): HarnessData {
@@ -238,4 +292,153 @@ export function stripHiddenHarnessData(
   }
 
   return copy;
+}
+
+function stripHiddenCodexHarnessData(
+  data: CodexHarnessData,
+  hiddenSections: readonly string[],
+): CodexHarnessData {
+  if (!hiddenSections || hiddenSections.length === 0) return data;
+
+  const hidden = hideSetFromArray(hiddenSections);
+  const copy: CodexHarnessData = {
+    ...data,
+    toolUsage: { ...(data.toolUsage ?? {}) },
+    cliTools: { ...(data.cliTools ?? {}) },
+    skillInventory: [...(data.skillInventory ?? [])],
+    plugins: [...(data.plugins ?? [])],
+    safety: {
+      ...(data.safety ?? {}),
+      approvalModes: [...(data.safety?.approvalModes ?? [])],
+      trustLevels: [...(data.safety?.trustLevels ?? [])],
+      rulesAllowlist: [...(data.safety?.rulesAllowlist ?? [])],
+    },
+    workflowData: data.workflowData ? { ...data.workflowData } : null,
+    workSurfaces: {
+      ...(data.workSurfaces ?? {}),
+      desktopPresence: [...(data.workSurfaces?.desktopPresence ?? [])],
+    },
+  };
+
+  for (const key of hiddenSections) {
+    if (!STRIPPABLE_HARNESS_DATA_KEYS.has(key)) continue;
+
+    switch (key) {
+      case "workflowData":
+        copy.workflowData = null;
+        break;
+      case "skillInventory":
+        copy.skillInventory = [];
+        break;
+      case "plugins":
+        copy.plugins = [];
+        break;
+      case "cliTools":
+        copy.cliTools = {};
+        break;
+      case "toolUsage":
+        copy.toolUsage = {};
+        break;
+    }
+  }
+
+  if (!isSectionHidden(hidden, "skillInventory")) {
+    copy.skillInventory = filterList(
+      copy.skillInventory,
+      hidden,
+      "skillInventory",
+      (s) => s.name,
+    );
+  }
+  if (!isSectionHidden(hidden, "plugins")) {
+    copy.plugins = filterList(copy.plugins, hidden, "plugins", (p) => p.name);
+  }
+  if (!isSectionHidden(hidden, "toolUsage")) {
+    copy.toolUsage = filterRecord(copy.toolUsage, hidden, "toolUsage");
+  }
+  if (!isSectionHidden(hidden, "cliTools")) {
+    copy.cliTools = filterRecord(copy.cliTools, hidden, "cliTools");
+  }
+
+  return copy;
+}
+
+function stripHiddenHarnessEnvelope(
+  envelope: HarnessToolsEnvelope,
+  hiddenSections: readonly string[],
+): HarnessToolsEnvelope {
+  const tools: HarnessToolsEnvelope["tools"] = {};
+  const claude = envelope.tools["claude-code"];
+  const codex = envelope.tools.codex;
+
+  if (claude) {
+    tools["claude-code"] = stripHiddenLegacyHarnessData(
+      claude,
+      hiddenSectionsForTool(hiddenSections, "claude-code", true),
+    );
+  }
+  if (codex) {
+    tools.codex = stripHiddenCodexHarnessData(
+      codex,
+      hiddenSectionsForTool(hiddenSections, "codex", false),
+    );
+  }
+
+  return {
+    ...envelope,
+    tools,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function isEnvelopeShape(data: unknown): boolean {
+  return isRecord(data) && isRecord(data.tools);
+}
+
+/**
+ * Strip hidden harness data from legacy Claude harnesses, Codex harnesses, or
+ * tools-map envelopes. Legacy hide keys apply to Claude slices; namespaced
+ * `tools.<tool>.<section>` keys apply only to the matching tool slice.
+ */
+export function stripHiddenHarnessData(
+  data: HarnessData,
+  hiddenSections: readonly string[],
+): HarnessData;
+export function stripHiddenHarnessData(
+  data: CodexHarnessData,
+  hiddenSections: readonly string[],
+): CodexHarnessData;
+export function stripHiddenHarnessData(
+  data: HarnessToolsEnvelope,
+  hiddenSections: readonly string[],
+): HarnessToolsEnvelope;
+export function stripHiddenHarnessData<T>(
+  data: T,
+  hiddenSections: readonly string[],
+): T;
+export function stripHiddenHarnessData(
+  data: unknown,
+  hiddenSections: readonly string[],
+): unknown {
+  if (!hiddenSections || hiddenSections.length === 0) return data;
+
+  if (isEnvelopeShape(data)) {
+    const envelope = normalizeHarnessEnvelope(data);
+    return envelope
+      ? stripHiddenHarnessEnvelope(envelope, hiddenSections)
+      : data;
+  }
+
+  const codexEnvelope = normalizeHarnessEnvelope(data);
+  if (codexEnvelope?.tools.codex && !codexEnvelope.tools["claude-code"]) {
+    return stripHiddenCodexHarnessData(
+      codexEnvelope.tools.codex,
+      hiddenSectionsForTool(hiddenSections, "codex", true),
+    );
+  }
+
+  return stripHiddenLegacyHarnessData(data as HarnessData, hiddenSections);
 }

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -59,6 +59,15 @@ const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
 
 const TOOL_KEY_ORDER: HarnessToolKey[] = ["claude-code", "codex"];
 
+export function buildCodexVisibilityKey(
+  sectionKey: string,
+  itemKey?: string,
+): string {
+  return itemKey
+    ? `tools.codex.${sectionKey}.${itemKey}`
+    : `tools.codex.${sectionKey}`;
+}
+
 function parseToolKeypath(keypath: string): {
   toolKey: HarnessToolKey;
   innerKeypath: string;

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -31,6 +31,8 @@ export const HIDEABLE_HARNESS_SECTION_KEYS = [
   "versions",
   "writeupSections",
   "harnessFiles",
+  "safety",
+  "workSurfaces",
 ] as const;
 
 export type HideableHarnessSectionKey =
@@ -51,6 +53,8 @@ const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
   "versions",
   "writeupSections",
   "harnessFiles",
+  "safety",
+  "workSurfaces",
 ]);
 
 const TOOL_KEY_ORDER: HarnessToolKey[] = ["claude-code", "codex"];
@@ -338,6 +342,17 @@ function stripHiddenCodexHarnessData(
         break;
       case "toolUsage":
         copy.toolUsage = {};
+        break;
+      case "safety":
+        copy.safety = {
+          approvalsReviewer: null,
+          approvalModes: [],
+          trustLevels: [],
+          rulesAllowlist: [],
+        };
+        break;
+      case "workSurfaces":
+        copy.workSurfaces = { desktopPresence: [] };
         break;
     }
   }

--- a/src/lib/publish-report.ts
+++ b/src/lib/publish-report.ts
@@ -58,6 +58,13 @@ function generateSlug(): string {
   return `${date}-${shortId}`;
 }
 
+function toStoredTokenCount(value: unknown): bigint | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return null;
+  }
+  return BigInt(Math.round(value));
+}
+
 /**
  * Build the auto-generated title used when the caller didn't supply
  * one. Mirrors `handlePublish`'s "<First>'s {Insight Harness | Claude
@@ -146,6 +153,10 @@ export async function publishReport(
   const storedHarnessData = toStoredHarnessData(parsed.harnessData);
   const claudeHarnessData = getClaudeHarnessData(storedHarnessData);
   const codexHarnessData = getCodexHarnessData(storedHarnessData);
+  const storedTotalTokens =
+    typeof claudeHarnessData?.stats.totalTokens === "number"
+      ? claudeHarnessData.stats.totalTokens
+      : codexHarnessData?.stats.totalTokens;
 
   // 3. Title fallback.
   const isHarness = parsed.reportType === "insight-harness";
@@ -207,12 +218,7 @@ export async function publishReport(
         detectedSkills: parsed.detectedSkills ?? [],
         reportType: parsed.reportType ?? "insights",
         // Harness scalar denorm — null when this isn't a harness report.
-        totalTokens:
-          typeof claudeHarnessData?.stats.totalTokens === "number"
-            ? BigInt(claudeHarnessData.stats.totalTokens)
-            : typeof codexHarnessData?.stats.totalTokens === "number"
-              ? BigInt(codexHarnessData.stats.totalTokens)
-              : null,
+        totalTokens: toStoredTokenCount(storedTotalTokens),
         durationHours:
           typeof claudeHarnessData?.stats.durationHours === "number"
             ? Math.round(claudeHarnessData.stats.durationHours)

--- a/src/lib/publish-report.ts
+++ b/src/lib/publish-report.ts
@@ -19,7 +19,11 @@
 import type { Prisma } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { applyRedactions } from "@/lib/redaction";
-import { normalizeHarnessData } from "@/types/insights";
+import {
+  getClaudeHarnessData,
+  getCodexHarnessData,
+  toStoredHarnessData,
+} from "@/types/insights";
 import type {
   InsightsData,
   ParsedInsightsReport,
@@ -139,6 +143,10 @@ export async function publishReport(
       redactedData[dataKey as keyof InsightsData] ?? null;
   }
 
+  const storedHarnessData = toStoredHarnessData(parsed.harnessData);
+  const claudeHarnessData = getClaudeHarnessData(storedHarnessData);
+  const codexHarnessData = getCodexHarnessData(storedHarnessData);
+
   // 3. Title fallback.
   const isHarness = parsed.reportType === "insight-harness";
   const title =
@@ -200,20 +208,21 @@ export async function publishReport(
         reportType: parsed.reportType ?? "insights",
         // Harness scalar denorm — null when this isn't a harness report.
         totalTokens:
-          typeof parsed.harnessData?.stats.totalTokens === "number"
-            ? BigInt(parsed.harnessData.stats.totalTokens)
-            : null,
+          typeof claudeHarnessData?.stats.totalTokens === "number"
+            ? BigInt(claudeHarnessData.stats.totalTokens)
+            : typeof codexHarnessData?.stats.totalTokens === "number"
+              ? BigInt(codexHarnessData.stats.totalTokens)
+              : null,
         durationHours:
-          typeof parsed.harnessData?.stats.durationHours === "number"
-            ? Math.round(parsed.harnessData.stats.durationHours)
+          typeof claudeHarnessData?.stats.durationHours === "number"
+            ? Math.round(claudeHarnessData.stats.durationHours)
             : null,
-        avgSessionMinutes: parsed.harnessData?.stats.avgSessionMinutes ?? null,
-        prCount: parsed.harnessData?.stats.prCount ?? null,
-        autonomyLabel: parsed.harnessData?.autonomy.label ?? null,
+        avgSessionMinutes:
+          claudeHarnessData?.stats.avgSessionMinutes ?? null,
+        prCount: claudeHarnessData?.stats.prCount ?? null,
+        autonomyLabel: claudeHarnessData?.autonomy.label ?? null,
         harnessData:
-          (normalizeHarnessData(
-            parsed.harnessData,
-          ) as unknown as Prisma.InputJsonValue) ?? undefined,
+          (storedHarnessData as unknown as Prisma.InputJsonValue) ?? undefined,
         hiddenHarnessSections: args.hiddenHarnessSections,
       },
       select: {

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -310,6 +310,10 @@ export interface CodexHarnessWorkSurfaces {
   }>;
 }
 
+export interface CodexHarnessWorkflowData {
+  phaseTransitions?: Record<string, number>;
+}
+
 export interface CodexHarnessData {
   tool: "codex";
   stats: CodexHarnessStats;
@@ -318,7 +322,7 @@ export interface CodexHarnessData {
   skillInventory: CodexHarnessSkillEntry[];
   plugins: CodexHarnessPlugin[];
   safety: CodexHarnessSafety;
-  workflowData: Record<string, unknown> | null;
+  workflowData: CodexHarnessWorkflowData | null;
   workSurfaces: CodexHarnessWorkSurfaces;
   localOnly: boolean;
 }
@@ -489,6 +493,13 @@ function normalizeNumberMap(raw: unknown): Record<string, number> {
   );
 }
 
+function normalizeNonNegativeInteger(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) {
+    return undefined;
+  }
+  return Math.round(raw);
+}
+
 function normalizeStringArray(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
   return raw.filter((item): item is string => typeof item === "string");
@@ -562,6 +573,15 @@ function normalizeCodexWorkSurfaces(raw: unknown): CodexHarnessWorkSurfaces {
   };
 }
 
+function normalizeCodexWorkflowData(
+  raw: unknown,
+): CodexHarnessWorkflowData | null {
+  if (!isRecord(raw)) return null;
+
+  const phaseTransitions = normalizeNumberMap(raw.phaseTransitions);
+  return Object.keys(phaseTransitions).length > 0 ? { phaseTransitions } : null;
+}
+
 function normalizeCodexHarnessData(raw: unknown): CodexHarnessData | null {
   if (!isRecord(raw)) return null;
   if (raw.tool !== "codex") return null;
@@ -570,29 +590,21 @@ function normalizeCodexHarnessData(raw: unknown): CodexHarnessData | null {
   return {
     tool: "codex",
     stats: {
-      totalTokens:
-        typeof raw.stats.totalTokens === "number"
-          ? raw.stats.totalTokens
-          : undefined,
-      sessionCount:
-        typeof raw.stats.sessionCount === "number"
-          ? raw.stats.sessionCount
-          : undefined,
-      payloadFormatSessions:
-        typeof raw.stats.payloadFormatSessions === "number"
-          ? raw.stats.payloadFormatSessions
-          : undefined,
-      legacyFormatSessions:
-        typeof raw.stats.legacyFormatSessions === "number"
-          ? raw.stats.legacyFormatSessions
-          : undefined,
+      totalTokens: normalizeNonNegativeInteger(raw.stats.totalTokens),
+      sessionCount: normalizeNonNegativeInteger(raw.stats.sessionCount),
+      payloadFormatSessions: normalizeNonNegativeInteger(
+        raw.stats.payloadFormatSessions,
+      ),
+      legacyFormatSessions: normalizeNonNegativeInteger(
+        raw.stats.legacyFormatSessions,
+      ),
     },
     toolUsage: normalizeNumberMap(raw.toolUsage),
     cliTools: normalizeNumberMap(raw.cliTools),
     skillInventory: normalizeCodexSkillInventory(raw.skillInventory),
     plugins: normalizeCodexPlugins(raw.plugins),
     safety: normalizeCodexSafety(raw.safety),
-    workflowData: null,
+    workflowData: normalizeCodexWorkflowData(raw.workflowData),
     workSurfaces: normalizeCodexWorkSurfaces(raw.workSurfaces),
     localOnly: raw.localOnly === true,
   };

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -111,7 +111,7 @@ export interface ParsedInsightsReport {
   multiClauding?: MultiClaudingStats;
   detectedSkills?: SkillKey[];
   reportType?: "insights" | "insight-harness";
-  harnessData?: HarnessData;
+  harnessData?: StoredHarnessData;
 }
 
 // ── Harness Data (insight-harness reports) ──────────────────────────────
@@ -328,6 +328,8 @@ export interface HarnessToolsEnvelope {
     codex?: CodexHarnessData;
   };
 }
+
+export type StoredHarnessData = HarnessData | HarnessToolsEnvelope;
 
 // v2: Chart data parsed from HTML report
 export interface ChartDataPoint {

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -304,8 +304,10 @@ export interface CodexHarnessSafety {
 }
 
 export interface CodexHarnessWorkSurfaces {
-  desktopPresence: Array<Record<string, unknown>>;
-  [key: string]: unknown;
+  desktopPresence: Array<{
+    tool?: string;
+    present?: boolean;
+  }>;
 }
 
 export interface CodexHarnessData {
@@ -498,7 +500,6 @@ function normalizeCodexSkillInventory(raw: unknown): CodexHarnessSkillEntry[] {
     if (!isRecord(entry) || typeof entry.name !== "string") return [];
     return [
       {
-        ...entry,
         name: entry.name,
         description:
           typeof entry.description === "string" ? entry.description : null,
@@ -520,7 +521,6 @@ function normalizeCodexPlugins(raw: unknown): CodexHarnessPlugin[] {
     if (!isRecord(entry) || typeof entry.name !== "string") return [];
     return [
       {
-        ...entry,
         name: entry.name,
         enabled: typeof entry.enabled === "boolean" ? entry.enabled : undefined,
         version: typeof entry.version === "string" ? entry.version : null,
@@ -534,7 +534,6 @@ function normalizeCodexPlugins(raw: unknown): CodexHarnessPlugin[] {
 function normalizeCodexSafety(raw: unknown): CodexHarnessSafety {
   const source = isRecord(raw) ? raw : {};
   return {
-    ...source,
     approvalsReviewer:
       typeof source.approvalsReviewer === "string"
         ? source.approvalsReviewer
@@ -548,9 +547,17 @@ function normalizeCodexSafety(raw: unknown): CodexHarnessSafety {
 function normalizeCodexWorkSurfaces(raw: unknown): CodexHarnessWorkSurfaces {
   const source = isRecord(raw) ? raw : {};
   return {
-    ...source,
     desktopPresence: Array.isArray(source.desktopPresence)
-      ? source.desktopPresence.filter(isRecord)
+      ? source.desktopPresence.flatMap((entry) => {
+          if (!isRecord(entry)) return [];
+          return [
+            {
+              tool: typeof entry.tool === "string" ? entry.tool : undefined,
+              present:
+                typeof entry.present === "boolean" ? entry.present : undefined,
+            },
+          ];
+        })
       : [],
   };
 }
@@ -562,13 +569,30 @@ function normalizeCodexHarnessData(raw: unknown): CodexHarnessData | null {
 
   return {
     tool: "codex",
-    stats: raw.stats as CodexHarnessStats,
+    stats: {
+      totalTokens:
+        typeof raw.stats.totalTokens === "number"
+          ? raw.stats.totalTokens
+          : undefined,
+      sessionCount:
+        typeof raw.stats.sessionCount === "number"
+          ? raw.stats.sessionCount
+          : undefined,
+      payloadFormatSessions:
+        typeof raw.stats.payloadFormatSessions === "number"
+          ? raw.stats.payloadFormatSessions
+          : undefined,
+      legacyFormatSessions:
+        typeof raw.stats.legacyFormatSessions === "number"
+          ? raw.stats.legacyFormatSessions
+          : undefined,
+    },
     toolUsage: normalizeNumberMap(raw.toolUsage),
     cliTools: normalizeNumberMap(raw.cliTools),
     skillInventory: normalizeCodexSkillInventory(raw.skillInventory),
     plugins: normalizeCodexPlugins(raw.plugins),
     safety: normalizeCodexSafety(raw.safety),
-    workflowData: isRecord(raw.workflowData) ? raw.workflowData : null,
+    workflowData: null,
     workSurfaces: normalizeCodexWorkSurfaces(raw.workSurfaces),
     localOnly: raw.localOnly === true,
   };

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -268,6 +268,67 @@ export interface HarnessData {
   perModelTokens?: Record<string, HarnessModelTokenBreakdown> | null;
 }
 
+export type HarnessToolKey = "claude-code" | "codex";
+
+export interface CodexHarnessStats {
+  totalTokens?: number;
+  sessionCount?: number;
+  payloadFormatSessions?: number;
+  legacyFormatSessions?: number;
+  [key: string]: unknown;
+}
+
+export interface CodexHarnessSkillEntry {
+  name: string;
+  description?: string | null;
+  installPointer?: string | null;
+  source?: string | null;
+  category?: string | null;
+  calls?: number;
+}
+
+export interface CodexHarnessPlugin {
+  name: string;
+  enabled?: boolean;
+  version?: string | null;
+  marketplace?: string | null;
+  [key: string]: unknown;
+}
+
+export interface CodexHarnessSafety {
+  approvalsReviewer?: string | null;
+  approvalModes: string[];
+  trustLevels: string[];
+  rulesAllowlist: string[];
+  [key: string]: unknown;
+}
+
+export interface CodexHarnessWorkSurfaces {
+  desktopPresence: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export interface CodexHarnessData {
+  tool: "codex";
+  stats: CodexHarnessStats;
+  toolUsage: Record<string, number>;
+  cliTools: Record<string, number>;
+  skillInventory: CodexHarnessSkillEntry[];
+  plugins: CodexHarnessPlugin[];
+  safety: CodexHarnessSafety;
+  workflowData: Record<string, unknown> | null;
+  workSurfaces: CodexHarnessWorkSurfaces;
+  localOnly: boolean;
+}
+
+export interface HarnessToolsEnvelope {
+  primaryTool: HarnessToolKey;
+  tools: {
+    "claude-code"?: HarnessData;
+    codex?: CodexHarnessData;
+  };
+}
+
 // v2: Chart data parsed from HTML report
 export interface ChartDataPoint {
   label: string;
@@ -410,12 +471,122 @@ export function normalizeSkills(raw: unknown): SkillKey[] {
   return raw.filter(isSkillKey);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeNumberMap(raw: unknown): Record<string, number> {
+  if (!isRecord(raw)) return {};
+  return Object.fromEntries(
+    Object.entries(raw).filter(
+      (entry): entry is [string, number] =>
+        typeof entry[1] === "number" && Number.isFinite(entry[1]),
+    ),
+  );
+}
+
+function normalizeStringArray(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((item): item is string => typeof item === "string");
+}
+
+function normalizeCodexSkillInventory(raw: unknown): CodexHarnessSkillEntry[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.name !== "string") return [];
+    return [
+      {
+        ...entry,
+        name: entry.name,
+        description:
+          typeof entry.description === "string" ? entry.description : null,
+        installPointer:
+          typeof entry.installPointer === "string"
+            ? entry.installPointer
+            : null,
+        source: typeof entry.source === "string" ? entry.source : null,
+        category: typeof entry.category === "string" ? entry.category : null,
+        calls: typeof entry.calls === "number" ? entry.calls : undefined,
+      },
+    ];
+  });
+}
+
+function normalizeCodexPlugins(raw: unknown): CodexHarnessPlugin[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.name !== "string") return [];
+    return [
+      {
+        ...entry,
+        name: entry.name,
+        enabled: typeof entry.enabled === "boolean" ? entry.enabled : undefined,
+        version: typeof entry.version === "string" ? entry.version : null,
+        marketplace:
+          typeof entry.marketplace === "string" ? entry.marketplace : null,
+      },
+    ];
+  });
+}
+
+function normalizeCodexSafety(raw: unknown): CodexHarnessSafety {
+  const source = isRecord(raw) ? raw : {};
+  return {
+    ...source,
+    approvalsReviewer:
+      typeof source.approvalsReviewer === "string"
+        ? source.approvalsReviewer
+        : null,
+    approvalModes: normalizeStringArray(source.approvalModes),
+    trustLevels: normalizeStringArray(source.trustLevels),
+    rulesAllowlist: normalizeStringArray(source.rulesAllowlist),
+  };
+}
+
+function normalizeCodexWorkSurfaces(raw: unknown): CodexHarnessWorkSurfaces {
+  const source = isRecord(raw) ? raw : {};
+  return {
+    ...source,
+    desktopPresence: Array.isArray(source.desktopPresence)
+      ? source.desktopPresence.filter(isRecord)
+      : [],
+  };
+}
+
+function normalizeCodexHarnessData(raw: unknown): CodexHarnessData | null {
+  if (!isRecord(raw)) return null;
+  if (raw.tool !== "codex") return null;
+  if (!isRecord(raw.stats)) return null;
+
+  return {
+    tool: "codex",
+    stats: raw.stats as CodexHarnessStats,
+    toolUsage: normalizeNumberMap(raw.toolUsage),
+    cliTools: normalizeNumberMap(raw.cliTools),
+    skillInventory: normalizeCodexSkillInventory(raw.skillInventory),
+    plugins: normalizeCodexPlugins(raw.plugins),
+    safety: normalizeCodexSafety(raw.safety),
+    workflowData: isRecord(raw.workflowData) ? raw.workflowData : null,
+    workSurfaces: normalizeCodexWorkSurfaces(raw.workSurfaces),
+    localOnly: raw.localOnly === true,
+  };
+}
+
+function listNormalizedHarnessTools(
+  tools: HarnessToolsEnvelope["tools"],
+): HarnessToolKey[] {
+  const available: HarnessToolKey[] = [];
+  if (tools["claude-code"]) available.push("claude-code");
+  if (tools.codex) available.push("codex");
+  return available;
+}
+
 /**
- * Validate that an unknown value from the DB (Prisma Json?) looks like
- * HarnessData. Returns the typed value if it passes, or null if malformed.
- * Checks for the required top-level keys with correct types.
+ * Validate that an unknown value looks like legacy Claude Code HarnessData.
+ * Returns the typed value if it passes, or null if malformed. Checks for the
+ * required top-level keys with correct types.
  */
-export function normalizeHarnessData(raw: unknown): HarnessData | null {
+function normalizeLegacyHarnessData(raw: unknown): HarnessData | null {
   if (!raw || typeof raw !== "object") return null;
   const obj = raw as Record<string, unknown>;
 
@@ -470,4 +641,69 @@ export function normalizeHarnessData(raw: unknown): HarnessData | null {
     perModelTokens:
       (obj.perModelTokens as HarnessData["perModelTokens"]) ?? null,
   };
+}
+
+export function normalizeHarnessEnvelope(
+  raw: unknown,
+): HarnessToolsEnvelope | null {
+  const legacy = normalizeLegacyHarnessData(raw);
+  if (legacy) {
+    return {
+      primaryTool: "claude-code",
+      tools: { "claude-code": legacy },
+    };
+  }
+
+  const codex = normalizeCodexHarnessData(raw);
+  if (codex) {
+    return {
+      primaryTool: "codex",
+      tools: { codex },
+    };
+  }
+
+  if (!isRecord(raw) || !isRecord(raw.tools)) return null;
+
+  const tools: HarnessToolsEnvelope["tools"] = {};
+  const claudeTool = normalizeLegacyHarnessData(raw.tools["claude-code"]);
+  const codexTool = normalizeCodexHarnessData(raw.tools.codex);
+
+  if (claudeTool) tools["claude-code"] = claudeTool;
+  if (codexTool) tools.codex = codexTool;
+
+  const available = listNormalizedHarnessTools(tools);
+  if (available.length === 0) return null;
+
+  const requestedPrimary = raw.primaryTool;
+  const primaryTool =
+    typeof requestedPrimary === "string" &&
+    available.includes(requestedPrimary as HarnessToolKey)
+      ? (requestedPrimary as HarnessToolKey)
+      : available[0];
+
+  return { primaryTool, tools };
+}
+
+/**
+ * Back-compat accessor for callers that render the existing Claude Code UI.
+ */
+export function normalizeHarnessData(raw: unknown): HarnessData | null {
+  return getClaudeHarnessData(raw);
+}
+
+export function getClaudeHarnessData(raw: unknown): HarnessData | null {
+  return normalizeHarnessEnvelope(raw)?.tools["claude-code"] ?? null;
+}
+
+export function getCodexHarnessData(raw: unknown): CodexHarnessData | null {
+  return normalizeHarnessEnvelope(raw)?.tools.codex ?? null;
+}
+
+export function listHarnessTools(raw: unknown): HarnessToolKey[] {
+  const tools = normalizeHarnessEnvelope(raw)?.tools;
+  return tools ? listNormalizedHarnessTools(tools) : [];
+}
+
+export function toStoredHarnessData(raw: unknown): HarnessToolsEnvelope | null {
+  return normalizeHarnessEnvelope(raw);
 }


### PR DESCRIPTION
## Summary
- add multi-tool harness envelope normalization for legacy Claude Code and Codex payloads
- accept Codex/combined harness uploads and persist normalized envelopes without a DB migration
- add per-tool visibility filtering, public tool selector, Codex dashboard, and Codex edit visibility controls

## Verification
- npm run lint (passes with existing 19 warnings)
- npx tsc --noEmit
- npx vitest run
- VERCEL_ENV=preview npm run build