### PR TITLE
feat(insights): lead the profile with derived Signature Patterns (B3)

### DIFF
--- a/docs/plans/2026-06-10-001-feat-signature-patterns-plan.md
+++ b/docs/plans/2026-06-10-001-feat-signature-patterns-plan.md
@@ -1,0 +1,68 @@
+# Plan — B3: Auto-emit Signature Patterns (server-side derivation)
+
+- **Date:** 2026-06-10
+- **Status:** Ready to implement
+- **Owner:** Craig
+- **Brainstorm:** `docs/brainstorms/2026-06-04-share-how-you-work-generalization-requirements.md` (B3; D2 page spine)
+- **Mockup:** `docs/mockups/show-how-you-work-profile.html` (Signature patterns section)
+
+## Decision (owner, 2026-06-10)
+
+**Server-side derivation.** A pure TS module derives 3–5 signature patterns from the already-persisted `harnessData` at render time. Chosen over skill-side emit because every input is already in `harnessData`, so this:
+
+- lights up retroactively for **every existing published report** (no re-run/re-publish),
+- makes **zero `harnessData` shape change** (honors the brainstorm's first-slice constraint),
+- stays in **one repo** (insightful), ~one PR, with fast copy iteration.
+
+Trade-off accepted: patterns aren't in the agent/learn-mode payload yet — a deliberate fast-follow (would duplicate derivation into `extract.py` for D1 parity).
+
+## What ships
+
+A new **Signature Patterns** section on the profile Dashboard tab, slotted right after `HeroStats` ("lead with the how", per D2 spine), wired into the existing hide/strip visibility pipeline like `workRhythm`.
+
+## Pattern catalog (data-driven; emit only those that clear threshold; cap 5)
+
+All derived from typed `HarnessData` fields. `autonomy` is the **lead** card (dark, `emphasis: "lead"`); the rest render in a 2-col grid. Order: autonomy → subagents → explore-first → dual-engine → authorship.
+
+| id              | Source fields                                                                              | Threshold (else omit)                                        | Headline                                  | Proof line (▸ … · …)                                                                      |
+| --------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ----------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `autonomy`      | `autonomy.{label,userMessages,assistantMessages,errorRate}`, `permissionModes`             | `autonomy.label` non-empty AND `userMessages>0`              | `autonomy.label` (e.g. "Fire-and-Forget") | `1 : N human:agent turns` · `X sent · Y back` · `Z% bypassPermissions`\* · `E error rate` |
+| `subagents`     | `agentDispatch.{totalAgents,backgroundPct,models,types}`                                   | `agentDispatch != null && totalAgents >= 5`                  | `Orchestrates N sub-agents`               | `N agents` · `B% background` · `sonnet x / opus y`\* · `top type: T (c)`                  |
+| `explore-first` | `workflowData.phaseStats.{exploreBeforeImplPct,testBeforeShipPct,totalSessionsWithPhases}` | `totalSessionsWithPhases >= 5 && exploreBeforeImplPct >= 50` | `Explores before building — X%`           | `exploreBeforeImpl X%` · `testBeforeShip Y%` · `across N sessions`                        |
+| `dual-engine`   | `cliTools.codex`, `gitPatterns.branchPrefixes.codex`                                       | `cliTools.codex > 0` (codex CLI invoked)                     | `Runs Claude + Codex`                     | `codex called N×` · `codex branch prefix M×`\*                                            |
+| `authorship`    | `skillInventory[].{source,name}`                                                           | `>= 2` skills with `source` in {`custom`,`user`}             | `Builds the tools they use`               | `authored: a, b, c …` (cap 6 names)                                                       |
+
+\* bracketed proof chips are conditional — only included when the underlying value is present/non-zero (reuses the no-silent-zero discipline from #29).
+
+Characterization sentences (the one-liner under each headline) are short, fixed-per-pattern templates with the verified numbers interpolated; the explore-first card appends an honest-gap clause when `testBeforeShipPct < 20` (mirrors the mockup's "warts and all" copy). No prose essay (that's Bucket C).
+
+## Files
+
+**New**
+
+- `src/lib/signature-patterns.ts` — `SignaturePattern` type + pure `deriveSignaturePatterns(harnessData: HarnessData | null): SignaturePattern[]`. No JSX, no I/O → trivially unit-testable.
+- `src/components/SignaturePatterns.tsx` — presentational: lead card (dark gradient) for `emphasis: "lead"`, 2-col grid for the rest; each card = headline + "Verified" badge + characterization + mono proof line. Renders `null` when the derived list is empty.
+- `src/lib/__tests__/signature-patterns.test.ts` — per-pattern threshold + proof-text assertions (omit-below-threshold, render-above, chip conditionality).
+- `src/components/__tests__/SignaturePatterns.test.tsx` — `renderToStaticMarkup` smoke: empty → "", populated → headlines/badges present.
+
+**Edit (visibility wiring — mirror `workRhythm` exactly, 3 sites)**
+
+- `src/app/insights/[username]/[slug]/page.tsx` — render `<SignaturePatterns harnessData={claudeHarnessData} />` after `HeroStats`, gated on `!isSectionHidden(hiddenSet, "signaturePatterns")`.
+- `src/app/insights/[username]/[slug]/edit/page.tsx` — add a toggle row keyed `"signaturePatterns"` (next to the `workRhythm` toggle ~L1021).
+- `src/app/upload/page.tsx` — add the upload-time enable/disable toggle keyed `"signaturePatterns"` (next to `workRhythm` ~L2518).
+
+## Invariants honored
+
+- No `harnessData` JSON shape change (derived, not stored) — satisfies the CLAUDE.md `harnessData` invariant trivially.
+- PII: derivation reads only already-scrubbed, already-persisted aggregate fields; emits no new raw strings (skill names in `authorship` are already public in `skillInventory`).
+- Visibility: section is hideable/strippable via the same `hiddenHarnessSections` keying as every other section → authors can suppress it.
+
+## Out of scope (fast-follows)
+
+- Learn-mode/agent-payload parity (emit `signaturePatterns` from `extract.py`) — D1 follow-up.
+- My Stack self-declared block (B6/D3) and per-card editable blurbs (D4).
+- Cross-surface Claude+Codex unification (B5) — `dual-engine` here is single-surface ("uses Codex alongside Claude"), not the merged two-profile contrast.
+
+## Test/verify
+
+`npx vitest run` (new + full suite green), `npx tsc --noEmit`, `npm run lint`, then visual check that the section leads the Dashboard and hides when toggled off. CI (lint/typecheck/test/build) must pass before merge.

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -28,6 +28,8 @@ import HeroStats from "@/components/HeroStats";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import WorkRhythm from "@/components/WorkRhythm";
+import SignaturePatterns from "@/components/SignaturePatterns";
+import { deriveSignaturePatterns } from "@/lib/signature-patterns";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
@@ -986,6 +988,16 @@ export default function EditReportPage() {
               })}
             />
           </HideableCard>
