### PR TITLE
fix: reserve 'install' username to match the /install route

### DIFF
--- a/src/lib/reserved-usernames.ts
+++ b/src/lib/reserved-usernames.ts
@@ -12,6 +12,7 @@ export const RESERVED_USERNAMES: ReadonlySet<string> = new Set([
   // Currently present top-level routes
   "api",
   "insights",
+  "install",
   "search",
   "top",
   "u",


### PR DESCRIPTION
PR #149 added the public skill-install page at `src/app/install/` but didn't add `install` to `RESERVED_USERNAMES`. The drift-detection guard (`reserved-usernames.test.ts`) walks `src/app/` and fails when a top-level route segment lacks a matching reservation — so the test suite has been **red on main since #149 merged**.

Without the reservation, a user could register the username `install` and collide with the route.

One-line fix: add `install` to the "currently present top-level routes" group. `reserved-usernames.test.ts` now passes (5/5).

Codex review: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)