### PR TITLE
feat(insights): render Work Rhythm — parallel sessions + when-I-work

### DIFF
--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -27,6 +27,7 @@ import { buildItemKey } from "@/lib/item-visibility";
 import HeroStats from "@/components/HeroStats";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
+import WorkRhythm from "@/components/WorkRhythm";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
@@ -419,7 +420,8 @@ function CodexVisibilityPreview({
                     ...codexData.safety.approvalModes,
                     ...codexData.safety.trustLevels,
                     ...codexData.safety.rulesAllowlist,
-                  ].length.toLocaleString()} values
+                  ].length.toLocaleString()}{" "}
+                  values
                 </div>
               </div>
             </div>
@@ -1011,6 +1013,20 @@ export default function EditReportPage() {
           >
             <HowIWorkCluster harnessData={harnessData} />
           </HideableCard>
+
+          {((harnessData.concurrency?.maxConcurrent ?? 0) > 0 ||
+            harnessData.temporal?.label) && (
+            <HideableCard
+              title="Work Rhythm"
+              hidden={!!hiddenSections["workRhythm"]}
+              onToggle={() => toggleSection("workRhythm")}
+            >
+              <WorkRhythm
+                concurrency={harnessData.concurrency}
+                temporal={harnessData.temporal}
+              />
+            </HideableCard>
+          )}
 
           {harnessData.workflowData && (
             <HideableCard

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -38,6 +38,7 @@ import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 // New redesigned components for harness reports
 import HeroStats from "@/components/HeroStats";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
+import WorkRhythm from "@/components/WorkRhythm";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import { SkillsTeaserCard } from "@/components/SkillsTeaserCard";
@@ -480,6 +481,14 @@ export default function InsightDetailPage() {
                   {/* How I Work cluster: Autonomy + Model Donut + File Ops */}
                   {!isSectionHidden(hiddenSet, "howIWork") && (
                     <HowIWorkCluster harnessData={claudeHarnessData} />
+                  )}
+
+                  {/* Work Rhythm: parallel-session concurrency + when-I-work */}
+                  {!isSectionHidden(hiddenSet, "workRhythm") && (
+                    <WorkRhythm
+                      concurrency={claudeHarnessData.concurrency}
+                      temporal={claudeHarnessData.temporal}
+                    />
                   )}
 
                   {/* Skills Teaser — hero-thumbnail cards for the top shareable

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -54,6 +54,7 @@ import PermissionModeDisplay from "@/components/PermissionModeDisplay";
 import HooksSafetyTable from "@/components/HooksSafetyTable";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
+import WorkRhythm from "@/components/WorkRhythm";
 import ProjectLinks from "@/components/ProjectLinks";
 import MiniBarChart from "@/components/MiniBarChart";
 import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
@@ -1567,8 +1568,7 @@ export default function UploadPage() {
           reportType: parsed.reportType ?? "insights",
           totalTokens: claudeHarnessData?.stats.totalTokens ?? null,
           durationHours: claudeHarnessData?.stats.durationHours ?? null,
-          avgSessionMinutes:
-            claudeHarnessData?.stats.avgSessionMinutes ?? null,
+          avgSessionMinutes: claudeHarnessData?.stats.avgSessionMinutes ?? null,
           prCount: claudeHarnessData?.stats.prCount ?? null,
           autonomyLabel: claudeHarnessData?.autonomy.label ?? null,
           // Persist the FULL harnessData (including hidden showcase content).
@@ -2382,72 +2382,71 @@ export default function UploadPage() {
             )}
           </div>
 
-          {parsed.reportType === "insight-harness" &&
-            previewCodexData && (
-              <div className="space-y-4">
-                <RedactableSection
-                  title="Codex Tool Usage"
-                  enabled={!disabledSections[buildCodexVisibilityKey("toolUsage")]}
-                  onToggle={() =>
-                    toggleSection(buildCodexVisibilityKey("toolUsage"))
-                  }
-                >
-                  <CodexHarnessDashboard codexData={previewCodexData} />
-                </RedactableSection>
-                <RedactableSection
-                  title="Codex Skills"
-                  enabled={
-                    !disabledSections[
-                      buildCodexVisibilityKey("skillInventory")
-                    ]
-                  }
-                  onToggle={() =>
-                    toggleSection(buildCodexVisibilityKey("skillInventory"))
-                  }
-                >
-                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-                    {previewCodexData.skillInventory.length.toLocaleString()}{" "}
-                    inventory items
-                  </div>
-                </RedactableSection>
-                <RedactableSection
-                  title="Codex Plugins"
-                  enabled={!disabledSections[buildCodexVisibilityKey("plugins")]}
-                  onToggle={() =>
-                    toggleSection(buildCodexVisibilityKey("plugins"))
-                  }
-                >
-                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-                    {previewCodexData.plugins.length.toLocaleString()} plugins
-                  </div>
-                </RedactableSection>
-                <RedactableSection
-                  title="Codex Safety And Rules"
-                  enabled={!disabledSections[buildCodexVisibilityKey("safety")]}
-                  onToggle={() =>
-                    toggleSection(buildCodexVisibilityKey("safety"))
-                  }
-                >
-                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-                    Safety metadata will be shown unless hidden.
-                  </div>
-                </RedactableSection>
-                <RedactableSection
-                  title="Codex Work Surfaces"
-                  enabled={
-                    !disabledSections[buildCodexVisibilityKey("workSurfaces")]
-                  }
-                  onToggle={() =>
-                    toggleSection(buildCodexVisibilityKey("workSurfaces"))
-                  }
-                >
-                  <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
-                    {previewCodexData.workSurfaces.desktopPresence.length.toLocaleString()}{" "}
-                    desktop signals
-                  </div>
-                </RedactableSection>
-              </div>
-            )}
+          {parsed.reportType === "insight-harness" && previewCodexData && (
+            <div className="space-y-4">
+              <RedactableSection
+                title="Codex Tool Usage"
+                enabled={
+                  !disabledSections[buildCodexVisibilityKey("toolUsage")]
+                }
+                onToggle={() =>
+                  toggleSection(buildCodexVisibilityKey("toolUsage"))
+                }
+              >
+                <CodexHarnessDashboard codexData={previewCodexData} />
+              </RedactableSection>
+              <RedactableSection
+                title="Codex Skills"
+                enabled={
+                  !disabledSections[buildCodexVisibilityKey("skillInventory")]
+                }
+                onToggle={() =>
+                  toggleSection(buildCodexVisibilityKey("skillInventory"))
+                }
+              >
+                <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                  {previewCodexData.skillInventory.length.toLocaleString()}{" "}
+                  inventory items
+                </div>
+              </RedactableSection>
+              <RedactableSection
+                title="Codex Plugins"
+                enabled={!disabledSections[buildCodexVisibilityKey("plugins")]}
+                onToggle={() =>
+                  toggleSection(buildCodexVisibilityKey("plugins"))
+                }
+              >
+                <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                  {previewCodexData.plugins.length.toLocaleString()} plugins
+                </div>
+              </RedactableSection>
+              <RedactableSection
+                title="Codex Safety And Rules"
+                enabled={!disabledSections[buildCodexVisibilityKey("safety")]}
+                onToggle={() =>
+                  toggleSection(buildCodexVisibilityKey("safety"))
+                }
+              >
+                <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                  Safety metadata will be shown unless hidden.
+                </div>
+              </RedactableSection>
+              <RedactableSection
+                title="Codex Work Surfaces"
+                enabled={
+                  !disabledSections[buildCodexVisibilityKey("workSurfaces")]
+                }
+                onToggle={() =>
+                  toggleSection(buildCodexVisibilityKey("workSurfaces"))
+                }
+              >
+                <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                  {previewCodexData.workSurfaces.desktopPresence.length.toLocaleString()}{" "}
+                  desktop signals
+                </div>
+              </RedactableSection>
+            </div>
+          )}
 
           {/* ── Harness Report Preview — mirrors profile page layout ── */}
           {parsed.reportType === "insight-harness" && previewHarnessData ? (
@@ -2510,6 +2509,21 @@ export default function UploadPage() {
               >
                 <HowIWorkCluster harnessData={previewHarnessData} />
               </RedactableSection>
+
+              {/* Work Rhythm: parallel-session concurrency + when-I-work */}
+              {((previewHarnessData.concurrency?.maxConcurrent ?? 0) > 0 ||
+                previewHarnessData.temporal?.label) && (
+                <RedactableSection
+                  title="Work Rhythm"
+                  enabled={!disabledSections["workRhythm"]}
+                  onToggle={() => toggleSection("workRhythm")}
+                >
+                  <WorkRhythm
+                    concurrency={previewHarnessData.concurrency}
+                    temporal={previewHarnessData.temporal}
+                  />
+                </RedactableSection>
+              )}
 
               {/* Workflow Diagrams */}
               {previewHarnessData.workflowData && (

--- a/src/components/WorkRhythm.tsx
+++ b/src/components/WorkRhythm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { HarnessConcurrency, HarnessTemporal } from "@/types/insights";
+
+interface WorkRhythmProps {
+  concurrency?: HarnessConcurrency | null;
+  temporal?: HarnessTemporal | null;
+}
+
+function formatHour(h: number): string {
+  const hr = ((Math.round(h) % 24) + 24) % 24;
+  if (hr === 0) return "12am";
+  if (hr === 12) return "12pm";
+  return hr < 12 ? `${hr}am` : `${hr - 12}pm`;
+}
+
+/**
+ * Surfaces two verified "how I work" rhythm signals the harness now ships:
+ * session concurrency ("runs N in parallel") and a when-I-work temporal
+ * characterization with a 24-hour activity histogram. Renders nothing when
+ * neither signal has data, so older reports are unaffected.
+ */
+export default function WorkRhythm({ concurrency, temporal }: WorkRhythmProps) {
+  const hasConcurrency =
+    !!concurrency &&
+    Number.isFinite(concurrency.maxConcurrent) &&
+    concurrency.maxConcurrent > 0;
+  // Data is cast from unknown JSON, so guard peakHour is a real number before
+  // formatting it (a partial object could otherwise render "peaks NaNpm").
+  const hasTemporal =
+    !!temporal && !!temporal.label && Number.isFinite(temporal.peakHour);
+  if (!hasConcurrency && !hasTemporal) return null;
+
+  const hourCounts =
+    temporal && typeof temporal.hourCounts === "object" && temporal.hourCounts
+      ? temporal.hourCounts
+      : {};
+  const hours = Array.from({ length: 24 }, (_, h) => ({
+    h,
+    count: hourCounts[String(h)] ?? 0,
+  }));
+  const maxHour = Math.max(1, ...hours.map((x) => x.count));
+
+  return (
+    <div className="mb-6 rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-700 dark:bg-slate-900/50">
+      <h3 className="mb-4 text-[15px] font-bold text-slate-900 dark:text-slate-100">
+        Work Rhythm
+      </h3>
+      <div className="grid gap-6 md:grid-cols-2">
+        {hasConcurrency && (
+          <div className="flex flex-col justify-center">
+            <div className="text-[11px] font-bold uppercase tracking-wider text-blue-700 dark:text-blue-400">
+              Parallel sessions
+            </div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="text-4xl font-extrabold tracking-tight text-slate-900 sm:text-5xl dark:text-slate-50">
+                {concurrency!.maxConcurrent}
+              </span>
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                peak at once
+              </span>
+            </div>
+            <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              ~{concurrency!.medianConcurrent} typically running together ·{" "}
+              {concurrency!.sessionsCounted} sessions
+            </div>
+          </div>
+        )}
+
+        {hasTemporal && (
+          <div className="flex flex-col justify-center">
+            <div className="text-[11px] font-bold uppercase tracking-wider text-amber-700 dark:text-amber-400">
+              When I work
+            </div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <span className="text-xl font-extrabold text-slate-900 dark:text-slate-50">
+                {temporal!.label}
+              </span>
+              <span className="text-sm text-slate-500 dark:text-slate-400">
+                peaks {formatHour(temporal!.peakHour)}
+              </span>
+            </div>
+            <div
+              className="mt-3 flex h-12 items-end gap-[2px]"
+              role="img"
+              aria-label="Activity by hour of day"
+            >
+              {hours.map(({ h, count }) => (
+                <div
+                  key={h}
+                  title={`${formatHour(h)}: ${count}`}
+                  className={`flex-1 rounded-sm ${
+                    h === temporal!.peakHour
+                      ? "bg-amber-500"
+                      : "bg-amber-200 dark:bg-amber-900/50"
+                  }`}
+                  style={{ height: `${Math.max(6, (count / maxHour) * 100)}%` }}
+                />
+              ))}
+            </div>
+            <div className="mt-1 flex justify-between text-[10px] text-slate-400">
+              <span>12am</span>
+              <span>12pm</span>
+              <span>11pm</span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/__tests__/harness-section-visibility.test.ts
+++ b/src/lib/__tests__/harness-section-visibility.test.ts
@@ -38,6 +38,16 @@ function buildFullHarnessData(): HarnessData {
     workflowData: null,
     integrityHash: "abc",
     skillVersion: null,
+    concurrency: {
+      maxConcurrent: 13,
+      medianConcurrent: 9,
+      sessionsCounted: 107,
+    },
+    temporal: {
+      hourCounts: { "15": 79 },
+      peakHour: 15,
+      label: "Afternoon peak",
+    },
   };
 }
 
@@ -110,6 +120,25 @@ describe("stripHiddenHarnessData", () => {
     const full = buildFullHarnessData();
     const result = stripHiddenHarnessData(full, []);
     expect(result).toBe(full);
+  });
+
+  it("strips concurrency and temporal when workRhythm is hidden", () => {
+    const result = stripHiddenHarnessData(buildFullHarnessData(), [
+      "workRhythm",
+    ]);
+    expect(result.concurrency).toBeNull();
+    expect(result.temporal).toBeNull();
+    expect(result.cliTools).toEqual({ gh: 1 }); // unrelated data untouched
+  });
+
+  it("keeps concurrency and temporal when workRhythm is not hidden", () => {
+    const result = stripHiddenHarnessData(buildFullHarnessData(), ["plugins"]);
+    expect(result.concurrency).toEqual({
+      maxConcurrent: 13,
+      medianConcurrent: 9,
+      sessionsCounted: 107,
+    });
+    expect(result.temporal?.label).toBe("Afternoon peak");
   });
 
   it("round-trips full HarnessData with empty-array fields and a section hidden", () => {

--- a/src/lib/__tests__/harness-tools.test.ts
+++ b/src/lib/__tests__/harness-tools.test.ts
@@ -126,6 +126,35 @@ describe("harness tools normalization", () => {
     expect(getClaudeHarnessData(legacyClaude())?.dailyActivity).toBeNull();
   });
 
+  it("preserves concurrency and temporal signals through normalization", () => {
+    const raw = legacyClaude({
+      concurrency: {
+        maxConcurrent: 13,
+        medianConcurrent: 9,
+        sessionsCounted: 107,
+      },
+      temporal: {
+        hourCounts: { "15": 79 },
+        peakHour: 15,
+        label: "Afternoon peak",
+      },
+    });
+
+    expect(getClaudeHarnessData(raw)?.concurrency).toEqual({
+      maxConcurrent: 13,
+      medianConcurrent: 9,
+      sessionsCounted: 107,
+    });
+    expect(getClaudeHarnessData(raw)?.temporal?.label).toBe("Afternoon peak");
+    expect(getClaudeHarnessData(raw)?.temporal?.peakHour).toBe(15);
+  });
+
+  it("defaults concurrency and temporal to null when omitted", () => {
+    const out = getClaudeHarnessData(legacyClaude());
+    expect(out?.concurrency).toBeNull();
+    expect(out?.temporal).toBeNull();
+  });
+
   it("accepts a Codex Phase 1 tool island", () => {
     const raw = codex();
 

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -17,6 +17,7 @@ export const HIDEABLE_HARNESS_SECTION_KEYS = [
   "heroStats",
   "activityHeatmap",
   "howIWork",
+  "workRhythm",
   "toolUsage",
   "workflowData",
   "skillInventory",
@@ -39,6 +40,10 @@ export type HideableHarnessSectionKey =
   (typeof HIDEABLE_HARNESS_SECTION_KEYS)[number];
 
 const STRIPPABLE_HARNESS_DATA_KEYS = new Set<string>([
+  // concurrency + temporal are used only by the Work Rhythm card, so hiding the
+  // section can fully strip them from non-owner payloads (unlike heroStats /
+  // activityHeatmap / howIWork, whose data is shared across stat sections).
+  "workRhythm",
   "toolUsage",
   "workflowData",
   "skillInventory",
@@ -234,6 +239,10 @@ function stripHiddenLegacyHarnessData(
         break;
       case "toolUsage":
         copy.toolUsage = {};
+        break;
+      case "workRhythm":
+        copy.concurrency = null;
+        copy.temporal = null;
         break;
     }
   }

--- a/src/types/insights.ts
+++ b/src/types/insights.ts
@@ -253,6 +253,20 @@ export interface HarnessDailyActivity {
   tokens: number;
 }
 
+/** Session concurrency — how many sessions overlapped in time. */
+export interface HarnessConcurrency {
+  maxConcurrent: number;
+  medianConcurrent: number;
+  sessionsCounted: number;
+}
+
+/** When work happens — activity by clock hour, with a derived characterization. */
+export interface HarnessTemporal {
+  hourCounts: Record<string, number>;
+  peakHour: number;
+  label: string;
+}
+
 export interface HarnessData {
   stats: HarnessStats;
   autonomy: HarnessAutonomy;
@@ -279,6 +293,8 @@ export interface HarnessData {
   enhancedStats?: HarnessEnhancedStats | null;
   perModelTokens?: Record<string, HarnessModelTokenBreakdown> | null;
   dailyActivity?: HarnessDailyActivity[] | null;
+  concurrency?: HarnessConcurrency | null;
+  temporal?: HarnessTemporal | null;
 }
 
 export type HarnessToolKey = "claude-code" | "codex";
@@ -692,6 +708,8 @@ function normalizeLegacyHarnessData(raw: unknown): HarnessData | null {
     perModelTokens:
       (obj.perModelTokens as HarnessData["perModelTokens"]) ?? null,
     dailyActivity: (obj.dailyActivity as HarnessData["dailyActivity"]) ?? null,
+    concurrency: (obj.concurrency as HarnessData["concurrency"]) ?? null,
+    temporal: (obj.temporal as HarnessData["temporal"]) ?? null,
   };
 }
 


### PR DESCRIPTION
## What

Renders the two new verified "how I work" signals the harness now ships — **concurrency** (insight-harness #32) and **temporal** (#33) — as a **Work Rhythm** card. Closes backlog **B4** (rendering) and completes the "make new signals visible" task.

## Changes

- **Types/parser** (`insights.ts`): `HarnessConcurrency` + `HarnessTemporal`, optional fields on `HarnessData`, mapped in `normalizeLegacyHarnessData` (mirrors `dailyActivity`).
- **Component** (`WorkRhythm.tsx`): "Parallel sessions" (peak + median + session count) and "When I work" (dominant-quarter label + peak hour + a 24-hour activity histogram). Returns `null` when neither signal has data; guards `Number.isFinite` on numeric fields and a record-like `hourCounts`.
- **Report** (`page.tsx`): rendered after the How I Work cluster.
- **Visibility**: `workRhythm` added to `HIDEABLE_HARNESS_SECTION_KEYS` **and** `STRIPPABLE_HARNESS_DATA_KEYS` — since `concurrency`/`temporal` are WorkRhythm-only, hiding the section fully **strips** them from non-owner payloads (better than the shared-data stat sections, which can only hide the render). UI toggles added to the **edit** + **upload** pages, shown only when there's data.

## Verification

- Live data renders: **maxConcurrent 13 / median 9**, "Afternoon peak" (peaks 3pm).
- `npx tsc --noEmit` ✅ · `npx vitest run` ✅ **715 passing** (adds round-trip + strip-when-hidden tests) · `npx eslint` ✅.
- **Codex review: clean** — prior [High] (visibility-pipeline integration) and [Low] (NaN guard) both resolved; no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)