### PR TITLE
fix(insights): make upload-path narrative hides reversible too

### DIFF
--- a/src/app/api/insights/[username]/[slug]/route.ts
+++ b/src/app/api/insights/[username]/[slug]/route.ts
@@ -3,7 +3,10 @@ import { prisma } from "@/lib/db";
 import { auth } from "@/lib/auth";
 import type { InsightReportDetailContract } from "@/types/api-contracts";
 import { ALLOWED_PUT_FIELDS } from "@/app/api/insights/allowed-fields";
-import { filterReportForResponse } from "@/lib/filter-report-response";
+import {
+  filterReportForResponse,
+  sanitizeNarrativeHideKeys,
+} from "@/lib/filter-report-response";
 import {
   wantsAgentPayload,
   buildAgentPayload,
@@ -249,6 +252,15 @@ export async function PUT(
       if (body[field] !== undefined) {
         updateData[field] = body[field];
       }
+    }
+
+    // Sanitize narrative hide keys against the canonical allowlist so the DB
+    // can't record a "hidden" key the filter won't strip (which would let
+    // search and the detail response disagree about what's hidden).
+    if (updateData.hiddenNarrativeSections !== undefined) {
+      updateData.hiddenNarrativeSections = sanitizeNarrativeHideKeys(
+        updateData.hiddenNarrativeSections,
+      );
     }
 
     // R10/R11 (Wave 4 Unit 10): isDraft is one-way. We allow

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -9,6 +9,7 @@ import {
   toStoredHarnessData,
 } from "@/types/insights";
 import type { Prisma } from "@prisma/client";
+import { sanitizeNarrativeHideKeys } from "@/lib/filter-report-response";
 import { fetchLinkPreview } from "@/lib/link-preview";
 import { filterReportForListFeed } from "@/lib/filter-report-response";
 import {
@@ -83,6 +84,7 @@ const createInsightReportSchema = z.object({
   autonomyLabel: optionalNullableString,
   harnessData: z.unknown().optional(),
   hiddenHarnessSections: z.array(z.string()).optional(),
+  hiddenNarrativeSections: z.array(z.string()).optional(),
 });
 
 function toStoredTokenCount(value: unknown): bigint | null {
@@ -352,6 +354,7 @@ export async function POST(request: Request) {
       autonomyLabel,
       harnessData,
       hiddenHarnessSections,
+      hiddenNarrativeSections,
     } = parsed.data;
     const storedHarnessData = toStoredHarnessData(harnessData);
     const claudeHarnessData = getClaudeHarnessData(storedHarnessData);
@@ -551,6 +554,9 @@ export async function POST(request: Request) {
           hiddenHarnessSections: Array.isArray(hiddenHarnessSections)
             ? hiddenHarnessSections
             : [],
+          hiddenNarrativeSections: sanitizeNarrativeHideKeys(
+            hiddenNarrativeSections,
+          ),
         },
       });
 

--- a/src/app/insights/[username]/[slug]/edit/page.tsx
+++ b/src/app/insights/[username]/[slug]/edit/page.tsx
@@ -751,9 +751,17 @@ export default function EditReportPage() {
     // Record hidden narrative sections as keys (reversible). The section's JSON
     // column is left intact — the server strips hidden sections from non-owner
     // responses, and unhiding simply drops the key. No data is destroyed.
-    body.hiddenNarrativeSections = SECTIONS.filter(
-      (s) => hiddenSections[s.key],
-    ).map((s) => s.key);
+    // Carry over hidden keys this page doesn't expose a toggle for (e.g.
+    // projectAreas, which can be hidden at upload) so an unrelated edit doesn't
+    // silently un-hide them.
+    const editManaged = new Set<string>(SECTIONS.map((s) => s.key));
+    const carriedOver = (report?.hiddenNarrativeSections ?? []).filter(
+      (key) => !editManaged.has(key),
+    );
+    body.hiddenNarrativeSections = [
+      ...carriedOver,
+      ...SECTIONS.filter((s) => hiddenSections[s.key]).map((s) => s.key),
+    ];
 
     body.hiddenHarnessSections = getHiddenKeypaths(hiddenSections);
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1526,8 +1526,7 @@ export default function UploadPage() {
         ? `${firstName}'s Insight Harness - ${titleDate}`
         : `${firstName}'s Claude Code Insights - ${titleDate}`;
 
-      // Map InsightsData snake_case keys to Prisma camelCase fields
-      // and remove disabled sections
+      // Map InsightsData snake_case keys to Prisma camelCase fields.
       const sectionMap: Record<keyof InsightsData, string> = {
         at_a_glance: "atAGlance",
         interaction_style: "interactionStyle",
@@ -1539,11 +1538,16 @@ export default function UploadPage() {
         fun_ending: "funEnding",
       };
 
+      // Persist EVERY narrative section's JSON so hides stay reversible (no
+      // data loss at upload), and record disabled sections as keys the server
+      // strips from non-owner responses. Mirrors the edit-page hide model.
       const sectionFields: Record<string, unknown> = {};
+      const hiddenNarrativeSections: string[] = [];
       for (const [dataKey, prismaKey] of Object.entries(sectionMap)) {
-        if (!disabledSet.has(dataKey)) {
-          sectionFields[prismaKey] =
-            redactedData[dataKey as keyof InsightsData] ?? null;
+        sectionFields[prismaKey] =
+          redactedData[dataKey as keyof InsightsData] ?? null;
+        if (disabledSet.has(dataKey)) {
+          hiddenNarrativeSections.push(prismaKey);
         }
       }
 
@@ -1581,6 +1585,7 @@ export default function UploadPage() {
           // docs/plans/2026-04-12-002 → "Storage Decision".
           harnessData: parsed.harnessData ?? null,
           hiddenHarnessSections,
+          hiddenNarrativeSections,
         }),
       });
 

--- a/src/lib/__tests__/filter-report-response.test.ts
+++ b/src/lib/__tests__/filter-report-response.test.ts
@@ -534,6 +534,15 @@ describe("filterReportForResponse", () => {
     expect(report.impressiveWorkflows).not.toBeNull();
   });
 
+  it("nulls a whole projectAreas section when hidden (upload-set 7th key)", () => {
+    const report = makeReport({ hiddenNarrativeSections: ["projectAreas"] });
+    const result = filterReportForResponse(report, {
+      viewerIsOwner: false,
+      includeHidden: false,
+    });
+    expect(result.projectAreas).toBeNull();
+  });
+
   it("applies narrative hides even when no harness sections are hidden", () => {
     const report = makeReport({
       hiddenHarnessSections: [],

--- a/src/lib/filter-report-response.ts
+++ b/src/lib/filter-report-response.ts
@@ -21,19 +21,36 @@ interface FilterOptions {
 }
 
 /**
- * Narrative sections that can be hidden whole (matches the edit page's SECTIONS
- * and the camelCase Prisma columns). A key listed in a report's
- * hiddenNarrativeSections nulls the corresponding column in the response for
- * non-owners — non-destructively (the DB column is untouched).
+ * The canonical set of narrative sections that can be hidden whole (the
+ * camelCase Prisma columns). A key listed in a report's hiddenNarrativeSections
+ * nulls the corresponding column in the response for non-owners —
+ * non-destructively (the DB column is untouched).
+ *
+ * This is the single source of truth: write paths (POST/PUT) must sanitize
+ * incoming keys against it (see `sanitizeNarrativeHideKeys`) so the DB never
+ * records a "hidden" key the filter won't actually strip — otherwise search
+ * and the detail response would disagree about what's hidden.
  */
-const NARRATIVE_SECTION_KEYS = [
+export const NARRATIVE_SECTION_KEYS = [
   "atAGlance",
   "interactionStyle",
+  "projectAreas",
   "impressiveWorkflows",
   "frictionAnalysis",
   "suggestions",
   "onTheHorizon",
 ] as const;
+
+const NARRATIVE_SECTION_KEY_SET = new Set<string>(NARRATIVE_SECTION_KEYS);
+
+/**
+ * Keep only canonical, de-duplicated narrative hide keys. Applied on every
+ * write so the stored array can never contain a key the filter ignores.
+ */
+export function sanitizeNarrativeHideKeys(keys: unknown): string[] {
+  if (!Array.isArray(keys)) return [];
+  return [...new Set(keys.filter((k) => NARRATIVE_SECTION_KEY_SET.has(k)))];
+}
 
 /**
  * Filter a report's data for the response. Returns a new object with hidden


### PR DESCRIPTION
## What

Completes the narrative-hide data-loss fix from #164. That PR made the **edit-path** hide reversible; this fixes the remaining **upload-path** trap — initial publish used to *drop* disabled narrative sections (omit from POST → null column → gone forever).

Now upload always persists every narrative section's JSON and records disabled ones in `hiddenNarrativeSections`, just like the edit path. No data lost; hides reversible end-to-end.

## Changes

- **upload page** — always send all narrative JSON; send `hiddenNarrativeSections` (disabled keys, camelCase) instead of omitting columns.
- **POST `/api/insights`** — accept + persist `hiddenNarrativeSections`.
- **filter-report-response** — `projectAreas` is now the 7th canonical narrative key (it's hideable at upload, rendered inside the snapshot card), so it strips for non-owners like the rest.
- **edit `buildSaveBody`** — carry over hidden keys the edit UI exposes no toggle for (e.g. `projectAreas`), so an unrelated edit doesn't silently un-hide them.
- **canonical allowlist enforcement** — new exported `sanitizeNarrativeHideKeys` filters incoming keys against the canonical 7 on **both** write paths (POST + PUT), so the DB can't store a "hidden" key the filter ignores (which would make search and the detail response disagree). Closes the Codex finding from the #164 review.

## Testing

- +1 `projectAreas` whole-section strip test. **845 pass**; lint, `tsc`, `next build` green.
- Codex-reviewed; the one finding (write-path key sanitization) is fixed here.

No migration (reuses #164's `hiddenNarrativeSections` column). Stacks on #164 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)