+
+          {deriveSignaturePatterns(harnessData).length > 0 && (
+            <HideableCard
+              title="Signature Patterns"
+              hidden={!!hiddenSections["signaturePatterns"]}
+              onToggle={() => toggleSection("signaturePatterns")}
+            >
+              <SignaturePatterns harnessData={harnessData} />
+            </HideableCard>
+          )}
 
           <HideableCard
             title="Activity Heatmap"

--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -39,6 +39,7 @@ import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import HeroStats from "@/components/HeroStats";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import WorkRhythm from "@/components/WorkRhythm";
+import SignaturePatterns from "@/components/SignaturePatterns";
 import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import { SkillsTeaserCard } from "@/components/SkillsTeaserCard";
@@ -445,6 +446,15 @@ export default function InsightDetailPage() {
                         harnessData: claudeHarnessData,
                       })}
                     />
+                  )}
+
+                  {/* Signature Patterns — lead the Dashboard with 3–5 verified
+                  characterizations of how this person works, derived from the
+                  persisted harnessData (autonomy, sub-agents, explore-first,
+                  Claude+Codex, authorship). Renders nothing when no pattern
+                  clears its evidence threshold. */}
+                  {!isSectionHidden(hiddenSet, "signaturePatterns") && (
+                    <SignaturePatterns harnessData={claudeHarnessData} />
                   )}
 
                   {/* Activity Heatmap — real per-day series when the harness ships

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -55,6 +55,8 @@ import HooksSafetyTable from "@/components/HooksSafetyTable";
 import WorkflowDiagram from "@/components/WorkflowDiagram";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import WorkRhythm from "@/components/WorkRhythm";
+import SignaturePatterns from "@/components/SignaturePatterns";
+import { deriveSignaturePatterns } from "@/lib/signature-patterns";
 import ProjectLinks from "@/components/ProjectLinks";
 import MiniBarChart from "@/components/MiniBarChart";
 import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
@@ -2477,6 +2479,19 @@ export default function UploadPage() {
                   })}
                 />
               </RedactableSection>
+
+              {/* Signature Patterns — verified "how I work" characterizations,
+              derived from the harness data; leads the preview like the live
+              profile. Hidden when no pattern clears its evidence threshold. */}
+              {deriveSignaturePatterns(previewHarnessData).length > 0 && (
+                <RedactableSection
+                  title="Signature Patterns"
+                  enabled={!disabledSections["signaturePatterns"]}
+                  onToggle={() => toggleSection("signaturePatterns")}
+                >
+                  <SignaturePatterns harnessData={previewHarnessData} />
+                </RedactableSection>
+              )}
 
               {/* Activity Heatmap */}
               <RedactableSection

