### PR TITLE
feat(insights): fold agent-detail into one "Full technical detail" disclosure

### DIFF
--- a/src/app/insights/[username]/[slug]/page.tsx
+++ b/src/app/insights/[username]/[slug]/page.tsx
@@ -39,11 +39,9 @@ import { resolveLinesAdded, resolveLinesRemoved } from "@/lib/lines-of-code";
 import HeroStats from "@/components/HeroStats";
 import HowIWorkCluster from "@/components/HowIWorkCluster";
 import WorkRhythm from "@/components/WorkRhythm";
-import ToolUsageTreemap from "@/components/ToolUsageTreemap";
 import SkillCardGrid from "@/components/SkillCardGrid";
 import { SkillsTeaserCard } from "@/components/SkillsTeaserCard";
 import { SkillsShowcaseSection } from "@/components/SkillsShowcaseSection";
-import CliToolsDonut from "@/components/CliToolsDonut";
 import GitPatternsDisplay from "@/components/GitPatternsDisplay";
 import PermissionModeDisplay from "@/components/PermissionModeDisplay";
 import HooksSafetyTable from "@/components/HooksSafetyTable";
@@ -52,11 +50,11 @@ import WorkflowDiagram from "@/components/WorkflowDiagram";
 import MiniBarChart from "@/components/MiniBarChart";
 import ToolSelector from "@/components/ToolSelector";
 import CodexHarnessDashboard from "@/components/CodexHarnessDashboard";
+import TechnicalDetailSection from "@/components/TechnicalDetailSection";
 import {
   hideSetFromArray,
   isSectionHidden,
   filterList,
-  filterRecord,
 } from "@/lib/item-visibility";
 
 interface ReportData {
@@ -568,20 +566,6 @@ export default function InsightDetailPage() {
                       </CollapsibleSection>
                     )}
 
-                  {/* Tool Usage Treemap */}
-                  {!isSectionHidden(hiddenSet, "toolUsage") &&
-                    Object.keys(claudeHarnessData.toolUsage).length > 0 && (
-                      <ToolUsageTreemap
-                        toolUsage={claudeHarnessData.toolUsage}
-                      />
-                    )}
-
-                  {/* CLI Tools Donut */}
-                  {!isSectionHidden(hiddenSet, "cliTools") &&
-                    Object.keys(claudeHarnessData.cliTools).length > 0 && (
-                      <CliToolsDonut cliTools={claudeHarnessData.cliTools} />
-                    )}
-
                   {/* Git Patterns */}
                   {!isSectionHidden(hiddenSet, "gitPatterns") && (
                     <GitPatternsDisplay
@@ -679,120 +663,16 @@ export default function InsightDetailPage() {
                       </CollapsibleSection>
                     )}
 
-                  {/* Languages */}
-                  {!isSectionHidden(hiddenSet, "languages") &&
-                    Object.keys(claudeHarnessData.languages).length > 0 && (
-                      <CollapsibleSection
-                        icon="💻"
-                        iconBgClass="bg-green-100 dark:bg-green-900/30"
-                        title="Languages"
-                        defaultOpen={false}
-                      >
-                        <MiniBarChart
-                          data={Object.entries(
-                            filterRecord(
-                              claudeHarnessData.languages,
-                              hiddenSet,
-                              "languages",
-                            ),
-                          )
-                            .sort((a, b) => b[1] - a[1])
-                            .slice(0, 12)
-                            .map(([label, value]) => ({ label, value }))}
-                          title=""
-                          color="bg-green-500"
-                        />
-                      </CollapsibleSection>
-                    )}
-
-                  {/* MCP Servers */}
-                  {!isSectionHidden(hiddenSet, "mcpServers") &&
-                    Object.keys(claudeHarnessData.mcpServers).length > 0 && (
-                      <CollapsibleSection
-                        icon="🔗"
-                        iconBgClass="bg-cyan-100 dark:bg-cyan-900/30"
-                        title="MCP Servers"
-                        defaultOpen={false}
-                      >
-                        <div className="space-y-1">
-                          {Object.entries(
-                            filterRecord(
-                              claudeHarnessData.mcpServers,
-                              hiddenSet,
-                              "mcpServers",
-                            ),
-                          )
-                            .sort((a, b) => b[1] - a[1])
-                            .map(([server, calls]) => (
-                              <div
-                                key={server}
-                                className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
-                              >
-                                <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
-                                  {server}
-                                </span>
-                                <span className="text-xs text-slate-400">
-                                  {calls.toLocaleString()} calls
-                                </span>
-                              </div>
-                            ))}
-                        </div>
-                      </CollapsibleSection>
-                    )}
-
-                  {/* Versions */}
-                  {!isSectionHidden(hiddenSet, "versions") &&
-                    claudeHarnessData.versions.length > 0 && (
-                      <CollapsibleSection
-                        icon="📦"
-                        iconBgClass="bg-slate-100 dark:bg-slate-900/30"
-                        title="Claude Code Versions"
-                        defaultOpen={false}
-                      >
-                        <div className="flex flex-wrap gap-1.5">
-                          {filterList(
-                            claudeHarnessData.versions,
-                            hiddenSet,
-                            "versions",
-                            (v) => v,
-                          ).map((v) => (
-                            <span
-                              key={v}
-                              className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
-                            >
-                              {v}
-                            </span>
-                          ))}
-                        </div>
-                      </CollapsibleSection>
-                    )}
-
-                  {/* Harness Files */}
-                  {!isSectionHidden(hiddenSet, "harnessFiles") &&
-                    claudeHarnessData.harnessFiles.length > 0 && (
-                      <CollapsibleSection
-                        icon="📁"
-                        iconBgClass="bg-orange-100 dark:bg-orange-900/30"
-                        title="Harness File Ecosystem"
-                        defaultOpen={false}
-                      >
-                        <div className="space-y-1">
-                          {filterList(
-                            claudeHarnessData.harnessFiles,
-                            hiddenSet,
-                            "harnessFiles",
-                            (f) => f,
-                          ).map((f) => (
-                            <div
-                              key={f}
-                              className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
-                            >
-                              {f}
-                            </div>
-                          ))}
-                        </div>
-                      </CollapsibleSection>
-                    )}
+                  {/* Full technical detail — the six low-signal-for-humans,
+                  high-signal-for-agents sections (tool usage, CLI commands, MCP
+                  servers, languages, versions, harness files) collapsed into one
+                  closed disclosure. The full data still ships to agents via the
+                  profile's JSON payload. Per-section visibility flags and
+                  per-item filters are preserved inside the component. */}
+                  <TechnicalDetailSection
+                    harnessData={claudeHarnessData}
+                    hiddenSet={hiddenSet}
+                  />
                 </>
               )}
 

