### PR TITLE
fix(install): point homepage + upload curl snippets at kabirdos/insight-harness

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1934,7 +1934,7 @@ export default function UploadPage() {
                 {showCurlFallback && (
                   <div className="mt-2">
                     <CommandBlock
-                      command="curl -sL https://github.com/craigdossantos/claude-toolkit/archive/main.tar.gz | tar xz -C /tmp && cp -r /tmp/claude-toolkit-main/skills/insight-harness ~/.claude/skills/ && rm -rf /tmp/claude-toolkit-main"
+                      command="curl -sL https://github.com/kabirdos/insight-harness/archive/main.tar.gz | tar xz -C /tmp && cp -r /tmp/insight-harness-main/skills/insight-harness ~/.claude/skills/ && rm -rf /tmp/insight-harness-main"
                       small
                     />
                   </div>

--- a/src/content/homepage.ts
+++ b/src/content/homepage.ts
@@ -66,7 +66,7 @@ export const homepage = {
     // Option 2: Enhanced /insight-harness (requires install)
     option2Title: "Option 2: Run /insight-harness",
     option2InstallCommand:
-      "mkdir -p ~/.claude/skills/insight-harness/scripts && curl -sL https://raw.githubusercontent.com/craigdossantos/claude-toolkit/main/skills/insight-harness/SKILL.md -o ~/.claude/skills/insight-harness/SKILL.md && curl -sL https://raw.githubusercontent.com/craigdossantos/claude-toolkit/main/skills/insight-harness/scripts/extract.py -o ~/.claude/skills/insight-harness/scripts/extract.py",
+      "curl -sL https://github.com/kabirdos/insight-harness/archive/main.tar.gz | tar xz -C /tmp && cp -r /tmp/insight-harness-main/skills/insight-harness ~/.claude/skills/ && rm -rf /tmp/insight-harness-main",
     option2InstallHint: "Install the skill first — paste in your terminal:",
     option2RunCommand: "/insight-harness",
     option2RunHint: "Then run this in Claude Code:",


### PR DESCRIPTION
## Why
The homepage install command (`src/content/homepage.ts`) and the upload page curl fallback still pulled from `craigdossantos/claude-toolkit`:
- That mirror is stale and incomplete — `scripts/pii_scrub.py` 404s, so the installed `extract.py` crashes on import.
- The homepage snippet also only fetched 2 of the skill's files (no `learn.py`, `codex_extract.py`, `pii_scrub.py`).
- `/install` already documents the canonical `kabirdos/insight-harness` source, so users got different installs depending on entry point.

## What
Both snippets now install the complete skill from the `kabirdos/insight-harness` tarball (verified: archive resolves and contains all 26 script files).

Surfaced by the 2026-06-10 UX streamlining audit (blocker-class finding on the core share path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)