### PR TITLE
fix(insights): omit silent-zero stats in listing & leaderboard cards

### DIFF
--- a/src/components/ContributorRow.tsx
+++ b/src/components/ContributorRow.tsx
@@ -23,7 +23,10 @@ interface ContributorRowProps {
 }
 
 function perWeek(value: number | null, dayCount: number | null): string | null {
-  if (value == null || dayCount == null || dayCount === 0) return null;
+  // A 0 value (e.g. a sourceless commitCount/linesAdded) must yield null, not
+  // "0" — rendering "0/wk" is a silent-zero false claim (issue #29). `!value`
+  // also drops null/undefined/NaN.
+  if (!value || dayCount == null || dayCount === 0) return null;
   const weeks = dayCount / 7;
   if (weeks === 0) return null;
   return Math.round(value / weeks).toLocaleString();

--- a/src/components/InsightCard.tsx
+++ b/src/components/InsightCard.tsx
@@ -158,23 +158,30 @@ export default function InsightCard({
       {/* Stats row */}
       {(sessionCount || messageCount || commitCount) && (
         <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-slate-500 dark:text-slate-400">
-          {messageCount != null && (
+          {/* Guard each metric on > 0, not just != null: a sourceless 0 (e.g.
+              commitCount/linesAdded on a machine without session-meta) must be
+              omitted, never rendered as "0 commits"/"+0" (issue #29). */}
+          {messageCount != null && messageCount > 0 && (
             <span>{messageCount.toLocaleString()} msgs</span>
           )}
-          {linesAdded != null && linesRemoved != null && (
+          {linesAdded != null && linesAdded > 0 && (
             <span className="text-green-600 dark:text-green-400">
               +{linesAdded.toLocaleString()}
             </span>
           )}
-          {linesRemoved != null && (
+          {linesRemoved != null && linesRemoved > 0 && (
             <span className="text-red-500 dark:text-red-400">
               -{linesRemoved.toLocaleString()}
             </span>
           )}
-          {fileCount != null && <span>{fileCount} files</span>}
-          {dayCount != null && <span>{dayCount} days</span>}
-          {msgsPerDay != null && <span>{msgsPerDay.toFixed(1)}/day</span>}
-          {commitCount != null && <span>{commitCount} commits</span>}
+          {fileCount != null && fileCount > 0 && <span>{fileCount} files</span>}
+          {dayCount != null && dayCount > 0 && <span>{dayCount} days</span>}
+          {msgsPerDay != null && msgsPerDay > 0 && (
+            <span>{msgsPerDay.toFixed(1)}/day</span>
+          )}
+          {commitCount != null && commitCount > 0 && (
+            <span>{commitCount} commits</span>
+          )}
         </div>
       )}
 

--- a/src/components/LeaderboardRow.tsx
+++ b/src/components/LeaderboardRow.tsx
@@ -116,7 +116,12 @@ export default function LeaderboardRow({ row }: { row: LeaderboardRowData }) {
           <Stat label="Sessions" value={row.sessionCount.toLocaleString()} />
         </div>
         <div className="hidden md:block">
-          <Stat label="Active" value={`${row.durationHours}h`} />
+          {/* A sourceless 0h is a silent-zero false claim (issue #29) — show an
+              em dash instead, matching the Lines cell's no-data convention. */}
+          <Stat
+            label="Active"
+            value={row.durationHours > 0 ? `${row.durationHours}h` : "—"}
+          />
         </div>
         <div className="hidden lg:block">
           <Stat

--- a/src/components/SnapshotCard.tsx
+++ b/src/components/SnapshotCard.tsx
@@ -16,7 +16,10 @@ interface SnapshotCardProps {
 }
 
 function perWeek(value: number | null, dayCount: number | null): string | null {
-  if (value == null || dayCount == null || dayCount === 0) return null;
+  // A 0 value (e.g. a sourceless commitCount/linesAdded) must yield null, not
+  // "0" — rendering "0/wk" is a silent-zero false claim (issue #29). `!value`
+  // also drops null/undefined/NaN.
+  if (!value || dayCount == null || dayCount === 0) return null;
   const weeks = dayCount / 7;
   if (weeks === 0) return null;
   return Math.round(value / weeks).toLocaleString();

--- a/src/components/__tests__/silent-zero-stats.test.tsx
+++ b/src/components/__tests__/silent-zero-stats.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import InsightCard from "@/components/InsightCard";
+import ContributorRow from "@/components/ContributorRow";
+import SnapshotCard from "@/components/SnapshotCard";
+
+// Regression guard for issue #29 (consumer side): listing/leaderboard cards
+// must omit a metric whose value is a sourceless 0 (e.g. commitCount/linesAdded
+// on a machine without the legacy session-meta dir), never render "0 commits" /
+// "+0" / "0/wk". A confident zero reads as a false claim and undercuts the
+// product's "verified, honest data" promise. The standalone-HTML half is pinned
+// by insight-harness/test_no_silent_zeros.py; this pins the React half.
+
+describe("InsightCard — no silent zeros", () => {
+  // A real report with sessions but a sourceless 0 for commits/lines/msgs.
+  const sourceless = {
+    slug: "s",
+    title: "Untitled Report",
+    authorUsername: "ada",
+    publishedAt: "2026-06-01",
+    voteCount: 0,
+    commentCount: 0,
+    sessionCount: 12,
+    messageCount: 0,
+    commitCount: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    fileCount: 0,
+    dayCount: 30,
+    msgsPerDay: 0,
+  };
+
+  it("omits zero-valued metrics instead of rendering '0 commits' / '+0'", () => {
+    const html = renderToStaticMarkup(<InsightCard {...sourceless} />);
+    expect(html).not.toContain("commits");
+    expect(html).not.toContain("msgs");
+    expect(html).not.toContain("files");
+    expect(html).not.toContain("+0");
+    expect(html).not.toContain("/day");
+  });
+
+  it("renders metrics that are genuinely positive", () => {
+    const html = renderToStaticMarkup(
+      <InsightCard
+        {...sourceless}
+        messageCount={4200}
+        commitCount={37}
+        linesAdded={1500}
+        linesRemoved={200}
+        fileCount={18}
+        msgsPerDay={140}
+      />,
+    );
+    expect(html).toContain("37 commits");
+    expect(html).toContain("4,200 msgs");
+    expect(html).toContain("18 files");
+    expect(html).toContain("+1,500");
+  });
+});
+
+describe("ContributorRow — no silent zeros", () => {
+  const base = {
+    slug: "s",
+    username: "ada",
+    displayName: "Ada",
+    avatarUrl: null,
+    publishedAt: "2026-06-01",
+    dateRangeStart: "2026-05-01",
+    dateRangeEnd: "2026-05-31",
+    dayCount: 7, // 1 week → per-week == raw value, keeps assertions simple
+    messageCount: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    fileCount: 0,
+    commitCount: 0,
+    detectedSkills: [],
+  };
+
+  it("omits per-week stats whose value is 0 (no '+0' / '0 commits')", () => {
+    const html = renderToStaticMarkup(<ContributorRow {...base} />);
+    expect(html).not.toContain("commits");
+    expect(html).not.toContain("msgs");
+    expect(html).not.toContain("+0");
+  });
+
+  it("renders per-week stats that are positive", () => {
+    const html = renderToStaticMarkup(
+      <ContributorRow {...base} commitCount={14} messageCount={70} />,
+    );
+    expect(html).toContain("commits");
+    expect(html).toContain("msgs");
+  });
+});
+
+describe("SnapshotCard — no silent zeros", () => {
+  const base = {
+    sessionCount: 10,
+    messageCount: 0,
+    linesAdded: 0,
+    linesRemoved: 0,
+    fileCount: 0,
+    dayCount: 7,
+    commitCount: 0,
+    chartData: null,
+    detectedSkills: [],
+    keyPattern: null,
+    projectAreas: null,
+  };
+
+  it("omits weekly-average stats whose value is 0", () => {
+    const html = renderToStaticMarkup(<SnapshotCard {...base} />);
+    expect(html).not.toContain("Commits");
+    expect(html).not.toContain("Added");
+    expect(html).not.toContain("Files");
+  });
+
+  it("renders weekly-average stats that are positive", () => {
+    const html = renderToStaticMarkup(
+      <SnapshotCard {...base} commitCount={21} linesAdded={3500} />,
+    );
+    expect(html).toContain("Commits");
+    expect(html).toContain("Added");
+  });
+});


### PR DESCRIPTION
## What

The main profile/report components already guard their stats (`durationHours > 0`, `commitCount > 0`, `linesAdded !== "0"`), but the **/top, home, and search listing surfaces** still leaked a confident `0` for sourceless metrics — the same false-claim failure mode #29 calls out. A `0h` / `0 commits` reads as "instant sessions, no work" and undercuts the product's load-bearing "verified, honest data" promise.

On machines without the legacy `~/.claude/usage-data/session-meta/` dir, `commitCount`/`linesAdded` persist as `0`, so:

- **`LeaderboardRow`** rendered `${durationHours}h` → **"0h"** on the Active column.
- **`InsightCard`** guarded counts on `!= null`, so a stored `0` printed **"0 commits" / "0 msgs" / "0 files" / "+0"**.
- **`ContributorRow`** & **`SnapshotCard`**'s `perWeek()` returned the string `"0"` for a `0` value (only `null` was filtered), printing **"+0" / "0/wk"**.

## How

- **`LeaderboardRow`**: show an em dash (`—`) when `durationHours` is `0`, matching the `Lines` cell's existing no-data convention (keeps leaderboard columns aligned rather than dropping a cell).
- **`InsightCard`**: guard each count metric on `> 0`, not just `!= null`. Also decouples the `+added` span from `linesRemoved` presence (show `+added` whenever `linesAdded > 0`).
- **`ContributorRow` / `SnapshotCard`**: `perWeek()` now returns `null` for a `0` value (`!value`), matching the already-correct copy in `top/page.tsx`.

`page.tsx` already guards its rendered per-week values on `> 0` (lines 644/691/794), so it didn't leak and is untouched.

## Why this is the consumer-side companion to insight-harness #34

#34 fixed the **standalone HTML** (`extract.py`) half of the no-render-0 rule. This fixes the **insightful React** half on the listing/leaderboard surfaces. Together they close issue #29's part-2 rule end-to-end. (commits/lines still have no clean non-PII source, so omission — not a fabricated fallback — remains the correct resolution; see #34.)

## Testing

- New `silent-zero-stats.test.tsx` (`renderToStaticMarkup`) pins **omit-on-zero / render-on-positive** for all three cards — 6 tests.
- Full vitest suite: **721 passed**, 12 skipped.
- `tsc --noEmit` clean; `npm run lint` 0 errors.

> Note: the local Codex pre-commit review hung on the known env flake (exit 137 / SIGKILL); proceeded per the repo handoff's documented guidance since typecheck/tests/lint are all green.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)