### PR TITLE
fix(insights): make narrative-section hiding reversible (no more data loss)

### DIFF
--- a/prisma/migrations/20260619000000_add_hidden_narrative_sections/migration.sql
+++ b/prisma/migrations/20260619000000_add_hidden_narrative_sections/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+-- Additive: new array column with an empty default. No existing data is read
+-- or modified, so this is safe to apply on a live table. Mirrors the existing
+-- "hiddenHarnessSections" column so narrative-section hides become reversible
+-- (the section's JSON column is left intact; this array only suppresses display).
+ALTER TABLE "InsightReport" ADD COLUMN     "hiddenNarrativeSections" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,10 @@ model InsightReport {
   autonomyLabel         String?
   harnessData           Json?
   hiddenHarnessSections String[] @default([])
+  // Narrative sections (atAGlance, interactionStyle, etc.) the author has
+  // hidden from the public view. Reversible: the section's JSON column is left
+  // intact; this array only suppresses display (mirrors hiddenHarnessSections).
+  hiddenNarrativeSections String[] @default([])
 
   // Content sections (stored as redacted JSON)
   atAGlance           Json?

--- a/src/app/api/insights/allowed-fields.ts
+++ b/src/app/api/insights/allowed-fields.ts
@@ -34,6 +34,10 @@ export const ALLOWED_PUT_FIELDS = [
   "chartData",
   "detectedSkills",
   "hiddenHarnessSections",
+  // Narrative-section visibility. Mirrors hiddenHarnessSections: hiding a
+  // narrative section now records its key here instead of nulling the column,
+  // so hides are reversible (the section's JSON column is preserved).
+  "hiddenNarrativeSections",
   // R10/R11 (Wave 4 Unit 10): "Make public" flips a draft to public.
   // The PUT handler enforces one-way semantics (true → false only)
   // — listing the field here merely makes it eligible for the

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -66,6 +66,10 @@ export async function GET(request: Request) {
     const scored: ScoredReport[] = allReports.map((report) => {
       let score = 0;
       const matchedSections: string[] = [];
+      // Hidden narrative sections persist in the DB (hides are reversible) but
+      // must not be searchable — skipping them stops search from acting as an
+      // oracle over hidden content or revealing which hidden section matched.
+      const hiddenNarrative = new Set(report.hiddenNarrativeSections ?? []);
 
       // Check title
       if (report.title.toLowerCase().includes(searchTerm)) {
@@ -82,6 +86,7 @@ export async function GET(request: Request) {
 
       // Check JSON content fields
       for (const field of SEARCHABLE_JSON_FIELDS) {
+        if (hiddenNarrative.has(field)) continue;
         const value = report[field];
         if (value !== null && value !== undefined) {
           const jsonStr = JSON.stringify(value).toLowerCase();

--- a/src/app/api/users/[username]/route.ts
+++ b/src/app/api/users/[username]/route.ts
@@ -49,6 +49,7 @@ export async function GET(
             dayCount: true,
             msgsPerDay: true,
             atAGlance: true,
+            hiddenNarrativeSections: true,
             _count: {
               select: {
                 comments: true,
@@ -68,6 +69,11 @@ export async function GET(
 
     const reports = user.reports.map((r) => {
       const atAGlance = r.atAGlance as Record<string, string> | null;
+      // Respect a hidden At-a-Glance: the section's JSON column persists (hides
+      // are reversible), so this public preview must check the flag itself.
+      const atAGlanceHidden = (r.hiddenNarrativeSections ?? []).includes(
+        "atAGlance",
+      );
       return {
         slug: r.slug,
         title: r.title,
@@ -82,7 +88,9 @@ export async function GET(
         fileCount: r.fileCount,
         dayCount: r.dayCount,
         msgsPerDay: r.msgsPerDay,
-        whatsWorkingPreview: atAGlance?.whats_working?.slice(0, 150) || null,
+        whatsWorkingPreview: atAGlanceHidden
+          ? null
+          : atAGlance?.whats_working?.slice(0, 150) || null,
         voteCount: r._count.votes,
         commentCount: r._count.comments,
         sectionTags: [],

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -8,7 +8,7 @@ import {
   buildReportUrl,
 } from "@/lib/urls";
 import { useSession } from "next-auth/react";
-import { ArrowLeft, AlertTriangle } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import EyeToggle from "@/components/EyeToggle";
 import HideableItem from "@/components/HideableItem";
 import type {
@@ -87,6 +87,7 @@ interface ReportData {
   linesRemoved: number | null;
   harnessData: HarnessToolsEnvelope | null;
   hiddenHarnessSections: string[];
+  hiddenNarrativeSections: string[];
   atAGlance: unknown;
   interactionStyle: unknown;
   projectAreas: unknown;
@@ -170,7 +171,9 @@ function HideableCard({
           {title}
         </span>
         {hidden && (
-          <span className="text-xs text-red-500">Will be removed</span>
+          <span className="text-xs text-slate-400">
+            Hidden — won&apos;t show publicly
+          </span>
         )}
       </div>
       {!hidden && children}
@@ -503,19 +506,6 @@ export default function EditReportPage() {
   const [hiddenSections, setHiddenSections] = useState<Record<string, boolean>>(
     {},
   );
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const [pendingSave, setPendingSave] = useState<Record<
-    string,
-    unknown
-  > | null>(null);
-  // When the modal was triggered by the "Make public" path (vs the
-  // ordinary "Save Changes" path), confirm runs the publish flow
-  // (which router.refresh()es and flips local state) instead of
-  // executeSave (which router.push()es to the public URL). Without
-  // this flag, confirming a publish with hidden sections would
-  // either redirect to a still-draft URL or permanently delete the
-  // sections without asking — codex P2 on 779cc45.
-  const [pendingIsPublish, setPendingIsPublish] = useState(false);
 
   // Group-sharing visibility state. `visibility` mirrors the report's
   // current value (or, for fresh drafts of authors with groups, defaults
@@ -590,7 +580,10 @@ export default function EditReportPage() {
           }
           setHiddenSections(
             Object.fromEntries(
-              (r.hiddenHarnessSections ?? []).map((key: string) => [key, true]),
+              [
+                ...(r.hiddenHarnessSections ?? []),
+                ...(r.hiddenNarrativeSections ?? []),
+              ].map((key: string) => [key, true]),
             ),
           );
         }
@@ -753,12 +746,12 @@ export default function EditReportPage() {
   const buildSaveBody = () => {
     const body: Record<string, unknown> = {};
 
-    // Null out hidden narrative sections
-    for (const section of SECTIONS) {
-      if (hiddenSections[section.key]) {
-        body[section.key] = null;
-      }
-    }
+    // Record hidden narrative sections as keys (reversible). The section's JSON
+    // column is left intact — the server strips hidden sections from non-owner
+    // responses, and unhiding simply drops the key. No data is destroyed.
+    body.hiddenNarrativeSections = SECTIONS.filter(
+      (s) => hiddenSections[s.key],
+    ).map((s) => s.key);
 
     body.hiddenHarnessSections = getHiddenKeypaths(hiddenSections);
 
@@ -800,46 +793,9 @@ export default function EditReportPage() {
 
   const handleSave = async () => {
     if (!report) return;
-
-    const body = buildSaveBody();
-
-    // Check if any sections are being removed
-    const removedSections = SECTIONS.filter((s) => hiddenSections[s.key]).map(
-      (s) => s.label,
-    );
-
-    if (removedSections.length > 0) {
-      setPendingSave(body);
-      // Reset publish intent — the modal could otherwise have been
-      // opened by a prior Make public click whose pendingIsPublish
-      // is still set. Without this, confirming would route the
-      // plain save through executePublish() and leave the UI saying
-      // "public" while the server kept the row as draft. (codex P2
-      // on 16de842.)
-      setPendingIsPublish(false);
-      setShowConfirmModal(true);
-      return;
-    }
-
-    await executeSave(body);
-  };
-
-  const handleConfirmSave = async () => {
-    if (!pendingSave) return;
-    setShowConfirmModal(false);
-    if (pendingIsPublish) {
-      await executePublish(pendingSave);
-    } else {
-      await executeSave(pendingSave);
-    }
-    setPendingSave(null);
-    setPendingIsPublish(false);
-  };
-
-  const handleCancelSave = () => {
-    setShowConfirmModal(false);
-    setPendingSave(null);
-    setPendingIsPublish(false);
+    // Hiding sections is now non-destructive (recorded as keypaths, data
+    // preserved), so save proceeds directly — no destructive confirmation.
+    await executeSave(buildSaveBody());
   };
 
   /**
@@ -883,25 +839,12 @@ export default function EditReportPage() {
    * edit-page header reflect the new state without a hard reload.
    *
    * Pending visibility edits (hidden sections / per-item hides) ride
-   * along with the publish in a single PUT (codex P1 on fc78b3b).
-   * If those pending edits include narrative-section removals, route
-   * through the existing destructive-save confirmation modal so the
-   * author has a final chance to cancel before content is permanently
-   * deleted (codex P2 on 779cc45).
+   * along with the publish in a single PUT (codex P1 on fc78b3b). Hiding is
+   * non-destructive now, so no confirmation modal is needed before publish.
    */
   const handleMakePublic = async () => {
     if (!report) return;
-    const body = { ...buildSaveBody(), isDraft: false };
-    const removedSections = SECTIONS.filter((s) => hiddenSections[s.key]).map(
-      (s) => s.label,
-    );
-    if (removedSections.length > 0) {
-      setPendingSave(body);
-      setPendingIsPublish(true);
-      setShowConfirmModal(true);
-      return;
-    }
-    await executePublish(body);
+    await executePublish({ ...buildSaveBody(), isDraft: false });
   };
 
   // Hold the spinner until BOTH the report fetch and the next-auth
@@ -1779,7 +1722,9 @@ export default function EditReportPage() {
                   {section.label}
                 </span>
                 {isHidden && (
-                  <span className="text-xs text-red-500">Will be removed</span>
+                  <span className="text-xs text-slate-400">
+                    Hidden — won&apos;t show publicly
+                  </span>
                 )}
               </div>
               {!isHidden && data != null && (
@@ -1816,54 +1761,6 @@ export default function EditReportPage() {
           {saving ? "Saving..." : "Save Changes"}
         </button>
       </div>
-
-      {/* Confirmation modal for destructive saves */}
-      {showConfirmModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-          <div className="mx-4 max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-slate-900">
-            <div className="mb-4 flex items-center gap-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
-                <AlertTriangle className="h-5 w-5 text-red-600 dark:text-red-400" />
-              </div>
-              <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
-                Confirm Removal
-              </h2>
-            </div>
-            <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-              This will permanently remove the following sections from your
-              published report:
-            </p>
-            <ul className="mb-4 space-y-1">
-              {SECTIONS.filter((s) => hiddenSections[s.key]).map((s) => (
-                <li
-                  key={s.key}
-                  className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300"
-                >
-                  <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
-                  {s.label}
-                </li>
-              ))}
-            </ul>
-            <p className="mb-6 text-sm font-medium text-red-600 dark:text-red-400">
-              This action cannot be undone.
-            </p>
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={handleCancelSave}
-                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 dark:border-slate-600 dark:text-slate-300 dark:hover:bg-slate-800"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirmSave}
-                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-red-700"
-              >
-                Remove &amp; Save
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/lib/__tests__/filter-report-response.test.ts
+++ b/src/lib/__tests__/filter-report-response.test.ts
@@ -491,6 +491,73 @@ describe("filterReportForResponse", () => {
     expect(tools["claude-code"].skillInventory).toHaveLength(2);
     expect(tools.codex.skillInventory).toHaveLength(2);
   });
+
+  // ── Whole narrative-section hides (hiddenNarrativeSections) ──────────────
+  // These are the reversible replacement for the old destructive "null the
+  // column" hide. The response must clear the section for non-owners; the
+  // owner-edit path keeps it so they can toggle it back on.
+
+  it("nulls a whole narrative section for non-owners (hiddenNarrativeSections)", () => {
+    const report = makeReport({
+      hiddenNarrativeSections: ["impressiveWorkflows", "suggestions"],
+    });
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    expect(result.impressiveWorkflows).toBeNull();
+    expect(result.suggestions).toBeNull();
+    // Sections NOT hidden stay intact.
+    expect(result.onTheHorizon).toEqual(report.onTheHorizon);
+  });
+
+  it("keeps hidden narrative sections for the owner edit view (includeHidden)", () => {
+    const report = makeReport({
+      hiddenNarrativeSections: ["impressiveWorkflows"],
+    });
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: true,
+      includeHidden: true,
+    });
+    expect(result.impressiveWorkflows).toEqual(report.impressiveWorkflows);
+  });
+
+  it("does not mutate the source report when nulling narrative sections", () => {
+    const report = makeReport({
+      hiddenNarrativeSections: ["impressiveWorkflows"],
+    });
+    filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    // The DB-backed object is untouched — the hide is non-destructive.
+    expect(report.impressiveWorkflows).not.toBeNull();
+  });
+
+  it("applies narrative hides even when no harness sections are hidden", () => {
+    const report = makeReport({
+      hiddenHarnessSections: [],
+      hiddenNarrativeSections: ["frictionAnalysis"],
+    });
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    expect(result.frictionAnalysis).toBeNull();
+  });
+
+  it("ignores unknown keys in hiddenNarrativeSections", () => {
+    const report = makeReport({
+      hiddenNarrativeSections: ["totallyNotASection", "harnessData"],
+    });
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    // Only the known narrative columns can be nulled — harnessData survives.
+    expect(result.harnessData).toEqual(report.harnessData);
+    expect(result.impressiveWorkflows).toEqual(report.impressiveWorkflows);
+  });
 });
 
 // ── Showcase-field regressions (Unit 5 of skill-showcase plan) ────────────
@@ -748,9 +815,11 @@ describe("filterReportForListFeed", () => {
   it("drops showcase bytes from compatible skill inventories inside envelopes", () => {
     const report = makeEnvelopeReport([]);
     const result = filterReportForListFeed(report);
-    const skills = (result.harnessData as unknown as {
-      skillInventory: Array<Record<string, unknown>>;
-    }).skillInventory;
+    const skills = (
+      result.harnessData as unknown as {
+        skillInventory: Array<Record<string, unknown>>;
+      }
+    ).skillInventory;
 
     for (const skill of skills) {
       expect(skill.readme_markdown).toBeNull();

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -21,6 +21,21 @@ interface FilterOptions {
 }
 
 /**
+ * Narrative sections that can be hidden whole (matches the edit page's SECTIONS
+ * and the camelCase Prisma columns). A key listed in a report's
+ * hiddenNarrativeSections nulls the corresponding column in the response for
+ * non-owners — non-destructively (the DB column is untouched).
+ */
+const NARRATIVE_SECTION_KEYS = [
+  "atAGlance",
+  "interactionStyle",
+  "impressiveWorkflows",
+  "frictionAnalysis",
+  "suggestions",
+  "onTheHorizon",
+] as const;
+
+/**
  * Filter a report's data for the response. Returns a new object with hidden
  * data stripped. When viewerIsOwner && includeHidden, returns data untouched.
  */
@@ -28,6 +43,9 @@ export function filterReportForResponse<
   T extends {
     harnessData?: unknown;
     hiddenHarnessSections?: string[] | null;
+    hiddenNarrativeSections?: string[] | null;
+    atAGlance?: unknown;
+    interactionStyle?: unknown;
     impressiveWorkflows?: unknown;
     frictionAnalysis?: unknown;
     projectAreas?: unknown;
@@ -37,15 +55,30 @@ export function filterReportForResponse<
 >(report: T, options: FilterOptions): T {
   const { viewerIsOwner, includeHidden } = options;
   const hiddenSections = report.hiddenHarnessSections ?? [];
+  const hiddenNarrative = report.hiddenNarrativeSections ?? [];
 
   // Owner with includeHidden=true gets unfiltered data (for edit page)
   if (viewerIsOwner && includeHidden) return report;
 
   // Nothing to filter
-  if (hiddenSections.length === 0) return report;
+  if (hiddenSections.length === 0 && hiddenNarrative.length === 0)
+    return report;
 
   const hidden = hideSetFromArray(hiddenSections);
   const result = { ...report };
+
+  // Null whole narrative sections the author has hidden. Non-destructive: the
+  // DB column is untouched; only this response copy is cleared, so the detail
+  // page's null-check skips the section. Owners re-fetch with includeHidden
+  // (edit page) to toggle them back on.
+  if (hiddenNarrative.length > 0) {
+    const narrativeHidden = new Set(hiddenNarrative);
+    for (const key of NARRATIVE_SECTION_KEYS) {
+      if (narrativeHidden.has(key)) {
+        (result as Record<string, unknown>)[key] = null;
+      }
+    }
+  }
 
   // Filter harnessData (the main privacy fix)
   if (result.harnessData && typeof result.harnessData === "object") {


### PR DESCRIPTION
## The bug (blocker-class data loss)

On the edit page, hiding a **narrative** section (At a Glance, How They Use…, Impressive Workflows, Where Things Go Wrong, Suggestions, On the Horizon) **permanently nulled the underlying Prisma column** behind a "cannot be undone" modal. It used the *same eye-toggle affordance* as **harness** section hides — which are fully reversible — so two identical-looking controls had opposite, irreversible consequences. (Audit rec #6.)

## The fix

Narrative hides now mirror harness hides: the section key is recorded in a new reversible **`hiddenNarrativeSections`** array and the section's JSON is **preserved**. Hidden sections are stripped from non-owner responses; the owner can toggle them back on.

- **prisma** — new `hiddenNarrativeSections String[]` column. Additive migration (`ALTER TABLE … ADD COLUMN … TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[]`); applies on the **production** build via `prisma migrate deploy` (preview deploys skip it, per the existing `VERCEL_ENV` gate). No data read or modified.
- **`filterReportForResponse`** — nulls hidden narrative sections in the response for non-owners. One central place covers **GET, the agent payload, and list feeds**. Non-destructive: the DB row is untouched; owners re-fetch with `includeHidden` (edit page) to toggle back on.
- **edit page** — records hidden sections as keys instead of nulling columns; seeds toggle state from both hidden arrays; **removes the destructive "Confirm Removal / cannot be undone" modal** and its now-dead state/handlers/import; relabels "Will be removed" → "Hidden — won't show publicly."
- **allowed-fields** — accept `hiddenNarrativeSections` on PUT.

## Leaks plugged (found in Codex review of this change)

Because the data now *persists* instead of being nulled, two other readers had to learn to honor the flag:
- **`/api/users/[username]`** — suppress the At-a-Glance preview (`whatsWorkingPreview`) when `atAGlance` is hidden.
- **`/api/search`** — skip hidden narrative fields when scoring and building `matchedSections`, so search can't act as an oracle over hidden content (reveal a match, or *which* hidden section matched).

## Testing

- 5 new `filterReportForResponse` cases: non-owner null, owner-edit keep, no source mutation, narrative-only hide, unknown-key safety. **822 tests pass**; lint, `tsc`, `next build` green.
- Codex-reviewed; all three findings (the two leaks above + the upload-path note below) addressed or scoped.

## ⚠️ Known follow-up (separate PR, NOT a regression)

The initial **upload/publish** flow still drops disabled narrative sections destructively — it omits them from the POST rather than persisting the JSON + a hidden flag, and the POST route doesn't accept `hiddenNarrativeSections`. This PR doesn't touch that path (so no regression), but it means **upload-time** hides aren't yet reversible. Fixing it needs reconciling the upload section set (7, incl. `projectAreas`) with the edit/filter set (6) + POST schema/write changes.

Also noted: the narrative columns remain in `ALLOWED_PUT_FIELDS` (the UI no longer nulls them, but the API capability persists) — optional hardening for a follow-up.

> Includes a **DB migration** — please review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)