--- a/src/components/SignaturePatterns.tsx
+++ b/src/components/SignaturePatterns.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import type { HarnessData } from "@/types/insights";
+import {
+  deriveSignaturePatterns,
+  type SignaturePattern,
+} from "@/lib/signature-patterns";
+
+interface SignaturePatternsProps {
+  harnessData?: HarnessData | null;
+}
+
+function VerifiedBadge({ tone = "light" }: { tone?: "light" | "dark" }) {
+  if (tone === "dark") {
+    return (
+      <span className="shrink-0 rounded-full border border-green-400/30 bg-green-400/15 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-green-300">
+        ✓ Verified
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 rounded-full border border-green-200 bg-green-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-green-700 dark:border-green-800 dark:bg-green-900/30 dark:text-green-400">
+      Verified
+    </span>
+  );
+}
+
+/** The mono "▸ a · b · c" evidence line shared by both card styles. */
+function ProofLine({
+  proof,
+  dark = false,
+}: {
+  proof: string[];
+  dark?: boolean;
+}) {
+  if (proof.length === 0) return null;
+  return (
+    <div
+      className={
+        dark
+          ? "mt-3 flex flex-wrap gap-x-1.5 gap-y-1 border-t border-white/10 pt-3 font-mono text-[11px] leading-relaxed text-slate-400"
+          : "mt-3 rounded-lg bg-slate-50 px-3 py-2 font-mono text-[11px] leading-relaxed text-slate-500 dark:bg-slate-800/60 dark:text-slate-400"
+      }
+    >
+      <span aria-hidden="true">▸</span>{" "}
+      {proof.map((chip, i) => (
+        <span key={i}>
+          {i > 0 && (
+            <span className="text-slate-300 dark:text-slate-600"> · </span>
+          )}
+          {chip}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function LeadCard({ pattern }: { pattern: SignaturePattern }) {
+  return (
+    <div className="rounded-xl bg-gradient-to-br from-slate-800 to-slate-900 p-6 text-white">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-2xl font-extrabold">{pattern.headline}</div>
+        <VerifiedBadge tone="dark" />
+      </div>
+      <div className="mt-1 text-sm text-slate-300">
+        {pattern.characterization}
+      </div>
+      <ProofLine proof={pattern.proof} dark />
+    </div>
+  );
+}
+
+function GridCard({ pattern }: { pattern: SignaturePattern }) {
+  return (
+    <div className="relative overflow-hidden rounded-xl border border-slate-200 bg-white p-5 dark:border-slate-700 dark:bg-slate-900/50">
+      <div className="absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-blue-500 to-violet-500" />
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-bold text-slate-900 dark:text-slate-100">
+          {pattern.headline}
+        </h3>
+        <VerifiedBadge />
+      </div>
+      <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
+        {pattern.characterization}
+      </p>
+      <ProofLine proof={pattern.proof} />
+    </div>
+  );
+}
+
+/**
+ * "Signature patterns" — leads the Dashboard with 3–5 verified characterizations
+ * of how this person works (autonomy, sub-agent orchestration, explore-first
+ * discipline, Claude+Codex, skill authorship), each derived from real harness
+ * data (see src/lib/signature-patterns.ts). Renders nothing when no pattern
+ * clears its evidence threshold, so older/sparse reports are unaffected.
+ */
+export default function SignaturePatterns({
+  harnessData,
+}: SignaturePatternsProps) {
+  const patterns = deriveSignaturePatterns(harnessData);
+  if (patterns.length === 0) return null;
+
+  const lead = patterns.find((p) => p.emphasis === "lead");
+  const rest = patterns.filter((p) => p.emphasis !== "lead");
+
+  return (
+    <section className="mb-6 space-y-4">
+      <div className="flex items-baseline gap-3 border-b border-slate-200 pb-2 dark:border-slate-700">
+        <h2 className="text-xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
+          Signature patterns
+        </h2>
+        <span className="font-mono text-xs text-slate-400">
+          how they work · drawn from real data
+        </span>
+      </div>
+
+      {lead && <LeadCard pattern={lead} />}
+
+      {rest.length > 0 && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {rest.map((p) => (
+            <GridCard key={p.id} pattern={p} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/__tests__/SignaturePatterns.test.tsx
+++ b/src/components/__tests__/SignaturePatterns.test.tsx
@@ -1,0 +1,102 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import SignaturePatterns from "@/components/SignaturePatterns";
+import type { HarnessData } from "@/types/insights";
+
+function makeHarnessData(overrides: Partial<HarnessData> = {}): HarnessData {
+  return {
+    stats: {
+      totalTokens: 0,
+      durationHours: 0,
+      avgSessionMinutes: 0,
+      skillsUsedCount: 0,
+      hooksCount: 0,
+      prCount: 0,
+    },
+    autonomy: {
+      label: "",
+      description: "",
+      userMessages: 0,
+      assistantMessages: 0,
+      turnCount: 0,
+      errorRate: "",
+    },
+    featurePills: [],
+    toolUsage: {},
+    skillInventory: [],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      readPct: 0,
+      editPct: 0,
+      writePct: 0,
+      grepCount: 0,
+      globCount: 0,
+      style: "",
+    },
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 0,
+      commitCount: 0,
+      linesAdded: "0",
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "",
+    skillVersion: null,
+    ...overrides,
+  };
+}
+
+describe("SignaturePatterns", () => {
+  it("renders nothing when no pattern qualifies", () => {
+    expect(
+      renderToStaticMarkup(
+        <SignaturePatterns harnessData={makeHarnessData()} />,
+      ),
+    ).toBe("");
+    expect(renderToStaticMarkup(<SignaturePatterns harnessData={null} />)).toBe(
+      "",
+    );
+  });
+
+  it("renders the section header, lead card, and grid cards when patterns exist", () => {
+    const html = renderToStaticMarkup(
+      <SignaturePatterns
+        harnessData={makeHarnessData({
+          autonomy: {
+            label: "Fire-and-Forget",
+            description: "",
+            userMessages: 2038,
+            assistantMessages: 26832,
+            turnCount: 0,
+            errorRate: "3.4%",
+          },
+          permissionModes: { bypassPermissions: 99, default: 1 },
+          agentDispatch: {
+            totalAgents: 304,
+            types: { "general-purpose": 216 },
+            models: { "claude-sonnet-4-5": 69, "claude-opus-4-6": 18 },
+            backgroundPct: 45,
+            customAgents: [],
+          },
+        })}
+      />,
+    );
+    expect(html).toContain("Signature patterns");
+    expect(html).toContain("Fire-and-Forget"); // lead card headline
+    expect(html).toContain("Orchestrates 304 sub-agents"); // grid card
+    expect(html).toContain("Verified");
+    expect(html).toContain("304 agents"); // proof line rendered
+  });
+});

--- a/src/lib/__tests__/harness-section-visibility.test.ts
+++ b/src/lib/__tests__/harness-section-visibility.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { stripHiddenHarnessData } from "../harness-section-visibility";
+import {
+  stripHiddenHarnessData,
+  getHiddenKeypaths,
+  HIDEABLE_HARNESS_SECTION_KEYS,
+} from "../harness-section-visibility";
 import type { HarnessData } from "@/types/insights";
 
 function buildFullHarnessData(): HarnessData {
@@ -158,5 +162,34 @@ describe("stripHiddenHarnessData", () => {
     expect(result.cliTools).toEqual({ gh: 1 });
     expect(result.gitPatterns.prCount).toBe(1);
     expect(result.gitPatterns.branchPrefixes).toEqual({ feat: 1 });
+  });
+});
+
+describe("signaturePatterns visibility", () => {
+  // Regression: the upload/edit toggle keys "signaturePatterns", but only keys
+  // in HIDEABLE_HARNESS_SECTION_KEYS are persisted to hiddenHarnessSections.
+  // Without the allowlist entry the hide is silently dropped on publish/save
+  // and the section reappears on the public page.
+  it("is in the hideable allowlist so the hide persists", () => {
+    expect(HIDEABLE_HARNESS_SECTION_KEYS).toContain("signaturePatterns");
+  });
+
+  it("getHiddenKeypaths keeps a hidden signaturePatterns key", () => {
+    expect(getHiddenKeypaths({ signaturePatterns: true })).toContain(
+      "signaturePatterns",
+    );
+    expect(getHiddenKeypaths({ signaturePatterns: false })).not.toContain(
+      "signaturePatterns",
+    );
+  });
+
+  it("is derived, so stripping leaves the underlying HarnessData untouched", () => {
+    // The patterns are computed at render time, not stored, so hiding the
+    // section must not be in STRIPPABLE — the payload is unchanged.
+    const full = buildFullHarnessData();
+    const result = stripHiddenHarnessData(full, ["signaturePatterns"]);
+    expect(result.autonomy).toEqual(full.autonomy);
+    expect(result.agentDispatch).toEqual(full.agentDispatch);
+    expect(result.cliTools).toEqual(full.cliTools);
   });
 });

--- a/src/lib/__tests__/signature-patterns.test.ts
+++ b/src/lib/__tests__/signature-patterns.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveSignaturePatterns } from "@/lib/signature-patterns";
+import type { HarnessData } from "@/types/insights";
+
+// Minimal complete HarnessData; override only the fields a given pattern reads.
+function makeHarnessData(overrides: Partial<HarnessData> = {}): HarnessData {
+  return {
+    stats: {
+      totalTokens: 0,
+      durationHours: 0,
+      avgSessionMinutes: 0,
+      skillsUsedCount: 0,
+      hooksCount: 0,
+      prCount: 0,
+    },
+    autonomy: {
+      label: "",
+      description: "",
+      userMessages: 0,
+      assistantMessages: 0,
+      turnCount: 0,
+      errorRate: "",
+    },
+    featurePills: [],
+    toolUsage: {},
+    skillInventory: [],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      readPct: 0,
+      editPct: 0,
+      writePct: 0,
+      grepCount: 0,
+      globCount: 0,
+      style: "",
+    },
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 0,
+      commitCount: 0,
+      linesAdded: "0",
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "",
+    skillVersion: null,
+    ...overrides,
+  };
+}
+
+function byId(h: HarnessData) {
+  return Object.fromEntries(deriveSignaturePatterns(h).map((p) => [p.id, p]));
+}
+
+describe("deriveSignaturePatterns — empty / guards", () => {
+  it("returns [] for null/undefined", () => {
+    expect(deriveSignaturePatterns(null)).toEqual([]);
+    expect(deriveSignaturePatterns(undefined)).toEqual([]);
+  });
+
+  it("returns [] when nothing clears threshold", () => {
+    expect(deriveSignaturePatterns(makeHarnessData())).toEqual([]);
+  });
+});
+
+describe("autonomy (lead)", () => {
+  const h = makeHarnessData({
+    autonomy: {
+      label: "Fire-and-Forget",
+      description: "1 human turn per 13 Claude turns",
+      userMessages: 2038,
+      assistantMessages: 26832,
+      turnCount: 0,
+      errorRate: "3.4%",
+    },
+    permissionModes: { bypassPermissions: 99, default: 1 },
+  });
+
+  it("is the lead card with headline = autonomy.label", () => {
+    const p = byId(h).autonomy;
+    expect(p).toBeTruthy();
+    expect(p.emphasis).toBe("lead");
+    expect(p.headline).toBe("Fire-and-Forget");
+  });
+
+  it("builds the verified proof chips", () => {
+    const p = byId(h).autonomy;
+    expect(p.proof).toContain("1 : 13 human:agent turns");
+    expect(p.proof).toContain("2,038 sent · 26,832 back");
+    expect(p.proof).toContain("99% bypassPermissions");
+    expect(p.proof).toContain("3.4% error rate");
+  });
+
+  it("omits the error-rate chip when it is 0%", () => {
+    const p = byId(
+      makeHarnessData({
+        autonomy: { ...h.autonomy, errorRate: "0%" },
+        permissionModes: h.permissionModes,
+      }),
+    ).autonomy;
+    expect(p.proof.some((c) => c.includes("error rate"))).toBe(false);
+  });
+
+  it("is omitted without a label or without human turns", () => {
+    expect(
+      byId(makeHarnessData({ autonomy: { ...h.autonomy, label: "" } }))
+        .autonomy,
+    ).toBeUndefined();
+    expect(
+      byId(makeHarnessData({ autonomy: { ...h.autonomy, userMessages: 0 } }))
+        .autonomy,
+    ).toBeUndefined();
+  });
+});
+
+describe("subagents", () => {
+  it("requires >= 5 agents", () => {
+    const few = makeHarnessData({
+      agentDispatch: {
+        totalAgents: 4,
+        types: {},
+        models: {},
+        backgroundPct: 0,
+        customAgents: [],
+      },
+    });
+    expect(byId(few).subagents).toBeUndefined();
+  });
+
+  it("headlines the count and tiers models when there are 2+ families", () => {
+    const h = makeHarnessData({
+      agentDispatch: {
+        totalAgents: 304,
+        types: { "general-purpose": 216, Explore: 88 },
+        models: { "claude-sonnet-4-5": 69, "claude-opus-4-6": 18 },
+        backgroundPct: 45,
+        customAgents: [],
+      },
+    });
+    const p = byId(h).subagents;
+    expect(p.headline).toBe("Orchestrates 304 sub-agents");
+    expect(p.characterization).toContain("model-tiered");
+    expect(p.proof).toContain("304 agents");
+    expect(p.proof).toContain("45% background");
+    expect(p.proof).toContain("sonnet 69 / opus 18");
+    expect(p.proof).toContain("top type: general-purpose (216)");
+  });
+
+  it("drops the tier chip (and 'model-tiered') with a single model family", () => {
+    const h = makeHarnessData({
+      agentDispatch: {
+        totalAgents: 12,
+        types: {},
+        models: { "claude-opus-4-6": 12 },
+        backgroundPct: 0,
+        customAgents: [],
+      },
+    });
+    const p = byId(h).subagents;
+    expect(p.characterization).not.toContain("model-tiered");
+    expect(p.proof.some((c) => c.includes("/"))).toBe(false);
+  });
+});
+
+describe("explore-first", () => {
+  const strong = {
+    exploreBeforeImplPct: 74,
+    testBeforeShipPct: 3,
+    totalSessionsWithPhases: 106,
+  };
+
+  it("headlines the explore pct and flags the honest test gap", () => {
+    const p = byId(
+      makeHarnessData({
+        workflowData: {
+          skillInvocations: {},
+          agentDispatches: {},
+          workflowPatterns: [],
+          phaseTransitions: {},
+          phaseDistribution: {},
+          phaseStats: strong,
+        },
+      }),
+    )["explore-first"];
+    expect(p.headline).toBe("Explores before building — 74%");
+    expect(p.characterization).toContain("honest gap");
+    expect(p.proof).toContain("exploreBeforeImpl 74%");
+    expect(p.proof).toContain("testBeforeShip 3%");
+  });
+
+  it("is omitted below 50% explore or under 5 phased sessions", () => {
+    const low = makeHarnessData({
+      workflowData: {
+        skillInvocations: {},
+        agentDispatches: {},
+        workflowPatterns: [],
+        phaseTransitions: {},
+        phaseDistribution: {},
+        phaseStats: { ...strong, exploreBeforeImplPct: 40 },
+      },
+    });
+    expect(byId(low)["explore-first"]).toBeUndefined();
+    const fewSessions = makeHarnessData({
+      workflowData: {
+        skillInvocations: {},
+        agentDispatches: {},
+        workflowPatterns: [],
+        phaseTransitions: {},
+        phaseDistribution: {},
+        phaseStats: { ...strong, totalSessionsWithPhases: 3 },
+      },
+    });
+    expect(byId(fewSessions)["explore-first"]).toBeUndefined();
+  });
+});
+
+describe("dual-engine", () => {
+  it("appears when codex CLI was invoked", () => {
+    const p = byId(
+      makeHarnessData({
+        cliTools: { git: 500, codex: 71 },
+        gitPatterns: {
+          prCount: 0,
+          commitCount: 0,
+          linesAdded: "0",
+          branchPrefixes: { codex: 27, fix: 10 },
+        },
+      }),
+    )["dual-engine"];
+    expect(p.headline).toBe("Runs Claude + Codex");
+    expect(p.proof).toContain("codex called 71×");
+    expect(p.proof).toContain("codex branch prefix 27×");
+  });
+
+  it("is omitted without a codex signal", () => {
+    expect(
+      byId(makeHarnessData({ cliTools: { git: 500 } }))["dual-engine"],
+    ).toBeUndefined();
+  });
+});
+
+describe("authorship", () => {
+  const mk = (sources: string[]) =>
+    makeHarnessData({
+      skillInventory: sources.map((source, i) => ({
+        name: `skill-${i}`,
+        calls: 1,
+        source,
+        description: "",
+      })),
+    });
+
+  it("requires >= 2 authored (custom/user) skills", () => {
+    expect(byId(mk(["custom"])).authorship).toBeUndefined();
+    expect(
+      byId(mk(["plugin:foo/bar", "plugin:baz"])).authorship,
+    ).toBeUndefined();
+  });
+
+  it("headlines 'Builds the tools they use' at 3+, 'Author of N' at 2", () => {
+    expect(byId(mk(["custom", "user", "custom"])).authorship.headline).toBe(
+      "Builds the tools they use",
+    );
+    expect(byId(mk(["custom", "user"])).authorship.headline).toBe(
+      "Author of 2 skills",
+    );
+  });
+
+  it("lists authored names (capped) and excludes installed plugins", () => {
+    const p = byId(mk(["custom", "user", "plugin:x"])).authorship;
+    expect(p.proof[0]).toContain("skill-0");
+    expect(p.proof[0]).toContain("skill-1");
+    expect(p.proof[0]).not.toContain("skill-2"); // the plugin
+  });
+});
+
+describe("ordering & cap", () => {
+  it("puts autonomy first and caps at 5", () => {
+    const h = makeHarnessData({
+      autonomy: {
+        label: "Fire-and-Forget",
+        description: "",
+        userMessages: 100,
+        assistantMessages: 1300,
+        turnCount: 0,
+        errorRate: "2%",
+      },
+      agentDispatch: {
+        totalAgents: 50,
+        types: { "general-purpose": 50 },
+        models: { "claude-sonnet-4-5": 30, "claude-opus-4-6": 20 },
+        backgroundPct: 40,
+        customAgents: [],
+      },
+      workflowData: {
+        skillInvocations: {},
+        agentDispatches: {},
+        workflowPatterns: [],
+        phaseTransitions: {},
+        phaseDistribution: {},
+        phaseStats: {
+          exploreBeforeImplPct: 80,
+          testBeforeShipPct: 60,
+          totalSessionsWithPhases: 40,
+        },
+      },
+      cliTools: { codex: 5 },
+      skillInventory: [
+        { name: "a", calls: 1, source: "custom", description: "" },
+        { name: "b", calls: 1, source: "user", description: "" },
+      ],
+    });
+    const patterns = deriveSignaturePatterns(h);
+    expect(patterns).toHaveLength(5);
+    expect(patterns[0].id).toBe("autonomy");
+  });
+});

--- a/src/lib/harness-section-visibility.ts
+++ b/src/lib/harness-section-visibility.ts
@@ -16,6 +16,7 @@ import {
 export const HIDEABLE_HARNESS_SECTION_KEYS = [
   "heroStats",
   "activityHeatmap",
+  "signaturePatterns",
   "howIWork",
   "workRhythm",
   "toolUsage",

--- a/src/lib/signature-patterns.ts
+++ b/src/lib/signature-patterns.ts
@@ -1,0 +1,198 @@
+import type { HarnessData } from "@/types/insights";
+
+/**
+ * A "signature pattern" — one verified characterization of how someone works,
+ * derived from the already-persisted, already-scrubbed `harnessData`. Each is a
+ * headline ("Orchestrates 304 sub-agents") + a one-line characterization + a
+ * proof line of the verified numbers behind it. See B3 in
+ * docs/brainstorms/2026-06-04-share-how-you-work-generalization-requirements.md
+ * and docs/plans/2026-06-10-001-feat-signature-patterns-plan.md.
+ *
+ * Derived server-side at render time (not stored), so it lights up for every
+ * existing report without a re-run and makes zero `harnessData` shape change.
+ */
+export interface SignaturePattern {
+  id: "autonomy" | "subagents" | "explore-first" | "dual-engine" | "authorship";
+  headline: string;
+  characterization: string;
+  /** Verified proof chips, rendered as "▸ a · b · c". Each chip is only present
+   *  when its underlying value is real (no silent zeros — see issue #29). */
+  proof: string[];
+  /** "lead" → the prominent dark card; undefined → the standard grid card. */
+  emphasis?: "lead";
+}
+
+function nf(n: number): string {
+  return n.toLocaleString();
+}
+
+/** Collapse a model id ("claude-opus-4-6", "gpt-5.5") to its family. */
+function modelFamily(id: string): string | null {
+  const s = id.toLowerCase();
+  if (s.includes("opus")) return "opus";
+  if (s.includes("sonnet")) return "sonnet";
+  if (s.includes("haiku")) return "haiku";
+  if (s.includes("gpt") || s.includes("codex") || s.includes("o3"))
+    return "gpt";
+  return null;
+}
+
+/** "sonnet 69 / opus 18" from a model→count map, families ordered by count. */
+function modelTierChip(models: Record<string, number>): string | null {
+  const byFamily: Record<string, number> = {};
+  for (const [id, count] of Object.entries(models)) {
+    const fam = modelFamily(id);
+    if (fam) byFamily[fam] = (byFamily[fam] ?? 0) + count;
+  }
+  const entries = Object.entries(byFamily).sort((a, b) => b[1] - a[1]);
+  if (entries.length < 2) return null; // a single family isn't "tiering"
+  return entries.map(([fam, c]) => `${fam} ${c}`).join(" / ");
+}
+
+function topEntry(
+  rec: Record<string, number>,
+): { name: string; count: number } | null {
+  let best: { name: string; count: number } | null = null;
+  for (const [name, count] of Object.entries(rec)) {
+    if (!best || count > best.count) best = { name, count };
+  }
+  return best;
+}
+
+function autonomyPattern(h: HarnessData): SignaturePattern | null {
+  const a = h.autonomy;
+  if (!a || !a.label || a.userMessages <= 0) return null;
+
+  const ratio = Math.round(a.assistantMessages / a.userMessages);
+  const bypass = h.permissionModes?.bypassPermissions ?? 0;
+  const permTotal = Object.values(h.permissionModes ?? {}).reduce(
+    (s, n) => s + n,
+    0,
+  );
+  const bypassPct =
+    bypass > 0 && permTotal > 0 ? Math.round((bypass / permTotal) * 100) : 0;
+  const errorRate = a.errorRate && a.errorRate !== "0%" ? a.errorRate : "";
+
+  const proof: string[] = [];
+  if (ratio > 0) proof.push(`1 : ${ratio} human:agent turns`);
+  proof.push(`${nf(a.userMessages)} sent · ${nf(a.assistantMessages)} back`);
+  if (bypassPct > 0) proof.push(`${bypassPct}% bypassPermissions`);
+  if (errorRate) proof.push(`${errorRate} error rate`);
+
+  const ratioClause =
+    ratio > 0
+      ? ` For every message sent, the agent sends about ${ratio} back`
+      : "";
+  const hookClause = bypassPct >= 50 ? ", auto-approving along the way." : ".";
+
+  return {
+    id: "autonomy",
+    headline: a.label,
+    characterization: `Sets work in motion, then steps away.${ratioClause}${ratioClause ? hookClause : ""}`,
+    proof,
+    emphasis: "lead",
+  };
+}
+
+function subagentsPattern(h: HarnessData): SignaturePattern | null {
+  const d = h.agentDispatch;
+  if (!d || d.totalAgents < 5) return null;
+
+  const proof: string[] = [`${nf(d.totalAgents)} agents`];
+  if (d.backgroundPct > 0) proof.push(`${d.backgroundPct}% background`);
+  const tier = modelTierChip(d.models ?? {});
+  if (tier) proof.push(tier);
+  const top = topEntry(d.types ?? {});
+  if (top) proof.push(`top type: ${top.name} (${nf(top.count)})`);
+
+  return {
+    id: "subagents",
+    headline: `Orchestrates ${nf(d.totalAgents)} sub-agents`,
+    characterization: `Fans out work to subagents and synthesizes in the foreground${
+      tier ? ", model-tiered to cut cost" : ""
+    }.`,
+    proof,
+  };
+}
+
+function exploreFirstPattern(h: HarnessData): SignaturePattern | null {
+  const ps = h.workflowData?.phaseStats;
+  if (!ps || ps.totalSessionsWithPhases < 5 || ps.exploreBeforeImplPct < 50)
+    return null;
+
+  const lowTest = ps.testBeforeShipPct < 20;
+  return {
+    id: "explore-first",
+    headline: `Explores before building — ${ps.exploreBeforeImplPct}%`,
+    characterization: lowTest
+      ? "Strong explore-first discipline — and an honest gap: testing before shipping is rarer. The data shows the real shape, warts and all."
+      : "Strong explore-first discipline, with testing wired into the loop before shipping.",
+    proof: [
+      `exploreBeforeImpl ${ps.exploreBeforeImplPct}%`,
+      `testBeforeShip ${ps.testBeforeShipPct}%`,
+      `across ${nf(ps.totalSessionsWithPhases)} sessions`,
+    ],
+  };
+}
+
+function dualEnginePattern(h: HarnessData): SignaturePattern | null {
+  const codexCalls = h.cliTools?.codex ?? 0;
+  if (codexCalls <= 0) return null;
+
+  const branchCodex = h.gitPatterns?.branchPrefixes?.codex ?? 0;
+  const proof: string[] = [`codex called ${nf(codexCalls)}×`];
+  if (branchCodex > 0) proof.push(`codex branch prefix ${nf(branchCodex)}×`);
+
+  return {
+    id: "dual-engine",
+    headline: "Runs Claude + Codex",
+    characterization:
+      "Claude is the coding harness; Codex runs alongside — even called from inside Claude.",
+    proof,
+  };
+}
+
+function authorshipPattern(h: HarnessData): SignaturePattern | null {
+  const authored = (h.skillInventory ?? [])
+    .filter((s) => s.source === "custom" || s.source === "user")
+    .map((s) => s.name);
+  if (authored.length < 2) return null;
+
+  const shown = authored.slice(0, 6);
+  const more = authored.length - shown.length;
+  const list =
+    more > 0 ? `${shown.join(", ")} +${more} more` : shown.join(", ");
+
+  return {
+    id: "authorship",
+    headline:
+      authored.length >= 3
+        ? "Builds the tools they use"
+        : `Author of ${authored.length} skills`,
+    characterization:
+      "Several of the skills in this profile are self-authored, not just installed.",
+    proof: [`authored: ${list}`],
+  };
+}
+
+/**
+ * Derive the ordered list of signature patterns for a report. Returns only the
+ * patterns that clear their evidence threshold (data-driven per user), with the
+ * autonomy pattern first as the lead card. Empty array when nothing qualifies —
+ * callers should render no section in that case.
+ */
+export function deriveSignaturePatterns(
+  harnessData: HarnessData | null | undefined,
+): SignaturePattern[] {
+  if (!harnessData) return [];
+  const candidates = [
+    autonomyPattern(harnessData),
+    subagentsPattern(harnessData),
+    exploreFirstPattern(harnessData),
+    dualEnginePattern(harnessData),
+    authorshipPattern(harnessData),
+  ];
+  return candidates
+    .filter((p): p is SignaturePattern => p !== null)
+    .slice(0, 5);
+}


### PR DESCRIPTION
## What

Implements **B3 — the "show how you work" marquee**: a **Signature Patterns** section that leads the Dashboard with 3–5 *verified* characterizations of how someone works, each with a proof line behind it. This is the D2 page spine — **vanity stats → signature patterns → copyable evidence** — landing the brainstorm's "lead with the _how_, not raw bars" goal.

Mockup it realizes: `docs/mockups/show-how-you-work-profile.html` (Signature patterns section).

## How — server-side derivation (owner decision)

A pure `deriveSignaturePatterns(harnessData)` reads only **already-persisted, already-scrubbed** fields, so the section:
- lights up **retroactively for every existing report** (no re-run/re-publish),
- makes **zero `harnessData` schema change**,
- is **one repo, one PR**.

### Patterns (emitted only when they clear an evidence threshold — data-driven per user)

| id | Source | Threshold | Headline |
|----|--------|-----------|----------|
| `autonomy` (lead) | `autonomy.*`, `permissionModes` | label + `userMessages>0` | the autonomy label (e.g. "Fire-and-Forget") |
| `subagents` | `agentDispatch.*` | `totalAgents ≥ 5` | "Orchestrates N sub-agents" |
| `explore-first` | `workflowData.phaseStats` | `≥5` phased sessions & `explore ≥ 50%` | "Explores before building — X%" |
| `dual-engine` | `cliTools.codex`, `gitPatterns.branchPrefixes` | `cliTools.codex > 0` | "Runs Claude + Codex" |
| `authorship` | `skillInventory[].source` | `≥2` custom/user skills | "Builds the tools they use" |

Each proof chip is conditional (no silent zeros, per #29). The lead card is the dark autonomy box; the rest render in a 2-col grid. Renders nothing when no pattern qualifies, so sparse/older reports are unaffected.

## Visibility

Wired into the **profile** (after HeroStats), **edit**, and **upload preview** with the same `"signaturePatterns"` key as every other section — **including the `HIDEABLE_HARNESS_SECTION_KEYS` allowlist** so the author's hide actually persists on publish/save. (A Codex review caught that without the allowlist entry the toggle silently no-ops and the section reappears publicly.) The section is **hideable but not strippable** — it's derived at render time, not stored.

## Testing

- `deriveSignaturePatterns` — thresholds, proof math, ordering/cap (17 tests)
- `SignaturePatterns` — `renderToStaticMarkup` smoke (2)
- visibility — persistence + derived-not-stripped (3)
- Full suite **743 passed**; `tsc --noEmit`, `npm run lint`, `npm run build` all clean.

> Visual check: the styled cards are best verified on the **Vercel preview** against a real report (higher fidelity than a standalone render); the design mirrors the already-approved mockup adapted to the site's dark-mode tokens.

## Out of scope (fast-follows)
- Learn-mode/agent-payload parity (emit `signaturePatterns` from `extract.py`).
- My Stack self-declared block (B6) + per-card editable blurbs (D4).
- Cross-surface Claude+Codex unification (B5) — `dual-engine` here is single-surface.

Plan: `docs/plans/2026-06-10-001-feat-signature-patterns-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)