--- a/src/components/TechnicalDetailSection.tsx
+++ b/src/components/TechnicalDetailSection.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import type { HarnessData } from "@/types/insights";
+import { filterList, filterRecord } from "@/lib/item-visibility";
+import CollapsibleSection from "@/components/CollapsibleSection";
+import ToolUsageTreemap from "@/components/ToolUsageTreemap";
+import CliToolsDonut from "@/components/CliToolsDonut";
+import MiniBarChart from "@/components/MiniBarChart";
+
+interface TechnicalDetailSectionProps {
+  harnessData: HarnessData;
+  hiddenSet: Set<string>;
+}
+
+/**
+ * The six low-signal-for-humans, high-signal-for-agents sections — tool usage,
+ * CLI commands, MCP servers, languages, versions, and harness files — collapsed
+ * into a single closed disclosure at the bottom of the Dashboard.
+ *
+ * The full data still ships to agents via the profile's machine-readable JSON
+ * payload, so nothing is lost by hiding it from the default human scroll. The
+ * per-section visibility flags (hide/strip pipeline) and per-item filters are
+ * preserved exactly — this is a presentational regrouping, not a model change.
+ *
+ * Renders nothing when every inner section is hidden or empty, so an empty
+ * disclosure never appears.
+ */
+export default function TechnicalDetailSection({
+  harnessData,
+  hiddenSet,
+}: TechnicalDetailSectionProps) {
+  // Filter once, then drive both the empty-state guard and rendering off the
+  // filtered results. filterRecord/filterList already return empty when the
+  // whole section is hidden, so this also covers section-level hides. Using
+  // filtered (not raw) lengths means a section whose every item is individually
+  // hidden contributes no empty chrome, and an all-hidden disclosure never
+  // appears at all.
+  const toolUsage = filterRecord(harnessData.toolUsage, hiddenSet, "toolUsage");
+  const cliTools = filterRecord(harnessData.cliTools, hiddenSet, "cliTools");
+  const languages = filterRecord(harnessData.languages, hiddenSet, "languages");
+  const mcpServers = filterRecord(
+    harnessData.mcpServers,
+    hiddenSet,
+    "mcpServers",
+  );
+  const versions = filterList(
+    harnessData.versions,
+    hiddenSet,
+    "versions",
+    (v) => v,
+  );
+  const harnessFiles = filterList(
+    harnessData.harnessFiles,
+    hiddenSet,
+    "harnessFiles",
+    (f) => f,
+  );
+
+  const showToolUsage = Object.keys(toolUsage).length > 0;
+  const showCliTools = Object.keys(cliTools).length > 0;
+  const showLanguages = Object.keys(languages).length > 0;
+  const showMcp = Object.keys(mcpServers).length > 0;
+  const showVersions = versions.length > 0;
+  const showHarnessFiles = harnessFiles.length > 0;
+
+  const hasAny =
+    showToolUsage ||
+    showCliTools ||
+    showLanguages ||
+    showMcp ||
+    showVersions ||
+    showHarnessFiles;
+
+  if (!hasAny) return null;
+
+  return (
+    <CollapsibleSection
+      icon="🔧"
+      iconBgClass="bg-slate-100 dark:bg-slate-800"
+      title="Full technical detail"
+      summary="Tool usage, CLI commands, MCP servers, languages, versions, and harness files — also available to agents via this profile's JSON payload."
+      defaultOpen={false}
+    >
+      <div className="space-y-6">
+        {showToolUsage && <ToolUsageTreemap toolUsage={toolUsage} />}
+
+        {showCliTools && <CliToolsDonut cliTools={cliTools} />}
+
+        {showLanguages && (
+          <div>
+            <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Languages
+            </h4>
+            <MiniBarChart
+              data={Object.entries(languages)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 12)
+                .map(([label, value]) => ({ label, value }))}
+              title=""
+              color="bg-green-500"
+            />
+          </div>
+        )}
+
+        {showMcp && (
+          <div>
+            <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              MCP Servers
+            </h4>
+            <div className="space-y-1">
+              {Object.entries(mcpServers)
+                .sort((a, b) => b[1] - a[1])
+                .map(([server, calls]) => (
+                  <div
+                    key={server}
+                    className="flex justify-between border-b border-slate-100 py-1 dark:border-slate-800"
+                  >
+                    <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                      {server}
+                    </span>
+                    <span className="text-xs text-slate-400">
+                      {calls.toLocaleString()} calls
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {showVersions && (
+          <div>
+            <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Claude Code Versions
+            </h4>
+            <div className="flex flex-wrap gap-1.5">
+              {versions.map((v) => (
+                <span
+                  key={v}
+                  className="rounded border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-600 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-400"
+                >
+                  {v}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {showHarnessFiles && (
+          <div>
+            <h4 className="mb-2 text-sm font-semibold text-slate-700 dark:text-slate-300">
+              Harness File Ecosystem
+            </h4>
+            <div className="space-y-1">
+              {harnessFiles.map((f) => (
+                <div
+                  key={f}
+                  className="border-b border-slate-100 py-1 font-mono text-xs text-slate-600 dark:border-slate-800 dark:text-slate-400"
+                >
+                  {f}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/src/components/__tests__/TechnicalDetailSection.test.tsx
+++ b/src/components/__tests__/TechnicalDetailSection.test.tsx
@@ -1,0 +1,125 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import TechnicalDetailSection from "@/components/TechnicalDetailSection";
+import { hideSetFromArray } from "@/lib/item-visibility";
+import type { HarnessData } from "@/types/insights";
+
+// Minimal HarnessData with all six technical-detail fields empty by default.
+// Each test populates only what it needs.
+function makeHarness(overrides: Partial<HarnessData> = {}): HarnessData {
+  return {
+    stats: {
+      totalTokens: 0,
+      durationHours: 0,
+      avgSessionMinutes: 0,
+      skillsUsedCount: 0,
+      hooksCount: 0,
+      prCount: 0,
+      sessionCount: 0,
+      commitCount: 0,
+    },
+    autonomy: {
+      label: "Guided",
+      description: "",
+      userMessages: 0,
+      assistantMessages: 0,
+      turnCount: 0,
+      errorRate: "0%",
+    },
+    featurePills: [],
+    toolUsage: {},
+    skillInventory: [],
+    hookDefinitions: [],
+    hookFrequency: {},
+    plugins: [],
+    harnessFiles: [],
+    fileOpStyle: {
+      readPct: 0,
+      editPct: 0,
+      writePct: 0,
+      grepCount: 0,
+      globCount: 0,
+      style: "read-heavy",
+    },
+    agentDispatch: null,
+    cliTools: {},
+    languages: {},
+    models: {},
+    permissionModes: {},
+    mcpServers: {},
+    gitPatterns: {
+      prCount: 0,
+      commitCount: 0,
+      linesAdded: "0",
+      branchPrefixes: {},
+    },
+    versions: [],
+    writeupSections: [],
+    workflowData: null,
+    integrityHash: "hash",
+    skillVersion: "2.10.0",
+    ...overrides,
+  };
+}
+
+function render(harnessData: HarnessData, hidden: string[] = []): string {
+  return renderToStaticMarkup(
+    <TechnicalDetailSection
+      harnessData={harnessData}
+      hiddenSet={hideSetFromArray(hidden)}
+    />,
+  );
+}
+
+// The disclosure is closed by default, so static markup contains the title but
+// not the children. These tests exercise the new logic: the guard that decides
+// whether the disclosure appears at all.
+describe("TechnicalDetailSection", () => {
+  it("renders nothing when every technical section is empty", () => {
+    expect(render(makeHarness())).toBe("");
+  });
+
+  it("renders the disclosure when at least one section has content", () => {
+    const html = render(makeHarness({ toolUsage: { Read: 5 } }));
+    expect(html).toContain("Full technical detail");
+  });
+
+  it("renders nothing when the only populated sections are all hidden", () => {
+    const harness = makeHarness({
+      toolUsage: { Read: 5 },
+      versions: ["1.2.3"],
+    });
+    expect(render(harness, ["toolUsage", "versions"])).toBe("");
+  });
+
+  it("still renders when a populated section survives a partial hide", () => {
+    const harness = makeHarness({
+      toolUsage: { Read: 5 },
+      versions: ["1.2.3"],
+    });
+    // Hide toolUsage but versions remains → disclosure still appears.
+    expect(render(harness, ["toolUsage"])).toContain("Full technical detail");
+  });
+
+  it("renders nothing when the only content is hidden at the item level", () => {
+    // versions has one entry, hidden via its item-level keypath (not the
+    // section key) — the disclosure must not appear with empty chrome.
+    const harness = makeHarness({ versions: ["1.2.3"] });
+    expect(render(harness, ["versions.1-2-3"])).toBe("");
+  });
+
+  it("treats each of the six fields as a content source", () => {
+    const sources: Array<Partial<HarnessData>> = [
+      { toolUsage: { Read: 1 } },
+      { cliTools: { git: 1 } },
+      { languages: { TypeScript: 1 } },
+      { mcpServers: { sentry: 1 } },
+      { versions: ["1.0.0"] },
+      { harnessFiles: ["CLAUDE.md"] },
+    ];
+    for (const source of sources) {
+      expect(render(makeHarness(source))).toContain("Full technical detail");
+    }
+  });
+});


### PR DESCRIPTION
## What

Slims the harness profile **Dashboard** so it leads with what's interesting to a human reading someone's setup, and folds the six low-signal-for-humans / high-signal-for-agents sections into a single closed **"Full technical detail"** disclosure at the bottom.

**Moved into the disclosure:** Tool Usage · CLI Tools · MCP Servers · Languages · Claude Code Versions · Harness File Ecosystem.

**Stays in the main scroll (human-interesting):** Hero stats → Signature Patterns → Activity → How I Work → Work Rhythm → Skills → Workflow diagram → Plugins → Git Patterns → Permissions → Hooks → Agent Dispatch.

## Why

Per the 2026-06-10 UX streamlining audit (item #20: "long scroll of mostly-collapsed accordions"), the bottom of the Dashboard was agent-food rendered as human accordions — MCP call tallies, version lists, file inventories. A human skimming a profile to copy a setup doesn't read those; an agent does, and **it already gets them via the profile's machine-readable JSON payload** (content negotiation / learn mode). So the human page doesn't need to carry the exhaustive detail — nothing is lost by collapsing it.

## How

- New `TechnicalDetailSection` component owns the six sections; `page.tsx` drops ~130 lines of inline JSX and three now-dead imports.
- **Visibility model unchanged** — per-section hide flags and per-item filters are preserved exactly (this is a presentational regrouping).
- Empty-state guard is **filter-aware**: it drives off the *filtered* collections, so a section whose every item is hidden contributes no empty chrome, and an all-hidden disclosure never renders. (Tightens a latent empty-card edge case the old per-section layout had — surfaced in Codex review.)

## Testing

- 6 new unit tests (`renderToStaticMarkup`) covering the guard: empty, populated, section-level hide, item-level hide, partial hide, and each of the six fields as a content source.
- Full suite: 727 passing. Lint, `tsc --noEmit`, and `next build` all green.
- Codex review run; both findings (filter-aware guard, item-level filtering for tool usage/CLI) addressed.

## Note

Stacks alongside #161 (Learn CTA) and #158 (Signature Patterns) — all three touch `page.tsx` in **non-overlapping** regions (this one is the Dashboard tail; #161 is above the tabs; #158 is the lead). Minor import-block rebase at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)