### PR TITLE
chore: gitignore graphify-out/ and local .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,9 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Graphify code graph (regenerable artifacts)
+graphify-out/
+
+# Local MCP server config (machine-specific paths; keep out of shared repo)
+.mcp.json


### PR DESCRIPTION
Hygiene-only. Keeps two local-only/regenerable things out of the shared repo:

- `graphify-out/` — regenerable code-graph artifacts (~3MB: graph.html, graph.json, etc.)
- `.mcp.json` — machine-specific MCP config (hardcoded `/Users/...` paths), kept local

No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)