### PR TITLE
ci: enable GitHub Actions (lint, typecheck, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npx tsc --noEmit
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      # npm/cli#4828: `npm ci` skips the platform-specific rollup binary that
+      # vitest (via vite) needs at runtime. The runner is always ubuntu-x64, so
+      # force-install just that optional dep (kept out of the lockfile).
+      - run: npm install --no-save @rollup/rollup-linux-x64-gnu
+      - run: npx prisma generate
+      - run: npx vitest run
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
+    env:
+      # Dummy env vars so Next.js prerender + Prisma client generation don't fail.
+      # Real values are injected by Vercel for actual deploys.
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db'
+      DIRECT_URL: 'postgresql://user:pass@localhost:5432/db'
+      AUTH_SECRET: 'ci-dummy-auth-secret'
+      AUTH_GITHUB_ID: 'ci-dummy-github-id'
+      AUTH_GITHUB_SECRET: 'ci-dummy-github-secret'
+      NEXT_PUBLIC_SUPABASE_URL: 'https://ci-dummy.supabase.co'
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'ci-dummy-anon-key'
+      SUPABASE_SERVICE_ROLE_KEY: 'ci-dummy-service-role'
+      VERCEL_ENV: 'preview'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      # npm/cli#4828: `npm ci` skips platform-specific native binaries. Tailwind
+      # 4 (lightningcss + oxide) needs the linux-x64 ones at build time; the
+      # runner is always ubuntu-x64, so force-install them (kept out of lockfile).
+      - run: npm install --no-save lightningcss-linux-x64-gnu @tailwindcss/oxide-linux-x64-gnu
+      - run: npm run build


### PR DESCRIPTION
## Why

`.github/workflows/ci.yml` existed locally but was never committed, so **no GitHub Actions CI ran on PRs** — only Vercel's build check gated, and a broken test (`reserved-usernames`, fixed in #150) sat red on `main` undetected for days. This commits the workflow to turn on real CI.

## What runs (every PR + push to main)

- **lint** — `npm run lint`
- **typecheck** — `npx tsc --noEmit`
- **test** — `npx vitest run`
- **build** — `npm run build`, gated with `VERCEL_ENV=preview` so the prisma `migrate deploy` step stays off, plus dummy env for prerender/`prisma generate`.

## Self-validating

Because the workflow triggers on `pull_request`, **this PR's own checks are the first run** — if they're green here, CI is working. Merging only after they pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)