### PR TITLE
fix(insights): strip camelCase Codex hero blobs from the agent payload

### DIFF
--- a/src/lib/__tests__/agent-payload.test.ts
+++ b/src/lib/__tests__/agent-payload.test.ts
@@ -116,11 +116,36 @@ describe("stripHeroImages", () => {
     };
     expect(out.primaryTool).toBe("claude-code");
     expect(out.tools["claude-code"].skillInventory[0].hero_base64).toBeNull();
-    // Codex entries carry no image fields; structure is preserved verbatim.
+    // This Codex entry has no image fields, so it's preserved verbatim.
     expect(out.tools.codex.skillInventory[0]).toEqual({
       name: "codex-skill",
       description: "x",
     });
+  });
+
+  it("strips camelCase hero fields from Codex skills (codex_extract emits heroBase64)", () => {
+    const envelope = {
+      primaryTool: "codex",
+      tools: {
+        codex: {
+          tool: "codex",
+          skillInventory: [
+            {
+              name: "codex-skill",
+              heroBase64: "AAAA".repeat(200),
+              heroMimeType: "image/png",
+            },
+          ],
+        },
+      },
+    };
+    const out = stripHeroImages(envelope) as {
+      tools: { codex: { skillInventory: Array<Record<string, unknown>> } };
+    };
+    const entry = out.tools.codex.skillInventory[0];
+    expect(entry.heroBase64).toBeNull();
+    expect(entry.heroMimeType).toBeNull();
+    expect(entry.name).toBe("codex-skill");
   });
 
   it("returns non-object / inventory-less input unchanged", () => {

--- a/src/lib/agent-payload.ts
+++ b/src/lib/agent-payload.ts
@@ -73,10 +73,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+// Hero image keys in BOTH casings: the Claude extractor emits snake_case
+// hero_base64 / hero_mime_type; the Codex extractor emits camelCase
+// heroBase64 / heroMimeType (codex_extract.py). A Codex or multi-tool report
+// stores the raw island (parseHarnessHtml does not normalize away these
+// fields), so we must strip whichever are present.
+const HERO_KEYS = [
+  "hero_base64",
+  "hero_mime_type",
+  "heroBase64",
+  "heroMimeType",
+] as const;
+
 function stripHeroFromSkill(skill: unknown): unknown {
   if (!isRecord(skill)) return skill;
-  if (skill.hero_base64 == null && skill.hero_mime_type == null) return skill;
-  return { ...skill, hero_base64: null, hero_mime_type: null };
+  if (!HERO_KEYS.some((key) => skill[key] != null)) return skill;
+  const out: Record<string, unknown> = { ...skill };
+  for (const key of HERO_KEYS) {
+    if (key in out) out[key] = null;
+  }
+  return out;
 }
 
 function stripHeroFromHolder(holder: unknown): unknown {
@@ -90,9 +106,9 @@ function stripHeroFromHolder(holder: unknown): unknown {
 /**
  * Drop hero image blobs from every skill inventory while preserving the stored
  * shape — a bare `HarnessData` or a multi-tool `{ primaryTool, tools }`
- * envelope (`isEnvelopeShape` is just "has a `tools` record"). Codex skill
- * entries carry no image fields today; they pass through the stripper anyway so
- * the day they do, this still covers them. Pure: never mutates the input.
+ * envelope (`isEnvelopeShape` is just "has a `tools` record"). Covers both the
+ * Claude (snake_case) and Codex (camelCase) hero fields, so a Codex or
+ * multi-tool report's images are stripped too. Pure: never mutates the input.
  */
 export function stripHeroImages(stored: unknown): unknown {
   if (!isRecord(stored)) return stored;


### PR DESCRIPTION
## Bug

The agent payload's `stripHeroImages` (shipped in #151) only nulled **snake_case** `hero_base64` / `hero_mime_type` — the Claude extractor's fields. But the **Codex** extractor emits **camelCase** `heroBase64` / `heroMimeType` (`codex_extract.py`), and `parseHarnessHtml` stores the raw island without normalizing those away. So a **Codex or multi-tool** report's base64 image blobs survived into the agent payload — defeating the whole point of the lean payload (Phase 0 F1) for exactly the Codex profiles the multi-tool work added.

Surfaced during review of the consumer-side learn-mode PR (insight-harness #26), which already defends against this client-side. This closes it at the contract owner.

## Fix

`stripHeroFromSkill` now nulls hero keys in **both casings**. Also retracts the (now-wrong) "Codex skill entries carry no image fields" comment.

## Tests

New test proving camelCase Codex hero is stripped inside a multi-tool envelope. Full suite **709 passing**; tsc + eslint clean; codex review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)