### PR TITLE
feat(home): reframe the hero around sharing, not browsing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1101,19 +1101,19 @@ export default function HomePage() {
             {copy.hero.subtext}
           </p>
           <div className="mt-6 flex items-center justify-center gap-3">
-            <a
-              href="#profiles"
-              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
-            >
-              {copy.hero.primaryCta}
-            </a>
             <Link
               href="/upload"
-              className="inline-flex items-center gap-2 rounded-lg border-2 border-blue-600 px-5 py-2.5 text-sm font-semibold text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-950/30"
+              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-700"
             >
               <Upload className="h-4 w-4" />
-              {copy.hero.secondaryCta}
+              {copy.hero.primaryCta}
             </Link>
+            <a
+              href="#profiles"
+              className="inline-flex items-center gap-2 rounded-lg border-2 border-blue-600 px-5 py-2.5 text-sm font-semibold text-blue-600 transition-colors hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-950/30"
+            >
+              {copy.hero.secondaryCta}
+            </a>
             <Link
               href="/install"
               className="hidden text-sm font-semibold text-slate-500 underline decoration-slate-300 underline-offset-4 transition-colors hover:text-slate-900 dark:text-slate-400 dark:decoration-slate-700 dark:hover:text-white sm:inline-flex"

--- a/src/content/homepage.ts
+++ b/src/content/homepage.ts
@@ -6,11 +6,11 @@
 export const homepage = {
   // ── Hero ──────────────────────────────────────────────────
   hero: {
-    headline: "See how developers use Claude Code and Codex",
+    headline: "Share how you work with Claude Code and Codex",
     subtext:
-      "Browse real developer workflows — the tools, skills, plugins, and patterns they use across actual agent sessions. All personal data removed.",
-    primaryCta: "Browse Profiles",
-    secondaryCta: "Upload Your Insights",
+      "Publish your skills, hooks, and workflow patterns as a public profile others — and their coding agents — can learn from. All personal data removed before anything is shared.",
+    primaryCta: "Share your setup",
+    secondaryCta: "Browse profiles",
   },
 
   // ── Profile sections ─────────────────────────────────────
@@ -19,7 +19,7 @@ export const homepage = {
     recentHeading: "Recent Profiles",
     emptyTitle: "No profiles shared yet",
     emptySubtext: "Be the first to share your agent harness insights!",
-    emptyCta: "Upload Your Insights",
+    emptyCta: "Share your setup",
     strengthsLabel: "Strengths:",
   },
 
@@ -104,6 +104,6 @@ export const homepage = {
     heading: "Ready to share your harness?",
     subtext:
       "Join developers who are learning from each other's agent workflows.",
-    cta: "Upload Your Insights",
+    cta: "Share your setup",
   },
 } as const;


### PR DESCRIPTION
## What

Reframes the homepage hero from a *browse-the-gallery* message to a *share-your-setup* message, and swaps the CTA hierarchy so there's one obvious next action.

| | Before | After |
|---|---|---|
| **Headline** | "See how developers use Claude Code and Codex" | "Share how you work with Claude Code and Codex" |
| **Subtext** | "Browse real developer workflows…" | "Publish your skills, hooks, and workflow patterns as a public profile others — and their coding agents — can learn from…" |
| **Primary CTA** (filled) | Browse Profiles → `#profiles` | **Share your setup** → `/upload` |
| **Secondary CTA** (outline) | Upload Your Insights → `/upload` | Browse profiles → `#profiles` |

## Why

Per the 2026-06-10 UX streamlining audit (rec #3): the product's job is *sharing*, but the hero sold *browsing*, with the gallery as the primary CTA and the share flow demoted. This realigns the first impression with what the product is for. The subtext now also names the agent-learning path ("and their coding agents"), tying back to the "Learn from this" CTA shipped in #161.

## Notes

- Copy-only + CTA wiring. No schema, data, or `harnessData` changes.
- All hero copy is centralized in `src/content/homepage.ts` — adjust wording freely in review.
- `/upload` uses `<Link>` (internal route); `#profiles` uses `<a>` (in-page anchor) — both correct.
- Also aligned the empty-state and footer CTA labels to "Share your setup" so the share verb is consistent across the page.
- The install-org bug (audit rec #2) is already fixed separately in #159.

## Testing

- Full suite: 817 passing. Lint, `tsc --noEmit`, and `next build` all green. (No test pins the hero copy strings.)
- Codex review attempted; it hung in this env (exit 144 — a known intermittent issue noted in the repo handoff). Shipped on the green static gate given the change is copy + CTA wiring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)