### PR TITLE
feat(insights): add "Learn from this" CTA to harness profiles

### DIFF
--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -18,6 +18,7 @@ import { useSession } from "next-auth/react";
 import { Calendar, Pencil, Sparkles } from "lucide-react";
 import SectionRenderer from "@/components/SectionRenderer";
 import ShareButton from "@/components/ShareButton";
+import LearnFromThis from "@/components/LearnFromThis";
 import CommentSection from "@/components/CommentSection";
 import ProjectLinks from "@/components/ProjectLinks";
 import SnapshotCard from "@/components/SnapshotCard";
@@ -396,6 +397,13 @@ export default function InsightDetailPage() {
       {/* ── Harness Report Layout ── */}
       {isHarness && harnessEnvelope ? (
         <>
+          {/* Learn-from-this CTA — the product thesis made visible: a human or
+          their agent can consume this profile's machine-readable payload (the
+          insight-harness skill's learn mode) and copy what's useful. Placed
+          above the tool selector so it's tool-agnostic (learn fetches the whole
+          envelope). */}
+          <LearnFromThis url={buildReportUrl(username, slug)} />
+
           <ToolSelector
             tools={availableTools}
             active={selectedTool}

--- a/src/components/LearnFromThis.tsx
+++ b/src/components/LearnFromThis.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useCallback, type MouseEvent } from "react";
+import Link from "next/link";
+import { Bot, Check, Copy } from "lucide-react";
+import clsx from "clsx";
+
+export interface LearnFromThisProps {
+  /** Absolute, canonical public URL of the profile or group to learn from. */
+  url: string;
+  /**
+   * Tunes the copy for what's being learned from. "profile" (default) is a
+   * single person's harness; "group" is a collection at `/g/<slug>`.
+   */
+  variant?: "profile" | "group";
+  /** Extra classes appended to the outer callout. */
+  className?: string;
+}
+
+/**
+ * Builds the ready-to-paste agent prompt. The leading phrase matches the
+ * insight-harness skill's documented learn-mode triggers ("learn from this
+ * harness"), and the trailing URL is what `learn.py` resolves — so pasting
+ * this into Claude Code or Codex reliably switches the skill into learn mode.
+ */
+export function buildLearnPrompt(url: string, variant: "profile" | "group") {
+  const noun =
+    variant === "group" ? "group of harnesses" : "Claude Code / Codex harness";
+  return `Learn from this ${noun} and tell me what to copy into mine: ${url}`;
+}
+
+/**
+ * Resolves a (possibly relative) report/group path to an absolute URL.
+ * Callers pass the relative path from `buildReportUrl`, but `learn.py` needs a
+ * fetchable absolute URL. Already-absolute inputs pass through; without an
+ * origin (SSR) the input is returned unchanged.
+ */
+export function toAbsoluteUrl(url: string, origin?: string): string {
+  if (/^https?:\/\//.test(url)) return url;
+  return origin ? origin + url : url;
+}
+
+export default function LearnFromThis({
+  url,
+  variant = "profile",
+  className,
+}: LearnFromThisProps) {
+  const [copied, setCopied] = useState(false);
+  const subject = variant === "group" ? "this group" : "this setup";
+
+  const onCopy = useCallback(
+    async (e: MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      // Resolve to an absolute URL at click time, not during render — doing it
+      // here (vs. reading window during render) avoids an SSR/hydration
+      // mismatch.
+      const origin =
+        typeof window !== "undefined" ? window.location.origin : undefined;
+      await navigator.clipboard.writeText(
+        buildLearnPrompt(toAbsoluteUrl(url, origin), variant),
+      );
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    },
+    [url, variant],
+  );
+
+  return (
+    <div
+      className={clsx(
+        "mb-6 flex flex-col gap-3 rounded-xl border border-violet-200 bg-gradient-to-r from-violet-50 to-blue-50 p-4 sm:flex-row sm:items-center sm:gap-4 dark:border-violet-800/60 dark:from-violet-950/30 dark:to-blue-950/30",
+        className,
+      )}
+    >
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-100 text-violet-600 dark:bg-violet-900/40 dark:text-violet-300">
+        <Bot className="h-5 w-5" />
+      </div>
+      <div className="flex-1">
+        <p className="text-sm font-semibold text-slate-900 dark:text-white">
+          Learn from {subject}
+        </p>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Point your coding agent (Claude Code or Codex) at {subject} and
+          it&apos;ll tell you what to copy into your own harness.{" "}
+          <Link
+            href="/install"
+            className="font-medium text-violet-700 underline-offset-2 hover:underline dark:text-violet-300"
+          >
+            Needs the insight-harness skill
+          </Link>
+          .
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onCopy}
+        aria-label={`Copy the agent prompt to learn from ${subject}`}
+        className="flex shrink-0 items-center justify-center gap-2 rounded-lg bg-violet-600 px-3.5 py-2 text-sm font-medium text-white transition-colors hover:bg-violet-700"
+      >
+        {copied ? (
+          <>
+            <Check className="h-4 w-4" />
+            Copied!
+          </>
+        ) : (
+          <>
+            <Copy className="h-4 w-4" />
+            Copy agent prompt
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/LearnFromThis.test.tsx
+++ b/src/components/__tests__/LearnFromThis.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildLearnPrompt, toAbsoluteUrl } from "@/components/LearnFromThis";
+
+// The component mounts React + clipboard, which this repo can't render in unit
+// tests (no jsdom). The copy that actually matters — the agent prompt — is a
+// pure function, so we assert its contract directly: it must carry the skill's
+// learn-mode trigger phrase and the exact URL so a paste into Claude Code /
+// Codex reliably switches into learn mode.
+
+describe("buildLearnPrompt", () => {
+  const url = "https://insightharness.com/insights/kabirdos/2026-04-15-abc123";
+
+  it("embeds the URL verbatim so learn.py can resolve it", () => {
+    expect(buildLearnPrompt(url, "profile")).toContain(url);
+    expect(buildLearnPrompt(url, "group")).toContain(url);
+  });
+
+  it("leads with the documented learn-mode trigger phrase", () => {
+    // SKILL.md triggers learn mode on "learn from this harness".
+    expect(buildLearnPrompt(url, "profile").toLowerCase()).toContain(
+      "learn from this",
+    );
+    expect(buildLearnPrompt(url, "group").toLowerCase()).toContain(
+      "learn from this",
+    );
+  });
+
+  it("distinguishes a single profile from a group of profiles", () => {
+    expect(buildLearnPrompt(url, "profile")).toContain("harness");
+    expect(buildLearnPrompt(url, "group")).toContain("group of harnesses");
+  });
+
+  it("asks the agent for actionable copy advice", () => {
+    expect(buildLearnPrompt(url, "profile").toLowerCase()).toContain(
+      "what to copy",
+    );
+  });
+});
+
+describe("toAbsoluteUrl", () => {
+  const origin = "https://insightharness.com";
+
+  it("prefixes the origin onto a relative report path", () => {
+    expect(toAbsoluteUrl("/insights/kabirdos/abc123", origin)).toBe(
+      "https://insightharness.com/insights/kabirdos/abc123",
+    );
+  });
+
+  it("leaves an already-absolute URL untouched", () => {
+    const abs = "https://insightharness.com/g/hyperzen";
+    expect(toAbsoluteUrl(abs, origin)).toBe(abs);
+  });
+
+  it("returns the input unchanged when no origin is available (SSR)", () => {
+    expect(toAbsoluteUrl("/insights/kabirdos/abc123", undefined)).toBe(
+      "/insights/kabirdos/abc123",
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds a **"Learn from this" CTA** to every harness profile — the first UI surface for the product's core thesis: *point your agent at a profile and it tells you what to copy into your own harness.*

A violet callout sits just under the author bar (above the tool selector). Its button copies a ready-to-paste prompt:

> `Learn from this Claude Code / Codex harness and tell me what to copy into mine: https://insightharness.com/insights/<user>/<slug>`

Pasted into Claude Code or Codex, this triggers the insight-harness skill's existing **learn mode** (`learn.py` + the content-negotiated agent payload).

## Why

The learn-mode backend has been live since the agent-payload work, but a human viewer had **no way to discover or invoke it** — the single biggest gap called out in the 2026-06-10 UX streamlining audit (rec #1). This is pure surfacing of existing capability: no schema change, no `harnessData` shape change.

## Notes

- Placed above the tool selector so it's **tool-agnostic** (learn fetches the whole Claude+Codex envelope).
- Built **group-ready** via a `variant="group"` prop, so it drops into `/g/<slug>` when the groups branch lands.
- `toAbsoluteUrl` resolves the relative report path to an absolute URL **at click time** (learn.py needs a fetchable URL) — done in the handler, not during render, to avoid an SSR/hydration mismatch. (This was a real bug caught in Codex review — the raw `buildReportUrl` path is relative.)

## Testing

- 7 new unit tests (prompt construction + URL resolution).
- Full suite: 725 passing. Lint, `tsc --noEmit`, and `next build` all green.
- Codex review run; both findings (relative-URL bug, aria-label/variant) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)