### PR TITLE
feat: add public skill install page

### DIFF
--- a/src/app/install/page.tsx
+++ b/src/app/install/page.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import { ArrowLeft, Code2, Terminal, Upload } from "lucide-react";
+
+const claudeInstallCommands = [
+  "/plugin marketplace add kabirdos/insight-harness",
+  "/plugin install insight-harness@kabirdos-insight-harness",
+];
+
+const codexInstallCommand = `mkdir -p ~/.codex/skills/insight-harness/scripts && \\
+curl -sSL https://raw.githubusercontent.com/kabirdos/insight-harness/main/skills/insight-harness/SKILL.md \\
+  -o ~/.codex/skills/insight-harness/SKILL.md && \\
+curl -sSL https://raw.githubusercontent.com/kabirdos/insight-harness/main/skills/insight-harness/scripts/codex_extract.py \\
+  -o ~/.codex/skills/insight-harness/scripts/codex_extract.py && \\
+curl -sSL https://raw.githubusercontent.com/kabirdos/insight-harness/main/skills/insight-harness/scripts/pii_scrub.py \\
+  -o ~/.codex/skills/insight-harness/scripts/pii_scrub.py && \\
+curl -sSL https://raw.githubusercontent.com/kabirdos/insight-harness/main/skills/insight-harness/scripts/extract.py \\
+  -o ~/.codex/skills/insight-harness/scripts/extract.py`;
+
+function CommandBlock({ command }: { command: string }) {
+  return (
+    <pre className="overflow-x-auto rounded-lg bg-slate-950 p-4 text-xs leading-6 text-slate-100">
+      <code>{command}</code>
+    </pre>
+  );
+}
+
+export default function InstallPage() {
+  return (
+    <main className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+      <section className="border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm font-medium text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Home
+          </Link>
+          <div className="mt-8 max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+              Insight Harness Skill
+            </p>
+            <h1 className="mt-2 text-3xl font-extrabold tracking-tight sm:text-4xl">
+              Publish a Claude Code or Codex harness profile.
+            </h1>
+            <p className="mt-4 text-base leading-7 text-slate-600 dark:text-slate-300">
+              The skill generates a privacy-scrubbed HTML report from local
+              agent logs. Claude Code can publish directly with a token. Codex
+              currently generates an uploadable HTML file from local CLI logs.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-5xl gap-6 px-4 py-8 sm:px-6 lg:grid-cols-2">
+        <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300">
+              <Code2 className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="font-bold">Claude Code</h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Install from the Claude plugin marketplace.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            {claudeInstallCommands.map((command) => (
+              <CommandBlock key={command} command={command} />
+            ))}
+            <CommandBlock command="/insight-harness" />
+          </div>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+            For direct publish, sign in on the upload page, generate a token,
+            then run `/insight-harness --publish --token=ih_...`.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300">
+              <Terminal className="h-5 w-5" />
+            </span>
+            <div>
+              <h2 className="font-bold">Codex</h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Install the skill under `~/.codex/skills`.
+              </p>
+            </div>
+          </div>
+          <div className="space-y-3">
+            <CommandBlock command={codexInstallCommand} />
+            <CommandBlock command="python3 ~/.codex/skills/insight-harness/scripts/codex_extract.py --include-skills" />
+          </div>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
+            The report is written under `~/.codex/usage-data/`. Upload the
+            generated `*-codex-harness.html` file on the upload page.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-5xl px-4 pb-12 sm:px-6">
+        <div className="flex flex-col gap-3 rounded-lg border border-blue-200 bg-blue-50 p-5 dark:border-blue-900/60 dark:bg-blue-950/30 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-bold text-blue-950 dark:text-blue-100">
+              Ready to share?
+            </h2>
+            <p className="mt-1 text-sm text-blue-900/80 dark:text-blue-100/80">
+              Upload the generated HTML, preview redactions, then publish when
+              it looks right.
+            </p>
+          </div>
+          <Link
+            href="/upload"
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
+          >
+            <Upload className="h-4 w-4" />
+            Upload Report
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1114,6 +1114,12 @@ export default function HomePage() {
               <Upload className="h-4 w-4" />
               {copy.hero.secondaryCta}
             </Link>
+            <Link
+              href="/install"
+              className="hidden text-sm font-semibold text-slate-500 underline decoration-slate-300 underline-offset-4 transition-colors hover:text-slate-900 dark:text-slate-400 dark:decoration-slate-700 dark:hover:text-white sm:inline-flex"
+            >
+              Install the skill
+            </Link>
           </div>
         </div>
       </section>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -26,6 +26,7 @@ import {
   Loader2,
   RefreshCw,
   LogIn,
+  Terminal,
 } from "lucide-react";
 import clsx from "clsx";
 import type {
@@ -100,6 +101,7 @@ const EMPTY_FORM: ProjectFormInput = {
 
 const INSIGHTS_PATH = "~/.claude/usage-data/report.html";
 const HARNESS_PATH = "~/.claude/insight-harness/report.html";
+const CODEX_HARNESS_PATH = "~/.codex/usage-data/<date>-codex-harness.html";
 
 const SAMPLE_PROFILE_USERNAME = "kabirdos";
 const SAMPLE_PROFILE_SLUG = "20260413-e3n48n";
@@ -948,6 +950,16 @@ function TokenizedFlow({
                 See exactly what it runs
               </a>
               .
+            </p>
+            <p className="text-[11px] text-slate-500 dark:text-slate-400">
+              Using Codex?{" "}
+              <Link
+                href="/install"
+                className="font-medium text-slate-700 underline decoration-slate-300 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:decoration-slate-600 dark:hover:text-white"
+              >
+                Install the Codex version
+              </Link>{" "}
+              and upload the generated HTML file here.
             </p>
           </div>
         )}
@@ -1810,12 +1822,12 @@ export default function UploadPage() {
           {/* Header */}
           <div className="mb-7 text-center">
             <h1 className="text-xl font-extrabold text-slate-900 dark:text-slate-100">
-              Turn your Claude Code session data into your{" "}
+              Turn your Claude Code or Codex session data into your{" "}
               <span className="text-2xl">profile</span> in one minute
             </h1>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              Generate a report in Claude Code, drop the file below, and preview
-              your profile before anything goes public.
+              Generate a report, drop the file below, and preview your profile
+              before anything goes public.
             </p>
           </div>
 
@@ -1897,6 +1909,13 @@ export default function UploadPage() {
                 >
                   inspect the source
                 </a>
+                . Codex users can use the{" "}
+                <Link
+                  href="/install"
+                  className="font-medium text-slate-600 underline decoration-slate-300 underline-offset-2 hover:text-slate-900 hover:decoration-slate-500 dark:text-slate-300 dark:decoration-slate-600 dark:hover:text-slate-100 dark:hover:decoration-slate-400"
+                >
+                  Codex install instructions
+                </Link>
                 .
               </p>
               <div className="mt-1">
@@ -1925,6 +1944,29 @@ export default function UploadPage() {
                 Then run:
               </p>
               <CommandBlock command="/insight-harness" />
+            </div>
+
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4 dark:border-emerald-900/60 dark:bg-emerald-950/20">
+              <div className="mb-2 flex items-center gap-2 text-[13px] font-semibold text-emerald-900 dark:text-emerald-100">
+                <Terminal className="h-4 w-4" />
+                Codex CLI
+              </div>
+              <p className="text-xs leading-relaxed text-emerald-900/80 dark:text-emerald-100/80">
+                Codex reports are generated locally, then uploaded manually.
+              </p>
+              <div className="mt-3">
+                <CommandBlock
+                  command="python3 ~/.codex/skills/insight-harness/scripts/codex_extract.py --include-skills"
+                  small
+                />
+              </div>
+              <p className="mt-2 text-xs text-emerald-900/80 dark:text-emerald-100/80">
+                Output path: <code>{CODEX_HARNESS_PATH}</code>. Need setup?{" "}
+                <Link href="/install" className="font-semibold underline">
+                  Install the skill
+                </Link>
+                .
+              </p>
             </div>
 
             <div className="flex flex-col gap-2">

--- a/src/content/homepage.ts
+++ b/src/content/homepage.ts
@@ -6,9 +6,9 @@
 export const homepage = {
   // ── Hero ──────────────────────────────────────────────────
   hero: {
-    headline: "See how other developers use Claude Code",
+    headline: "See how developers use Claude Code and Codex",
     subtext:
-      "Browse real developer workflows — the tools, skills, plugins, and patterns they use across actual coding sessions. All personal data removed.",
+      "Browse real developer workflows — the tools, skills, plugins, and patterns they use across actual agent sessions. All personal data removed.",
     primaryCta: "Browse Profiles",
     secondaryCta: "Upload Your Insights",
   },
@@ -18,7 +18,7 @@ export const homepage = {
     featuredLabel: "Featured Profile",
     recentHeading: "Recent Profiles",
     emptyTitle: "No profiles shared yet",
-    emptySubtext: "Be the first to share your Claude Code insights!",
+    emptySubtext: "Be the first to share your agent harness insights!",
     emptyCta: "Upload Your Insights",
     strengthsLabel: "Strengths:",
   },
@@ -28,12 +28,11 @@ export const homepage = {
     heading: "Upgrade your profile with",
     skillName: "/insight-harness",
     description:
-      "A superset of /insights — everything you get from /insights, plus token usage, tool breakdowns, skill inventory, and more.",
-    githubUrl:
-      "https://github.com/craigdossantos/claude-toolkit/tree/main/skills/insight-harness",
+      "A shareable harness profile for Claude Code and Codex — tools, skills, plugin inventory, workflow signal, and more.",
+    githubUrl: "https://github.com/kabirdos/insight-harness",
     githubLabel: "View on GitHub →",
     privacyNote:
-      "Privacy-first: only reads tool names, skill names, and stats — never your code or messages",
+      "Privacy-first: only reads whitelisted local metadata — never your code or messages",
 
     // Comparison table
     table: {
@@ -77,19 +76,19 @@ export const homepage = {
   howItWorks: {
     heading: "Three commands to a public profile",
     subheading:
-      "Install once, run, upload. No accounts. No signup. /insight-harness is the command.",
+      "Install once, run, upload. Claude Code and Codex reports both publish here.",
     steps: [
       {
         icon: "📦",
         title: "Install /insight-harness",
         description:
-          "One curl command drops the skill into your Claude Code setup. One-time step.",
+          "Install the skill for Claude Code or Codex. One-time step.",
       },
       {
         icon: "⚡",
         title: "Run /insight-harness",
         description:
-          "In any Claude Code session. Scans tokens, skills, plugins, workflows. Outputs a single HTML report in seconds.",
+          "Generate a local HTML report from Claude Code or Codex CLI metadata.",
       },
       {
         icon: "🌐",
@@ -104,7 +103,7 @@ export const homepage = {
   footerCta: {
     heading: "Ready to share your harness?",
     subtext:
-      "Join developers who are learning from each other's Claude Code workflows.",
+      "Join developers who are learning from each other's agent workflows.",
     cta: "Upload Your Insights",
   },
 } as const;


### PR DESCRIPTION
## Summary
- add /install page with Claude Code and Codex setup commands
- link the install page from the homepage hero and upload flow
- update homepage/upload copy to describe Claude Code and Codex reports

## Verification
- npm run lint (passes with existing 19 warnings)
- npx tsc --noEmit
- VERCEL_ENV=preview npm run build